### PR TITLE
build(ci): update Actions and grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,16 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      react:
+        patterns:
+          - react
+          - react-dom
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Set up Node.js
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
           cache: npm
@@ -32,5 +32,23 @@ jobs:
         run: npx playwright install --with-deps chromium
       - name: Run browser tests
         run: npm run test:e2e
+
+  visual:
+    needs: verify
+    runs-on: windows-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Build static export
+        run: npm run build
+      - name: Install Chromium
+        run: npx playwright install chromium
       - name: Run visual regression tests
         run: npm run test:visual

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -22,9 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Set up Node.js
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/refresh-catalog.yml
+++ b/.github/workflows/refresh-catalog.yml
@@ -38,9 +38,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Set up Node.js
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/triage-submission.yml
+++ b/.github/workflows/triage-submission.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Set up Node.js
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
           cache: npm

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -6,8 +6,8 @@ import { parse } from "yaml";
 
 const workflowDirectory = resolve(".github/workflows");
 const pinnedActions = {
-  "actions/checkout": "d23441a48e516b6c34aea4fa41551a30e30af803",
-  "actions/setup-node": "249970729cb0ef3589644e2896645e5dc5ba9c38",
+  "actions/checkout": "3d3c42e5aac5ba805825da76410c181273ba90b1",
+  "actions/setup-node": "820762786026740c76f36085b0efc47a31fe5020",
   "actions/configure-pages": "45bfe0192ca1faeb007ade9deae92b16b8254a0d",
   "actions/upload-pages-artifact": "fc324d3547104276b827a68afc52ff2a11cc49c9",
   "actions/deploy-pages": "cd2ce8fcbc39b97be8ca5fce6e763baed58fa128",
@@ -58,6 +58,28 @@ test("keeps CI read-only and runs every local gate", async () => {
   expect(commands).toContain("playwright install --with-deps chromium");
   expect(commands).toContain("npm run test:e2e");
   expect(commands).toContain("npm run test:visual");
+});
+
+test("runs Windows-specific visual baselines on a Windows runner", async () => {
+  const ci = await workflow("ci");
+  const jobs = ci.jobs as Record<
+    string,
+    {
+      "runs-on"?: string;
+      steps?: Array<{ run?: string }>;
+    }
+  >;
+  const verifyCommands = (jobs.verify.steps ?? [])
+    .map((step) => step.run)
+    .filter(Boolean);
+  const visualCommands = (jobs.visual?.steps ?? [])
+    .map((step) => step.run)
+    .filter(Boolean);
+
+  expect(jobs.verify["runs-on"]).toBe("ubuntu-latest");
+  expect(verifyCommands).not.toContain("npm run test:visual");
+  expect(jobs.visual?.["runs-on"]).toBe("windows-latest");
+  expect(visualCommands).toContain("npm run test:visual");
 });
 
 test("deploys only a verified static export to the Pages environment", async () => {
@@ -112,4 +134,24 @@ test("triage can label issues but cannot write repository content", async () => 
     contents: "read",
     issues: "write",
   });
+});
+
+test("groups coupled dependency updates into coherent pull requests", async () => {
+  const dependabot = parse(
+    await readFile(resolve(".github/dependabot.yml"), "utf8"),
+  ) as {
+    updates: Array<{
+      "package-ecosystem": string;
+      groups?: Record<string, { patterns: string[] }>;
+    }>;
+  };
+  const npm = dependabot.updates.find(
+    (update) => update["package-ecosystem"] === "npm",
+  );
+  const actions = dependabot.updates.find(
+    (update) => update["package-ecosystem"] === "github-actions",
+  );
+
+  expect(npm?.groups?.react.patterns).toEqual(["react", "react-dom"]);
+  expect(actions?.groups?.actions.patterns).toEqual(["*"]);
 });


### PR DESCRIPTION
## Summary
- update pinned `actions/checkout` and `actions/setup-node` to v7 in all four workflows
- group React packages and GitHub Actions into coherent Dependabot updates
- keep static and browser verification on Ubuntu while running platform-specific visual baselines on Windows
- update workflow contract coverage for Action pins, dependency groups, and the visual runner

## Verification
- workflow runner correction followed red-green TDD
- `npm run check` — passed (22 test files, 129 tests, lint, typecheck, catalog validation, production build, static export)
- `npm run test:e2e` — passed (29 tests)
- `npm run test:visual` — passed (10 tests)
- GitHub Actions — passed (Ubuntu verify and Windows visual)