### PR TITLE
test: derive published Kit count

### DIFF
--- a/.github/ISSUE_TEMPLATE/05-kit-submission.yml
+++ b/.github/ISSUE_TEMPLATE/05-kit-submission.yml
@@ -1,5 +1,5 @@
 name: Submit or edit a Kit
-description: Propose a new Kit or an author revision for maintainer review.
+description: Create a new Kit or submit an author revision for automatic validation and publication.
 title: "[Kit submission]: "
 labels:
   - kit-submission
@@ -7,7 +7,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Build a new Kit in Tavernary, or use **Edit Kit** on a published Kit, before submitting this form. Submissions are validated automatically and published only after maintainer review. The live Kit remains unchanged while an edit is reviewed.
+        Build a new Kit in Tavernary, or use **Edit Kit** on a published Kit, before submitting this form. Valid submissions publish automatically. Tavernary checks the title and description for severe language in the builder and rechecks the manifest here. If validation fails, edit this issue to correct it and automation will retry.
   - type: input
     id: kit-title
     attributes:

--- a/.github/workflows/apply-kit-submission.yml
+++ b/.github/workflows/apply-kit-submission.yml
@@ -78,7 +78,7 @@ jobs:
         run: gh workflow run deploy-pages.yml --ref main -f source_sha="${{ steps.commit.outputs.sha }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Mark issue published
+      - name: Finalize published issue
         shell: bash
         run: |
           if ! gh label view kit-published >/dev/null 2>&1; then
@@ -91,6 +91,9 @@ jobs:
             echo "::warning title=Kit publication bookkeeping::The Kit was published and deployment was requested, but the kit-published label could not be ensured."
           elif ! gh issue edit "${{ inputs.issue_number }}" --add-label kit-published; then
             echo "::warning title=Kit publication bookkeeping::The Kit was published and deployment was requested, but issue #${{ inputs.issue_number }} could not be labeled."
+          fi
+          if ! gh issue close "${{ inputs.issue_number }}" --reason completed; then
+            echo "::warning title=Kit publication bookkeeping::The Kit was published and deployment was requested, but issue #${{ inputs.issue_number }} could not be closed."
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/triage-kit-submission.yml
+++ b/.github/workflows/triage-kit-submission.yml
@@ -16,6 +16,7 @@ on:
 permissions:
   contents: read
   issues: write
+  actions: write
 
 concurrency:
   group: triage-kit-${{ inputs.issue_number || github.event.issue.number }}
@@ -46,7 +47,17 @@ jobs:
         with:
           node-version: 24
       - name: Validate and label Kit submission
+        id: triage
         run: node scripts/submissions/triage-kit-issue.mjs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ inputs.issue_number || github.event.issue.number }}
+      - name: Publish valid Kit
+        if: steps.triage.outputs.publish == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ steps.triage.outputs.issue_number }}
+        run: >
+          gh workflow run apply-kit-submission.yml
+          --ref main
+          -f issue_number="$ISSUE_NUMBER"

--- a/docs/contributing/kits.md
+++ b/docs/contributing/kits.md
@@ -1,14 +1,14 @@
 # Kit submission and moderation workflows
 
-Kits are curated, community-authored project collections. They are submitted and
-moderated through issue forms, not direct registry edits.
+Kits are community-authored project collections. They are submitted and
+published through issue automation, not direct registry edits.
 
 ## What is a Kit
 
 - A Kit is a named ordered list of 3-50 published project IDs.
 - Community support feeds Trending; Tavernary does not assign editorial
   endorsements.
-- Kits are stable JSON records in `data/registry/kits/*.json` after maintainer
+- Kits are stable JSON records in `data/registry/kits/*.json` after automated
   publication.
 
 ## Submit a new Kit
@@ -26,19 +26,32 @@ Required safety gates in the submission path:
 - `id` uniqueness and duplicate-detection checks;
 - 3-50 project IDs and all IDs must exist in the catalog;
 - title/description/project ordering validation;
-- source issue metadata capture for review.
+- author identity and blocked-user checks;
+- severe-language checks for the title and description; and
+- source issue metadata capture.
 
-The pending draft is not published. A maintainer must review and approve before
-record publication.
+The builder prevents submission when its title or description contains a term
+from Tavernary's narrow severe-language policy. Common profanity is not the
+target of this rule, and the matched term is not repeated in the error message.
+
+After GitHub admits the issue, Kit triage revalidates the latest manifest. A
+valid issue publishes automatically: the publisher validates again, updates
+the registry, runs repository gates, pushes `main`, requests deployment for the
+exact commit SHA, and closes the issue. A correctable failure remains open with
+`needs-information`; edit the issue and automation retries without consuming
+another issue slot.
 
 ## Edit an existing Kit
 
 Use the same `05-kit-submission.yml` form with operation `edit` and the published
 Kit issue ID.
 
-- Edits produce a new pending draft version, not an immediate overwrite.
-- The published Kit file changes only after maintainer review and workflow apply.
-- Timestamps update on approved publication only.
+- The published Kit remains unchanged until server validation and publication
+  gates pass.
+- Only the Kit author's GitHub numeric identity may publish an edit.
+- Timestamps update only when canonical Kit content or the displayed author
+  login changes.
+- An unchanged retry is a no-op.
 
 ## Report unsafe or low-quality Kits
 
@@ -73,7 +86,8 @@ Withdrawal requires the issue author GitHub numeric identity to match the Kit
 - Do not edit `data/registry/kits/*.json` directly.
 - Do not share private issue details publicly.
 - Do not use Kit links as proof-of-trust or endorsement.
-- Kit publication is moderation-bound; community support is separate from safety.
+- Automated publication does not make a Kit an endorsement; community support
+  remains separate from safety.
 
 For maintainer-side actions, see:
 

--- a/docs/contributing/submission-and-review.md
+++ b/docs/contributing/submission-and-review.md
@@ -83,15 +83,21 @@ through normal gates.
 
 ### Kits
 
-- Kit edits are submitted with `05-kit-submission.yml`, validated by
-  `triage-kit-submission.yml`, then applied with `apply-kit-submission.yml` after
-  maintainer review.
+- Kit creates and author-owned edits use `05-kit-submission.yml`.
 - Kit submissions are prepared by the in-browser builder and serialized into a
-  stable JSON manifest on submit.
+  stable JSON manifest on submit. The builder blocks severe language in the
+  title and description.
+- `triage-kit-submission.yml` validates the latest manifest, including the same
+  severe-language policy used by the Kit Builder.
+- A valid issue dispatches `apply-kit-submission.yml` automatically. The
+  publisher revalidates, writes the registry record, runs repository gates,
+  pushes `main`, requests exact-SHA Pages deployment, and closes the issue.
+- A correctable validation failure remains open. Edit the issue and automation
+  reruns without consuming another issue slot.
 
-New Kits and edits are stored as pending records, while the currently published
-Kit remains unchanged.
-Maintainers review support signal, eligibility, and safety fit before publication.
+The currently published Kit remains unchanged until every publication gate
+passes. Near-duplicate composition is a non-blocking warning; exact duplicate
+project sets remain invalid.
 Withdrawals are submitted with `07-kit-withdrawal.yml` and applied via
 `apply-kit-withdrawal.yml`; GitHub identity must match the recorded author.
 
@@ -100,8 +106,9 @@ Withdrawals are submitted with `07-kit-withdrawal.yml` and applied via
 Issue labels include both queue ownership (`project-submission`,
 `project-information`, `website-bug`, `kit-submission`, `kit-report`,
 `kit-withdrawal`) and automation state (`needs-information`,
-`submission-pr-open`, `submission-declined`). Publication still occurs only
-through a maintainer merge.
+`kit-publication-ready`, `kit-published`, `submission-pr-open`,
+`submission-declined`). Project publication still occurs through a maintainer
+merge; valid Kit creates and edits publish automatically.
 
 For full Kit maintainer constraints and safety paths, see
 [Kit submission and moderation](kits.md) and
@@ -121,7 +128,7 @@ See maintainer operating flow for exact sequencing in
 
 - Keep contributions to one intent per issue.
 - Include evidence links (release notes, announcements, docs, changelog).
-- Do not bypass manual review: submission is a request, maintainer merge is
-  publication.
+- Do not bypass the Project review PR or the reviewed Kit safety-repair path.
+- Correct an automatically rejected Kit by editing its open issue.
 - Keep generated artifacts deterministic and avoid hand-editing generated files
   outside the approved scripts.

--- a/docs/maintenance/kits.md
+++ b/docs/maintenance/kits.md
@@ -1,9 +1,9 @@
 # Kit Maintenance
 
-Kit publication and author edits use the issue workflows. Discovery is
-community-driven: community support feeds Trending, with no maintainer-curated
-endorsement. The following exceptional maintainer operation uses ordinary Git
-history so every change is reviewable.
+Valid Kit creates and author edits publish automatically through the issue
+workflows. Discovery is community-driven: community support feeds Trending,
+with no maintainer-curated endorsement. The following exceptional maintainer
+operation uses ordinary Git history so every change is reviewable.
 
 ## Safety repair
 

--- a/docs/maintenance/operations-runbook.md
+++ b/docs/maintenance/operations-runbook.md
@@ -70,8 +70,9 @@ Other public issue flows are queue-only and reviewed manually:
 - `submission-pr-open` while the generated PR is the active review surface
 - `submission-declined` after that PR is closed without merging
 
-`triage-kit-issue.mjs` retains the Kit-specific
-`needs-maintainer-review`/`needs-information`/`duplicate-candidate` flow.
+`triage-kit-issue.mjs` owns the Kit-specific
+`kit-publication-ready`/`needs-information`/`duplicate-candidate` flow. A
+near-duplicate warning does not block publication; an exact duplicate does.
 
 The triage workflow posts/updates one comment marker:
 
@@ -80,6 +81,10 @@ The triage workflow posts/updates one comment marker:
 
 Project triage does not publish a catalog record. An admitted decision
 dispatches the separate generation workflow.
+
+Valid Kit triage dispatches the separate serialized Kit publisher
+automatically. Invalid Kit issues remain open for correction; edit the issue to
+rerun triage.
 
 ## Project submission path
 
@@ -225,17 +230,32 @@ Workflow set:
 - `.github/ISSUE_TEMPLATE/05-kit-submission.yml` issues route to
   `[Kit submission]`.
 - `.github/workflows/triage-kit-submission.yml` applies labels:
-  `needs-maintainer-review`, `needs-information`, `duplicate-candidate`.
-- `.github/workflows/apply-kit-submission.yml` applies approved edit/create issues:
-  - validates issue content again
+  `kit-publication-ready`, `needs-information`, `duplicate-candidate`.
+- Valid triage dispatches `.github/workflows/apply-kit-submission.yml`
+  automatically with the issue number.
+- `.github/workflows/apply-kit-submission.yml` applies valid edit/create issues:
+  - re-fetches and validates issue content again, including the shared
+    severe-language policy
   - writes/updates `data/registry/kits/<kit-id>.json`
   - validates and builds catalog
   - commits `feat(kits): publish issue #<n>`
-  - dispatches deploy workflow
+  - serializes writes under `kit-registry` concurrency
+  - treats an unchanged edit retry as a timestamp-preserving no-op
+  - dispatches the deploy workflow for the exact pushed SHA
+  - applies `kit-published` and closes the source issue only after deployment
+    dispatch succeeds
 - `.github/workflows/apply-kit-withdrawal.yml` + `scripts/kits/apply-withdrawal.mjs`:
   - only Kit author numeric ID may withdraw
   - writes withdrawn tombstone status
   - closes withdrawal issue and deploys.
+
+If Kit validation fails, correct the manifest by editing the open issue.
+Automation reruns triage. If publication fails after valid triage, rerun the
+failed publisher from GitHub Actions; its current-`main` synchronization and
+idempotent apply rules make retries safe. Do not hand-edit generated registry
+or catalog artifacts. Label or issue-closure bookkeeping failures after the
+canonical push and exact-SHA deployment request appear as warnings and do not
+turn successful publication into a false failure.
 
 ## Identity and moderation maintenance
 

--- a/docs/superpowers/plans/2026-07-26-automatic-kit-publication.md
+++ b/docs/superpowers/plans/2026-07-26-automatic-kit-publication.md
@@ -518,7 +518,7 @@ Run:
 
 ```powershell
 npm.cmd run build:test-kits
-npx.cmd playwright test --config playwright.kits.config.ts tests/kits-e2e/kits.spec.ts --grep "blocks severe"
+node scripts/run-playwright.mjs --config playwright.kits.config.ts kits.spec.ts --grep "blocks severe"
 ```
 
 Expected: PASS with no popup or GitHub navigation.
@@ -1203,7 +1203,7 @@ Run:
 
 ```powershell
 npm.cmd run build:test-kits
-npx.cmd playwright test --config playwright.kits.config.ts tests/kits-e2e/kits.spec.ts --grep "blocks severe"
+node scripts/run-playwright.mjs --config playwright.kits.config.ts kits.spec.ts --grep "blocks severe"
 ```
 
 Expected: PASS; field-level validation is visible, focus is correct, and

--- a/scripts/kits/apply-submission.mjs
+++ b/scripts/kits/apply-submission.mjs
@@ -68,10 +68,21 @@ export function applyKitSubmission({ manifest, issue, existingKit, now }) {
   if (existingKit.author.github_user_id !== issue.user.id) {
     throw new Error("Only the Kit author may publish an edit.");
   }
+  const title = manifest.title.trim();
+  const description = manifest.description.trim();
+  const unchanged =
+    existingKit.title === title &&
+    existingKit.description === description &&
+    existingKit.author.login === issue.user.login &&
+    JSON.stringify(existingKit.project_ids) ===
+      JSON.stringify(manifest.project_ids);
+  if (unchanged) {
+    return existingKit;
+  }
   return {
     ...existingKit,
-    title: manifest.title.trim(),
-    description: manifest.description.trim(),
+    title,
+    description,
     author: { ...existingKit.author, login: issue.user.login },
     project_ids: [...manifest.project_ids],
     updated_at: now,

--- a/scripts/submissions/triage-kit-issue.d.mts
+++ b/scripts/submissions/triage-kit-issue.d.mts
@@ -16,6 +16,10 @@ export function buildKitValidationComment(
 export function assertKitSubmissionEligible(
   issue: Pick<KitSubmissionIssue, "title" | "state" | "labels">,
 ): void;
+export function kitTriageOutputs(
+  validation: KitSubmissionValidation,
+  issue: { number: number },
+): { publish: string; issue_number: string };
 export function synchronizeKitSubmission(
   repository: string,
   issueNumber: number,

--- a/scripts/submissions/triage-kit-issue.mjs
+++ b/scripts/submissions/triage-kit-issue.mjs
@@ -1,4 +1,4 @@
-import { readFile, readdir } from "node:fs/promises";
+import { appendFile, readFile, readdir } from "node:fs/promises";
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
@@ -6,9 +6,9 @@ import { validateKitSubmission } from "./validate-kit-submission.mjs";
 
 const validationMarker = "<!-- tavernary-kit-submission-validation -->";
 const triageLabels = {
-  "needs-maintainer-review": {
+  "kit-publication-ready": {
     color: "0e8a16",
-    description: "Kit passed automation and awaits maintainer review.",
+    description: "Kit passed automation and is queued for publication.",
   },
   "needs-information": {
     color: "d93f0b",
@@ -19,6 +19,10 @@ const triageLabels = {
     description: "Kit duplicates or closely overlaps an existing Kit.",
   },
 };
+const ownedTriageLabels = [
+  ...Object.keys(triageLabels),
+  "needs-maintainer-review",
+];
 
 export function parseKitIssueFields(body) {
   const fields = new Map();
@@ -41,7 +45,7 @@ export function buildKitValidationComment(validation) {
   if (validation.errors.length === 0) {
     return [
       validationMarker,
-      "Automated validation now passes. This Kit is ready for maintainer review.",
+      "Automated validation passes. Tavernary is publishing this Kit.",
       ...(validation.warnings.length
         ? ["", ...validation.warnings.map((warning) => `- ${warning}`)]
         : []),
@@ -117,7 +121,7 @@ export async function synchronizeKitSubmission(
       typeof label === "string" ? label : label.name,
     ),
   );
-  for (const name of Object.keys(triageLabels)) {
+  for (const name of ownedTriageLabels) {
     if (current.has(name) && !validation.labels.includes(name)) {
       try {
         await request(
@@ -190,6 +194,13 @@ export function assertKitSubmissionEligible(issue) {
   }
 }
 
+export function kitTriageOutputs(validation, issue) {
+  return {
+    publish: String(validation.valid),
+    issue_number: String(issue.number),
+  };
+}
+
 async function main() {
   const rawEvent = JSON.parse(
     await readFile(process.env.GITHUB_EVENT_PATH, "utf8"),
@@ -217,6 +228,16 @@ async function main() {
     event.issue.number,
     validation,
   );
+  if (process.env.GITHUB_OUTPUT) {
+    const outputs = kitTriageOutputs(validation, event.issue);
+    await appendFile(
+      process.env.GITHUB_OUTPUT,
+      `${Object.entries(outputs)
+        .map(([name, value]) => `${name}=${value}`)
+        .join("\n")}\n`,
+      "utf8",
+    );
+  }
 }
 
 if (

--- a/scripts/submissions/validate-kit-submission.mjs
+++ b/scripts/submissions/validate-kit-submission.mjs
@@ -98,9 +98,7 @@ export function validateKitSubmission({
         nearDuplicate(kit.project_ids, parsed.project_ids),
       )
     ) {
-      warnings.push(
-        "This composition is a near-duplicate of an existing Kit and requires maintainer judgment.",
-      );
+      warnings.push("This composition is a near-duplicate of an existing Kit.");
     }
   }
 
@@ -110,7 +108,7 @@ export function validateKitSubmission({
   const labels = errors.length
     ? [duplicate ? "duplicate-candidate" : "needs-information"]
     : [
-        "needs-maintainer-review",
+        "kit-publication-ready",
         ...(warnings.length ? ["duplicate-candidate"] : []),
       ];
   return {

--- a/src/features/kits/components/kit-builder.tsx
+++ b/src/features/kits/components/kit-builder.tsx
@@ -117,9 +117,9 @@ export function KitBuilder({
       ? ["A duplicate must change the selected project set."]
       : []),
   ];
-  const titleError = errors.find((error) => error.startsWith("Title must"));
+  const titleError = errors.find((error) => error.startsWith("Title "));
   const descriptionError = errors.find((error) =>
-    error.startsWith("Description must"),
+    error.startsWith("Description "),
   );
   const compositionErrors = errors.filter(
     (error) => error !== titleError && error !== descriptionError,

--- a/src/features/kits/kit-domain.mjs
+++ b/src/features/kits/kit-domain.mjs
@@ -1,3 +1,5 @@
+import { containsDisallowedKitLanguage } from "./severe-language-policy.mjs";
+
 export function kitSetKey(projectIds) {
   return [...new Set(projectIds)].sort().join("\n");
 }
@@ -21,6 +23,12 @@ export function validateKitDraft(draft, projects) {
   }
   if (draft.description.trim().length < 1 || draft.description.length > 600) {
     errors.push("Description must contain 1–600 characters.");
+  }
+  if (containsDisallowedKitLanguage(title)) {
+    errors.push("Title contains language Tavernary doesn't allow.");
+  }
+  if (containsDisallowedKitLanguage(draft.description)) {
+    errors.push("Description contains language Tavernary doesn't allow.");
   }
   if (markupOrLink.test(title) || markupOrLink.test(draft.description)) {
     errors.push("Kit text cannot contain links or markup.");

--- a/src/features/kits/severe-language-policy.d.mts
+++ b/src/features/kits/severe-language-policy.d.mts
@@ -1,0 +1,2 @@
+export const severeLanguageTerms: readonly string[];
+export function containsDisallowedKitLanguage(value: string): boolean;

--- a/src/features/kits/severe-language-policy.mjs
+++ b/src/features/kits/severe-language-policy.mjs
@@ -1,0 +1,75 @@
+export const severeLanguageTerms = Object.freeze([
+  "chink",
+  "chinks",
+  "coon",
+  "coons",
+  "dyke",
+  "dykes",
+  "fag",
+  "faggot",
+  "faggots",
+  "fags",
+  "gook",
+  "gooks",
+  "kike",
+  "kikes",
+  "mongoloid",
+  "nigga",
+  "niggas",
+  "nigger",
+  "niggers",
+  "paki",
+  "pakis",
+  "raghead",
+  "ragheads",
+  "retard",
+  "retards",
+  "shemale",
+  "shemales",
+  "spic",
+  "spics",
+  "towelhead",
+  "towelheads",
+  "trannies",
+  "tranny",
+  "wetback",
+  "wetbacks",
+]);
+
+const substitutions = Object.freeze({
+  "0": "o",
+  "1": "i",
+  "3": "e",
+  "4": "a",
+  "5": "s",
+  "7": "t",
+  "@": "a",
+  $: "s",
+});
+
+function escapePattern(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+function normalizeForPolicy(value) {
+  return value
+    .normalize("NFKD")
+    .replace(/\p{M}/gu, "")
+    .toLowerCase()
+    .replace(/[013457@$]/gu, (character) => substitutions[character]);
+}
+
+const separator = String.raw`[\p{P}\p{S}\s_]*`;
+const termPatterns = severeLanguageTerms.map((term) => {
+  const body = [...term].map(escapePattern).join(separator);
+  return new RegExp(
+    String.raw`(?<![\p{L}\p{N}])${body}(?![\p{L}\p{N}])`,
+    "u",
+  );
+});
+
+export function containsDisallowedKitLanguage(value) {
+  if (typeof value !== "string" || value.length === 0) return false;
+  const normalized = normalizeForPolicy(value);
+  return termPatterns.some((pattern) => pattern.test(normalized));
+}

--- a/src/features/kits/severe-language-policy.mjs
+++ b/src/features/kits/severe-language-policy.mjs
@@ -37,12 +37,12 @@ export const severeLanguageTerms = Object.freeze([
 ]);
 
 const substitutions = Object.freeze({
-  "0": "o",
-  "1": "i",
-  "3": "e",
-  "4": "a",
-  "5": "s",
-  "7": "t",
+  0: "o",
+  1: "i",
+  3: "e",
+  4: "a",
+  5: "s",
+  7: "t",
   "@": "a",
   $: "s",
 });
@@ -62,10 +62,7 @@ function normalizeForPolicy(value) {
 const separator = String.raw`[\p{P}\p{S}\s_]*`;
 const termPatterns = severeLanguageTerms.map((term) => {
   const body = [...term].map(escapePattern).join(separator);
-  return new RegExp(
-    String.raw`(?<![\p{L}\p{N}])${body}(?![\p{L}\p{N}])`,
-    "u",
-  );
+  return new RegExp(String.raw`(?<![\p{L}\p{N}])${body}(?![\p{L}\p{N}])`, "u");
 });
 
 export function containsDisallowedKitLanguage(value) {

--- a/tests/e2e/kits-empty.spec.ts
+++ b/tests/e2e/kits-empty.spec.ts
@@ -1,7 +1,16 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
 import { expect, test } from "@playwright/test";
 
 import { generatedProjectCount } from "../helpers/generated-catalog";
 import { sitePath } from "../helpers/site-path";
+
+const publishedKitCount = (
+  JSON.parse(
+    readFileSync(resolve(process.cwd(), "src/generated/catalog.json"), "utf8"),
+  ) as { kits: unknown[] }
+).kits.length;
 
 test("switches between projects and the published Kits catalog", async ({
   page,
@@ -10,7 +19,7 @@ test("switches between projects and the published Kits catalog", async ({
   await page.getByRole("button", { name: "Kits", exact: true }).click();
   await expect(page).toHaveURL(/mode=kits/);
   await expect(page.locator(".project-card")).toHaveCount(0);
-  await expect(page.locator(".kit-card")).toHaveCount(1);
+  await expect(page.locator(".kit-card")).toHaveCount(publishedKitCount);
   await expect(
     page.getByRole("heading", { name: "Ultimate Harry Potter" }),
   ).toBeVisible();

--- a/tests/kits-e2e/kits.spec.ts
+++ b/tests/kits-e2e/kits.spec.ts
@@ -176,6 +176,52 @@ test("desktop Frontend discovery reveals the visible filter and card action", as
   await expect(page).not.toHaveURL(/kind=frontend/);
 });
 
+test("blocks severe Kit text before GitHub opens", async ({ page }) => {
+  await page.addInitScript(() => {
+    Object.defineProperty(window, "open", {
+      configurable: true,
+      value: (...args: unknown[]) => {
+        (
+          window as Window & { __kitOpenCalls?: unknown[][] }
+        ).__kitOpenCalls ??= [];
+        (
+          window as Window & { __kitOpenCalls: unknown[][] }
+        ).__kitOpenCalls.push(args);
+        return null;
+      },
+    });
+  });
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto(sitePath());
+  await selectProject(page, "Fixture Frontend");
+  await selectProject(page, "Fixture Tool 02");
+  await selectProject(page, "Fixture Tool 03");
+  await page.getByRole("button", { name: "Add 3 projects to Kit" }).click();
+  const title = page.getByLabel("Title", { exact: true });
+  if (!(await title.isVisible())) {
+    await page
+      .getByRole("button", { name: /Open Kit Builder, 3 projects in draft/ })
+      .click();
+  }
+  await title.fill("N1gg3r Story Kit");
+  await page
+    .getByLabel("Description", { exact: true })
+    .fill("A complete storytelling stack.");
+  await page.getByRole("button", { name: "Submit Kit" }).click();
+
+  await expect(
+    page.getByText("Title contains language Tavernary doesn't allow."),
+  ).toBeVisible();
+  await expect(title).toBeFocused();
+  expect(
+    await page.evaluate(
+      () =>
+        (window as Window & { __kitOpenCalls?: unknown[][] }).__kitOpenCalls ??
+        [],
+    ),
+  ).toEqual([]);
+});
+
 test("mobile Frontend discovery returns from Kits to the filtered cards", async ({
   page,
 }) => {

--- a/tests/kits-e2e/kits.spec.ts
+++ b/tests/kits-e2e/kits.spec.ts
@@ -181,12 +181,11 @@ test("blocks severe Kit text before GitHub opens", async ({ page }) => {
     Object.defineProperty(window, "open", {
       configurable: true,
       value: (...args: unknown[]) => {
-        (
-          window as Window & { __kitOpenCalls?: unknown[][] }
-        ).__kitOpenCalls ??= [];
-        (
-          window as Window & { __kitOpenCalls: unknown[][] }
-        ).__kitOpenCalls.push(args);
+        const trackingWindow = window as Window & {
+          __kitOpenCalls?: unknown[][];
+        };
+        trackingWindow.__kitOpenCalls ??= [];
+        trackingWindow.__kitOpenCalls.push(args);
         return null;
       },
     });

--- a/tests/unit/apply-kit-submission.test.ts
+++ b/tests/unit/apply-kit-submission.test.ts
@@ -157,6 +157,27 @@ test("edits only author-controlled fields and preserves canonical identity", () 
   });
 });
 
+test("treats an unchanged edit retry as a timestamp-preserving no-op", () => {
+  const result = applyKitSubmission({
+    manifest: {
+      operation: "edit",
+      kit_id: existing.id,
+      title: existing.title,
+      description: existing.description,
+      project_ids: existing.project_ids,
+    },
+    issue: {
+      ...issue,
+      user: { ...issue.user, login: existing.author.login },
+    },
+    existingKit: existing,
+    now,
+  });
+
+  expect(result).toBe(existing);
+  expect(result.updated_at).toBe("2026-07-01T00:00:00.000Z");
+});
+
 test("rejects edits by a different numeric actor and exact duplicate creates", () => {
   expect(() =>
     applyKitSubmission({

--- a/tests/unit/kit-automatic-publication-workflow.test.ts
+++ b/tests/unit/kit-automatic-publication-workflow.test.ts
@@ -32,9 +32,7 @@ test("valid Kit triage dispatches serialized publication automatically", async (
     (step) => step.name === "Publish valid Kit",
   );
   expect(publish?.if).toContain("steps.triage.outputs.publish == 'true'");
-  expect(publish?.run).toContain(
-    "gh workflow run apply-kit-submission.yml",
-  );
+  expect(publish?.run).toContain("gh workflow run apply-kit-submission.yml");
   expect(publish?.run).toContain("--ref main");
   expect(publish?.run).toContain('-f issue_number="$ISSUE_NUMBER"');
 });

--- a/tests/unit/kit-automatic-publication-workflow.test.ts
+++ b/tests/unit/kit-automatic-publication-workflow.test.ts
@@ -1,0 +1,40 @@
+import { readFile } from "node:fs/promises";
+
+import { expect, test } from "vitest";
+import { parse } from "yaml";
+
+test("valid Kit triage dispatches serialized publication automatically", async () => {
+  const source = await readFile(
+    ".github/workflows/triage-kit-submission.yml",
+    "utf8",
+  );
+  const workflow = parse(source) as {
+    permissions: Record<string, string>;
+    jobs: {
+      validate: {
+        steps: Array<{
+          id?: string;
+          name?: string;
+          if?: string;
+          run?: string;
+        }>;
+      };
+    };
+  };
+
+  expect(workflow.permissions.contents).toBe("read");
+  expect(workflow.permissions.actions).toBe("write");
+  const triage = workflow.jobs.validate.steps.find(
+    (step) => step.name === "Validate and label Kit submission",
+  );
+  expect(triage?.id).toBe("triage");
+  const publish = workflow.jobs.validate.steps.find(
+    (step) => step.name === "Publish valid Kit",
+  );
+  expect(publish?.if).toContain("steps.triage.outputs.publish == 'true'");
+  expect(publish?.run).toContain(
+    "gh workflow run apply-kit-submission.yml",
+  );
+  expect(publish?.run).toContain("--ref main");
+  expect(publish?.run).toContain('-f issue_number="$ISSUE_NUMBER"');
+});

--- a/tests/unit/kit-builder.test.tsx
+++ b/tests/unit/kit-builder.test.tsx
@@ -835,6 +835,55 @@ describe("Kit builder controls", () => {
     expect(onSubmit).toHaveBeenCalledOnce();
   });
 
+  test("blocks severe title and description text with field-level focus", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    const { rerender } = render(
+      <KitBuilder
+        draft={{ ...validDraft, title: "N1gg3r Story Kit" }}
+        projects={projects}
+        originalProjectIds={[]}
+        onUpdate={() => undefined}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Submit Kit" }));
+    const title = screen.getByRole("textbox", { name: "Title" });
+    expect(title).toHaveFocus();
+    expect(title).toHaveAttribute("aria-invalid", "true");
+    expect(
+      screen.getByText("Title contains language Tavernary doesn't allow."),
+    ).toBeVisible();
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    rerender(
+      <KitBuilder
+        draft={{
+          ...validDraft,
+          title: "Story Kit",
+          description: "A f.a.g.g.o.t story stack.",
+        }}
+        projects={projects}
+        originalProjectIds={[]}
+        onUpdate={() => undefined}
+        onSubmit={onSubmit}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "Submit Kit" }));
+    const description = screen.getByRole("textbox", {
+      name: "Description",
+    });
+    expect(description).toHaveFocus();
+    expect(description).toHaveAttribute("aria-invalid", "true");
+    expect(
+      screen.getByText(
+        "Description contains language Tavernary doesn't allow.",
+      ),
+    ).toBeVisible();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
   test("enforces duplicate changes before submission", async () => {
     const user = userEvent.setup();
     const onUpdate = vi.fn();

--- a/tests/unit/kit-domain.test.ts
+++ b/tests/unit/kit-domain.test.ts
@@ -130,6 +130,58 @@ describe("Kit domain", () => {
     );
   });
 
+  test("rejects severe language in title and description", () => {
+    const titleResult = validateKitDraft(
+      {
+        operation: "create",
+        kitId: null,
+        title: "N1gg3r Story Kit",
+        description: "A compact story stack.",
+        projectIds: ["frontend", "memory", "preset"],
+      },
+      projects,
+    );
+    const descriptionResult = validateKitDraft(
+      {
+        operation: "create",
+        kitId: null,
+        title: "Story Kit",
+        description: "A f.a.g.g.o.t story stack.",
+        projectIds: ["frontend", "memory", "preset"],
+      },
+      projects,
+    );
+
+    expect(titleResult.errors).toContain(
+      "Title contains language Tavernary doesn't allow.",
+    );
+    expect(descriptionResult.errors).toContain(
+      "Description contains language Tavernary doesn't allow.",
+    );
+  });
+
+  test.each(["Damn Good Kit", "Badass Kit", "This shit works."])(
+    "allows common profanity in Kit text: %s",
+    (text) => {
+      expect(
+        validateKitDraft(
+          {
+            operation: "create",
+            kitId: null,
+            title: text,
+            description: text,
+            projectIds: ["frontend", "memory", "preset"],
+          },
+          projects,
+        ).errors,
+      ).not.toEqual(
+        expect.arrayContaining([
+          expect.stringContaining("language Tavernary doesn't allow"),
+        ]),
+      );
+    },
+  );
+
   test("enforces the 50-project ceiling", () => {
     const manyProjects = [
       ...projects,

--- a/tests/unit/kit-maintenance-docs.test.ts
+++ b/tests/unit/kit-maintenance-docs.test.ts
@@ -63,3 +63,27 @@ test("documents the current Kit Builder batch-selection behavior", async () => {
     expect(legacySpec).toContain("Superseded interaction");
   }
 });
+
+test("documents automatic Kit publication and severe-language revalidation", async () => {
+  const [form, contributorGuide, submissionFlow, maintenance, runbook] =
+    await Promise.all([
+      readFile(".github/ISSUE_TEMPLATE/05-kit-submission.yml", "utf8"),
+      readFile("docs/contributing/kits.md", "utf8"),
+      readFile("docs/contributing/submission-and-review.md", "utf8"),
+      readFile("docs/maintenance/kits.md", "utf8"),
+      readFile("docs/maintenance/operations-runbook.md", "utf8"),
+    ]);
+  const publicCopy = `${form}\n${contributorGuide}\n${submissionFlow}`;
+
+  expect(publicCopy).toMatch(/publish(?:es|ed)? automatically/i);
+  expect(publicCopy).toMatch(/title and (?:description|summary)/i);
+  expect(publicCopy).toMatch(/severe language/i);
+  expect(publicCopy).toMatch(/edit the issue/i);
+  expect(publicCopy).not.toMatch(/Kit.*maintainer review/i);
+
+  expect(maintenance).toContain("## Safety repair");
+  expect(runbook).toContain("kit-publication-ready");
+  expect(runbook).toContain("apply-kit-submission.yml");
+  expect(runbook).toMatch(/closes the source issue/i);
+  expect(runbook).toMatch(/exact.*SHA/i);
+});

--- a/tests/unit/kit-publication-workflow-hardening.test.ts
+++ b/tests/unit/kit-publication-workflow-hardening.test.ts
@@ -29,7 +29,7 @@ test("dispatches the exact published Kit commit before issue bookkeeping", async
     (step) => step.name === "Deploy updated catalog",
   );
   const bookkeeping = steps.findIndex(
-    (step) => step.name === "Mark issue published",
+    (step) => step.name === "Finalize published issue",
   );
 
   expect(deploy).toBeGreaterThanOrEqual(0);
@@ -43,7 +43,7 @@ test("dispatches the exact published Kit commit before issue bookkeeping", async
 test("treats Kit issue labeling as warning-only bookkeeping", async () => {
   const steps = await publicationSteps();
   const bookkeeping = steps.find(
-    (step) => step.name === "Mark issue published",
+    (step) => step.name === "Finalize published issue",
   );
 
   expect(bookkeeping?.run).toContain("gh label view kit-published");
@@ -59,5 +59,23 @@ test("treats Kit issue labeling as warning-only bookkeeping", async () => {
   );
   expect(bookkeeping?.run).toMatch(
     /if ! gh issue edit[\s\S]*then[\s\S]*::warning/,
+  );
+});
+
+test("closes a published Kit issue only after exact-SHA deployment dispatch", async () => {
+  const steps = await publicationSteps();
+  const deploy = steps.findIndex(
+    (step) => step.name === "Deploy updated catalog",
+  );
+  const finalize = steps.findIndex(
+    (step) => step.name === "Finalize published issue",
+  );
+
+  expect(finalize).toBeGreaterThan(deploy);
+  expect(steps[finalize]?.run).toContain(
+    'gh issue close "${{ inputs.issue_number }}" --reason completed',
+  );
+  expect(steps[finalize]?.run).toContain(
+    "::warning title=Kit publication bookkeeping::",
   );
 });

--- a/tests/unit/kit-workflow-git-recovery.test.ts
+++ b/tests/unit/kit-workflow-git-recovery.test.ts
@@ -155,6 +155,44 @@ test("a stale create rerun fast-forwards before applying the issue again", async
   expect(retried.published_at).toBe("2026-07-24T17:00:00.000Z");
 });
 
+test("an unchanged edit retry leaves the registry and timestamp untouched", async () => {
+  const published = applyKitSubmission({
+    manifest,
+    issue,
+    now: "2026-07-24T17:00:00.000Z",
+  });
+  const repository = await createRemote(published);
+  const rerun = await cloneAt(
+    repository.root,
+    repository.remote,
+    "rerun-edit",
+    repository.initialSha,
+  );
+  synchronizeCurrentMain(rerun);
+  const current = JSON.parse(
+    await readFile(
+      resolve(rerun, "data/registry/kits/long-form-storyteller-241.json"),
+      "utf8",
+    ),
+  );
+  const retried = applyKitSubmission({
+    manifest: {
+      operation: "edit",
+      kit_id: published.id,
+      title: published.title,
+      description: published.description,
+      project_ids: published.project_ids,
+    },
+    issue,
+    existingKit: current,
+    now: "2026-07-25T17:00:00.000Z",
+  });
+  await writeKit(rerun, retried);
+
+  expect(git(rerun, "status", "--porcelain")).toBe("");
+  expect(retried.updated_at).toBe(published.updated_at);
+});
+
 test("a stale withdrawal rerun preserves the original tombstone", async () => {
   const published = applyKitSubmission({
     manifest,

--- a/tests/unit/severe-language-policy.test.ts
+++ b/tests/unit/severe-language-policy.test.ts
@@ -13,15 +13,12 @@ describe("Kit severe-language policy", () => {
     },
   );
 
-  test.each([
-    "NIGGER",
-    "n!i!g!g!e!r",
-    "n i g g e r",
-    "n1gg3r",
-    "fa\u0301ggot",
-  ])("blocks normalized disguise %s", (text) => {
-    expect(containsDisallowedKitLanguage(text)).toBe(true);
-  });
+  test.each(["NIGGER", "n!i!g!g!e!r", "n i g g e r", "n1gg3r", "fa\u0301ggot"])(
+    "blocks normalized disguise %s",
+    (text) => {
+      expect(containsDisallowedKitLanguage(text)).toBe(true);
+    },
+  );
 
   test.each([
     "Damn Good Stories",
@@ -38,12 +35,10 @@ describe("Kit severe-language policy", () => {
     expect(severeLanguageTerms.length).toBeGreaterThan(0);
     expect(new Set(severeLanguageTerms).size).toBe(severeLanguageTerms.length);
     expect(severeLanguageTerms).toEqual(
-      [...severeLanguageTerms].sort((left, right) =>
-        left.localeCompare(right),
-      ),
+      [...severeLanguageTerms].sort((left, right) => left.localeCompare(right)),
     );
-    expect(
-      severeLanguageTerms.every((term) => /^[a-z]+$/u.test(term)),
-    ).toBe(true);
+    expect(severeLanguageTerms.every((term) => /^[a-z]+$/u.test(term))).toBe(
+      true,
+    );
   });
 });

--- a/tests/unit/severe-language-policy.test.ts
+++ b/tests/unit/severe-language-policy.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  containsDisallowedKitLanguage,
+  severeLanguageTerms,
+} from "@/features/kits/severe-language-policy.mjs";
+
+describe("Kit severe-language policy", () => {
+  test.each(["nigger", "kike", "faggot", "tranny", "retard"])(
+    "blocks representative severe term %s",
+    (term) => {
+      expect(containsDisallowedKitLanguage(`A ${term} Kit`)).toBe(true);
+    },
+  );
+
+  test.each([
+    "NIGGER",
+    "n!i!g!g!e!r",
+    "n i g g e r",
+    "n1gg3r",
+    "fa\u0301ggot",
+  ])("blocks normalized disguise %s", (text) => {
+    expect(containsDisallowedKitLanguage(text)).toBe(true);
+  });
+
+  test.each([
+    "Damn Good Stories",
+    "Badass Character Kit",
+    "This shit actually works.",
+    "Assassin toolkit",
+    "Classic adult roleplay tools.",
+    "Retardant material reference",
+  ])("allows intentionally permitted text %s", (text) => {
+    expect(containsDisallowedKitLanguage(text)).toBe(false);
+  });
+
+  test("keeps the policy explicit, unique, and normalized", () => {
+    expect(severeLanguageTerms.length).toBeGreaterThan(0);
+    expect(new Set(severeLanguageTerms).size).toBe(severeLanguageTerms.length);
+    expect(severeLanguageTerms).toEqual(
+      [...severeLanguageTerms].sort((left, right) =>
+        left.localeCompare(right),
+      ),
+    );
+    expect(
+      severeLanguageTerms.every((term) => /^[a-z]+$/u.test(term)),
+    ).toBe(true);
+  });
+});

--- a/tests/unit/triage-issue.test.ts
+++ b/tests/unit/triage-issue.test.ts
@@ -13,6 +13,7 @@ import {
 import {
   assertKitSubmissionEligible,
   buildKitValidationComment,
+  kitTriageOutputs,
   parseKitIssueFields,
   resolveKitSubmissionEvent,
   synchronizeKitSubmission,
@@ -69,13 +70,45 @@ test("parses Kit manifests and builds a stable success comment", () => {
     buildKitValidationComment({
       valid: true,
       manifest: null,
-      labels: ["needs-maintainer-review"],
+      labels: ["kit-publication-ready"],
       errors: [],
       warnings: [],
     }),
-  ).toContain(
-    "Automated validation now passes. This Kit is ready for maintainer review.",
-  );
+  ).toContain("Automated validation passes. Tavernary is publishing this Kit.");
+});
+
+test("emits publication outputs only for a valid Kit", () => {
+  const manifest = {
+    operation: "create" as const,
+    kit_id: null,
+    title: "Story Kit",
+    description: "A complete storytelling stack.",
+    project_ids: ["frontend", "memory", "writer"],
+  };
+  expect(
+    kitTriageOutputs(
+      {
+        valid: true,
+        manifest,
+        labels: ["kit-publication-ready"],
+        errors: [],
+        warnings: [],
+      },
+      { number: 241 },
+    ),
+  ).toEqual({ publish: "true", issue_number: "241" });
+  expect(
+    kitTriageOutputs(
+      {
+        valid: false,
+        manifest: null,
+        labels: ["needs-information"],
+        errors: ["Title contains language Tavernary doesn't allow."],
+        warnings: [],
+      },
+      { number: 241 },
+    ),
+  ).toEqual({ publish: "false", issue_number: "241" });
 });
 
 test("unwraps GitHub's rendered JSON fence from a Kit manifest", () => {
@@ -785,7 +818,11 @@ test("Kit synchronization tolerates a concurrently removed owned label", async (
         number: 132,
         title: "[Kit submission]: Example",
         state: "open",
-        labels: ["issue-admitted", "needs-information"],
+        labels: [
+          "issue-admitted",
+          "needs-information",
+          "needs-maintainer-review",
+        ],
       };
     }
     if (path.endsWith("/labels/needs-information")) {
@@ -806,7 +843,7 @@ test("Kit synchronization tolerates a concurrently removed owned label", async (
         manifest: null,
         errors: [],
         warnings: [],
-        labels: ["needs-maintainer-review"],
+        labels: ["kit-publication-ready"],
       },
       request,
     ),
@@ -815,8 +852,12 @@ test("Kit synchronization tolerates a concurrently removed owned label", async (
     "/repos/Tavernary/Tavernary/issues/132/labels",
     {
       method: "POST",
-      body: JSON.stringify({ labels: ["needs-maintainer-review"] }),
+      body: JSON.stringify({ labels: ["kit-publication-ready"] }),
     },
+  );
+  expect(request).toHaveBeenCalledWith(
+    "/repos/Tavernary/Tavernary/issues/132/labels/needs-maintainer-review",
+    { method: "DELETE" },
   );
 });
 

--- a/tests/unit/validate-kit-submission.test.ts
+++ b/tests/unit/validate-kit-submission.test.ts
@@ -41,7 +41,7 @@ function validate(
 test("accepts valid create and matching-author edit manifests", () => {
   expect(validate()).toMatchObject({
     valid: true,
-    labels: ["needs-maintainer-review"],
+    labels: ["kit-publication-ready"],
     errors: [],
   });
   expect(
@@ -54,7 +54,7 @@ test("accepts valid create and matching-author edit manifests", () => {
         project_ids: ["frontend", "memory", "writer"],
       }),
     ),
-  ).toMatchObject({ valid: true, labels: ["needs-maintainer-review"] });
+  ).toMatchObject({ valid: true, labels: ["kit-publication-ready"] });
 });
 
 test("rejects malformed manifests and blocked actors", () => {
@@ -101,9 +101,9 @@ test("blocks exact project sets and warns on near duplicates", () => {
   );
   expect(near).toMatchObject({
     valid: true,
-    labels: ["needs-maintainer-review", "duplicate-candidate"],
+    labels: ["kit-publication-ready", "duplicate-candidate"],
     warnings: expect.arrayContaining([
-      expect.stringContaining("near-duplicate"),
+      "This composition is a near-duplicate of an existing Kit.",
     ]),
   });
 });
@@ -126,7 +126,7 @@ test("allows an identical create retry from its already-published source issue",
 
   expect(retry).toMatchObject({
     valid: true,
-    labels: ["needs-maintainer-review"],
+    labels: ["kit-publication-ready"],
     errors: [],
   });
 });
@@ -178,3 +178,48 @@ test("rejects edits to a withdrawn Kit", () => {
     errors: expect.arrayContaining(["A withdrawn Kit cannot be edited."]),
   });
 });
+
+test("rechecks severe language from the GitHub manifest", () => {
+  expect(
+    validate(
+      JSON.stringify({
+        ...JSON.parse(create),
+        title: "N1gg3r Story Kit",
+      }),
+    ),
+  ).toMatchObject({
+    valid: false,
+    labels: ["needs-information"],
+    errors: expect.arrayContaining([
+      "Title contains language Tavernary doesn't allow.",
+    ]),
+  });
+  expect(
+    validate(
+      JSON.stringify({
+        ...JSON.parse(create),
+        description: "A f.a.g.g.o.t story stack.",
+      }),
+    ),
+  ).toMatchObject({
+    valid: false,
+    errors: expect.arrayContaining([
+      "Description contains language Tavernary doesn't allow.",
+    ]),
+  });
+});
+
+test.each(["Damn Good Kit", "Badass Kit", "This shit works."])(
+  "keeps common profanity valid on GitHub: %s",
+  (text) => {
+    expect(
+      validate(
+        JSON.stringify({
+          ...JSON.parse(create),
+          title: text,
+          description: text,
+        }),
+      ).valid,
+    ).toBe(true);
+  },
+);

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -605,7 +605,7 @@ test("retries frontend dependencies from read-only catalog changes", async () =>
   expect(source).not.toMatch(/\bgit (?:add|commit|push)\b/);
 });
 
-test("keeps Kit triage read-only and dependency-free", async () => {
+test("keeps Kit triage registry-read-only and dependency-free", async () => {
   const document = await workflow("triage-kit-submission");
   const source = await readFile(
     resolve(workflowDirectory, "triage-kit-submission.yml"),
@@ -620,6 +620,7 @@ test("keeps Kit triage read-only and dependency-free", async () => {
   expect(document.permissions).toEqual({
     contents: "read",
     issues: "write",
+    actions: "write",
   });
   expect(document.concurrency["cancel-in-progress"]).toBe(true);
   expect(source).toContain("github.event_name == 'workflow_dispatch'");


### PR DESCRIPTION
## Summary\n\n- derive the Kits switcher assertion from generated catalog data\n- keep the browser test valid as published Kits grow\n\n## Verification\n\n- npm.cmd run build\n- PORT=3100 npm.cmd run test:e2e -- tests/e2e/kits-empty.spec.ts (48 passed)