### PR TITLE
fix: configure submission rebase identity

### DIFF
--- a/.github/workflows/generate-project-submission.yml
+++ b/.github/workflows/generate-project-submission.yml
@@ -110,6 +110,8 @@ jobs:
         run: |
           set -euo pipefail
           git fetch origin main
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           if [[ -n "$PR_NUMBER" && -n "$REMOTE_SHA" && -n "$MARKER_SHA" ]]; then
             git fetch origin "refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"
             git checkout -B "$BRANCH" "origin/$BRANCH"
@@ -176,8 +178,6 @@ jobs:
             echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git commit -m "feat(catalog): propose project from issue #${ISSUE_NUMBER}"
           head_sha="$(git rev-parse HEAD)"
           if [[ -z "$REMOTE_SHA" ]]; then

--- a/docs/superpowers/specs/2026-07-26-preset-card-metadata-design.md
+++ b/docs/superpowers/specs/2026-07-26-preset-card-metadata-design.md
@@ -1,0 +1,74 @@
+# Preset Card Metadata Design
+
+## Goal
+
+Remove low-value absence labels from curated external System Preset cards while
+preserving real preset facts and warnings that require user attention.
+
+## Problem
+
+External presets do not necessarily have GitHub repository evidence. The
+current card treats missing repository facts as visible metadata:
+
+- `Manual source`
+- `Activity unavailable`
+- `Release unavailable`
+- `Popularity unavailable`
+- `Repository size unavailable`
+
+These labels dominate the card despite describing either implementation
+provenance or fields that do not apply. Version information may also already be
+visible in the preset header, making the release fallback redundant.
+
+## Display Rules
+
+System Preset cards use a type-aware metadata policy:
+
+1. Show known preset facts:
+   - version;
+   - publication date; and
+   - artifact file size.
+2. Omit a preset fact when its value is unknown. Do not replace it with an
+   unavailable-state label.
+3. Do not show repository activity, popularity, or repository size absence on
+   presets without repository evidence.
+4. Do not show `Manual source`; manual curation is an internal provenance fact,
+   not a user-facing warning.
+5. Preserve actionable state:
+   - provisional or pending details;
+   - stale source information;
+   - license status, including a missing license.
+6. Leave Frontend and Extension card behavior unchanged.
+
+A future explicit broken-source state would also be actionable, but this change
+does not introduce a new catalog or source-status state.
+
+For Pura's Director v15.0, the resulting card keeps `v15.0`, its title,
+summary, tags, and `Missing` license state. The five-item fallback line is not
+rendered.
+
+## Accessibility
+
+Hidden unavailable fields must also be omitted from the card's accessible
+description. Known facts and actionable warnings remain available through the
+existing visible text, accessible description, and tooltip behavior.
+
+## Implementation Boundary
+
+The change belongs in the project-card presentation logic. Registry records and
+the generated catalog retain their existing null values and source-status
+semantics; the card decides which facts are useful to display.
+
+## Verification
+
+Focused component tests will prove that:
+
+- curated manual presets do not render the five low-value labels;
+- known preset publication and file-size facts still render;
+- version and license status still render;
+- actionable pending and stale states remain visible;
+- removed labels are absent from the accessible description; and
+- representative Frontend and Extension cards retain their existing metadata.
+
+The normal catalog checks and browser card tests will guard layout and
+interaction behavior.

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -659,9 +659,9 @@ test("generates submission PRs with scoped permissions and manual recovery", asy
   expect(source).toContain(
     'git config user.email "41898282+github-actions[bot]@users.noreply.github.com"',
   );
-  expect(source.indexOf('git config user.name "github-actions[bot]"')).toBeLessThan(
-    source.indexOf("git rebase origin/main"),
-  );
+  expect(
+    source.indexOf('git config user.name "github-actions[bot]"'),
+  ).toBeLessThan(source.indexOf("git rebase origin/main"));
   expect(source).toContain("previous-generated-paths.txt");
   expect(source).toContain("Refusing unsafe generated path");
   expect(source).toContain("labels.includes('issue-admitted')");

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -655,6 +655,13 @@ test("generates submission PRs with scoped permissions and manual recovery", asy
   );
   expect(source).toContain("git push --force-with-lease=");
   expect(source).toContain("git rebase origin/main");
+  expect(source).toContain('git config user.name "github-actions[bot]"');
+  expect(source).toContain(
+    'git config user.email "41898282+github-actions[bot]@users.noreply.github.com"',
+  );
+  expect(source.indexOf('git config user.name "github-actions[bot]"')).toBeLessThan(
+    source.indexOf("git rebase origin/main"),
+  );
   expect(source).toContain("previous-generated-paths.txt");
   expect(source).toContain("Refusing unsafe generated path");
   expect(source).toContain("labels.includes('issue-admitted')");


### PR DESCRIPTION
## Summary\n\n- configure the GitHub Actions bot identity before rebasing generated submission branches\n- add a regression assertion for the ordering\n\n## Verification\n\n- npx.cmd vitest run tests/unit/workflows.test.ts