### PR TITLE
fix: classify CrossRoads as a SillyTavern extension

### DIFF
--- a/data/registry/projects/jeppsterrr-crossroads.json
+++ b/data/registry/projects/jeppsterrr-crossroads.json
@@ -2,15 +2,15 @@
   "schema_version": 5,
   "id": "jeppsterrr-crossroads",
   "name": "CrossRoads",
-  "kind": "frontend",
-  "summary": "CrossRoads is a frontend that brings CYOA-style branching choices to roleplay conversations. It provides selectable story options that let users guide the narrative direction during interactive sessions.",
+  "kind": "extension",
+  "summary": "CrossRoads is a SillyTavern extension that generates CYOA-style branching choices from chat messages, letting users choose the story's next direction.",
   "metadata_status": "curated",
   "source": {
     "type": "github",
     "repository": "jeppsterrr/CrossRoads",
     "repository_id": 1310212816
   },
-  "frontends": ["crossroads"],
+  "frontends": ["sillytavern"],
   "primary_function": "interface-workflow",
   "capabilities": ["prompt-engineering"],
   "cataloged_at": "2026-07-26T19:32:33.792Z",

--- a/data/vocabularies/frontends.json
+++ b/data/vocabularies/frontends.json
@@ -6,11 +6,6 @@
       "description": "Works with the Aikobots roleplay frontend."
     },
     {
-      "id": "crossroads",
-      "label": "CrossRoads",
-      "description": "Works with the CrossRoads roleplay frontend."
-    },
-    {
       "id": "lumiverse",
       "label": "Lumiverse",
       "description": "Works with the Lumiverse roleplay frontend."


### PR DESCRIPTION
Closes #47\n\nCorrects CrossRoads from a standalone frontend to a SillyTavern extension, updates its supported frontend, and removes the obsolete frontend vocabulary entry.\n\nValidation: npm run check:content