### PR TITLE
fix(submissions): accept retryable generation

### DIFF
--- a/.github/workflows/generate-project-owner-request.yml
+++ b/.github/workflows/generate-project-owner-request.yml
@@ -65,7 +65,8 @@ jobs:
                 !labels.includes('issue-admitted') ||
                 !labels.includes('project-owner-request') ||
                 (!labels.includes('needs-maintainer-review') &&
-                 !labels.includes('submission-pr-open'))) {
+                 !labels.includes('submission-pr-open') &&
+                 !labels.includes('submission-retryable'))) {
               throw new Error('Owner request issue is no longer admitted.');
             }
           " "$issue_path"

--- a/.github/workflows/generate-project-submission.yml
+++ b/.github/workflows/generate-project-submission.yml
@@ -63,7 +63,9 @@ jobs:
             const labels = issue.labels.map((label) => label.name);
             if (issue.state !== 'open' || !labels.includes('issue-admitted') ||
                 !labels.includes('project-submission') ||
-                (!labels.includes('needs-maintainer-review') && !labels.includes('submission-pr-open'))) {
+                (!labels.includes('needs-maintainer-review') &&
+                 !labels.includes('submission-pr-open') &&
+                 !labels.includes('submission-retryable'))) {
               throw new Error('Submission issue is no longer admitted.');
             }
           " "$issue_path"
@@ -166,7 +168,9 @@ jobs:
             const labels = issue.labels.map((label) => label.name);
             if (issue.state !== 'open' || !labels.includes('issue-admitted') ||
                 !labels.includes('project-submission') ||
-                (!labels.includes('needs-maintainer-review') && !labels.includes('submission-pr-open'))) {
+                (!labels.includes('needs-maintainer-review') &&
+                 !labels.includes('submission-pr-open') &&
+                 !labels.includes('submission-retryable'))) {
               throw new Error('Submission issue is no longer admitted.');
             }
             const plan = planClassificationReviewNotice({
@@ -387,7 +391,9 @@ jobs:
             const labels = issue.labels.map((label) => label.name);
             if (issue.state !== 'open' || !labels.includes('issue-admitted') ||
                 !labels.includes('project-submission') ||
-                (!labels.includes('needs-maintainer-review') && !labels.includes('submission-pr-open'))) {
+                (!labels.includes('needs-maintainer-review') &&
+                 !labels.includes('submission-pr-open') &&
+                 !labels.includes('submission-retryable'))) {
               throw new Error('Submission issue is no longer admitted.');
             }
           " "${RUNNER_TEMP}/project-submission-issue.json"
@@ -405,7 +411,9 @@ jobs:
             const labels = issue.labels.map((label) => label.name);
             if (issue.state !== 'open' || !labels.includes('issue-admitted') ||
                 !labels.includes('project-submission') ||
-                (!labels.includes('needs-maintainer-review') && !labels.includes('submission-pr-open'))) {
+                (!labels.includes('needs-maintainer-review') &&
+                 !labels.includes('submission-pr-open') &&
+                 !labels.includes('submission-retryable'))) {
               throw new Error('Submission issue is no longer admitted.');
             }
             const owned = new Set([

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -862,6 +862,9 @@ test("generates submission PRs with scoped permissions and manual recovery", asy
     source.indexOf("Reject conflicting open submission paths"),
   ).toBeLessThan(source.indexOf("git push origin"));
   expect(source).toContain("labels.includes('issue-admitted')");
+  expect(
+    source.match(/labels\.includes\('submission-retryable'\)/gu)?.length,
+  ).toBeGreaterThanOrEqual(4);
   expect(source).toContain("Refresh and revalidate issue before PR mutation");
   expect(source).toContain("Refresh and revalidate issue before labeling");
   expect(
@@ -1048,6 +1051,7 @@ test("generates owner review PRs with operation-scoped guarded writes", async ()
   expect(source).toContain("git clean -fX -- src/generated/catalog.json");
   expect(source).not.toContain("git checkout -- src/generated/catalog.json");
   expect(source).toContain("submission-pr-open");
+  expect(source).toMatch(/labels\.includes\(["']submission-retryable["']\)/u);
   expect(source).toContain("gh label create submission-pr-open");
   expect(source).toContain("Owner generation changed unsafe paths");
   expect(source.indexOf("Owner generation changed unsafe paths")).toBeLessThan(


### PR DESCRIPTION
## Summary

- allow submission generation to consume `submission-retryable` at every pre-mutation recheck
- allow owner-request generation to consume the same reconciled retry state
- lock the recovery round trip with workflow regression coverage

## Live reproduction

Issue #167 was correctly reconciled to `submission-retryable`, but a subsequent generation dispatch stopped in `Inspect existing generated state` with `Submission issue is no longer admitted.`

## Verification

- `npm run check`
- 190 test files passed
- 1,928 tests passed

Refs #167
