### PR TITLE
fix(submissions): retry reconciled drafts

### DIFF
--- a/scripts/submissions/generate-project-submission.mjs
+++ b/scripts/submissions/generate-project-submission.mjs
@@ -200,7 +200,8 @@ function assertGenerationIssue(issue, issueNumber) {
   const labels = issueLabels(issue);
   if (
     !labels.includes("needs-maintainer-review") &&
-    !labels.includes("submission-pr-open")
+    !labels.includes("submission-pr-open") &&
+    !labels.includes("submission-retryable")
   ) {
     throw new Error("Submission issue is no longer admitted for generation.");
   }
@@ -329,7 +330,8 @@ export async function prepareProjectSubmissionDraft({
   const parsed = parseProjectSubmissionIssue(issue.body ?? "", {
     allowLegacyV3:
       issueLabels(issue).includes("needs-maintainer-review") ||
-      issueLabels(issue).includes("submission-pr-open"),
+      issueLabels(issue).includes("submission-pr-open") ||
+      issueLabels(issue).includes("submission-retryable"),
   });
   if (!parsed.valid) throw new Error(parsed.errors.join(" "));
   const request = sourceClients.request ?? defaultGithubRequest;

--- a/tests/unit/generate-project-submission-cli.test.ts
+++ b/tests/unit/generate-project-submission-cli.test.ts
@@ -168,7 +168,7 @@ test("writes only declared repository files and the external report", async () =
       fetchIssue: async () => ({
         number: 123,
         state: "open",
-        labels: [{ name: "needs-maintainer-review" }],
+        labels: [{ name: "submission-retryable" }],
         body: "fixture",
       }),
       sourceClients: {
@@ -276,7 +276,7 @@ test("recovers an admitted v3 owner request without leaking manual copy to enric
     issue: {
       number: 128,
       state: "open",
-      labels: [{ name: "needs-maintainer-review" }],
+      labels: [{ name: "submission-retryable" }],
       user: { id: 11, login: "owner" },
       author_association: "NONE",
       body: [


### PR DESCRIPTION
## Summary

- allow the submission generator runtime to consume `submission-retryable`
- preserve legacy admitted-v3 recovery for reconciled issues
- cover both CLI admission and legacy draft parsing directly

## Live reproduction

After #171 fixed the workflow shell guard, issue #167 reached `generate-project-submission.mjs` and stopped at its duplicate admission predicate with `Submission issue is no longer admitted for generation.`

## Verification

- `npm run check`
- 190 test files passed
- 1,928 tests passed

Refs #167
