### PR TITLE
Fix OpenAI enrichment schema compatibility

### DIFF
--- a/scripts/catalog/enrichment-provider.mjs
+++ b/scripts/catalog/enrichment-provider.mjs
@@ -4,11 +4,6 @@ import {
   CATALOG_COPY_RESULT_VALUES,
   catalogCopyInstructions,
 } from "./catalog-copy-contract.mjs";
-import {
-  GENERATED_SUMMARY_MAX_LENGTH,
-  GENERATED_SUMMARY_MIN_LENGTH,
-} from "./generated-summary-contract.mjs";
-
 export const ENRICHMENT_TIMEOUT_MS = 120_000;
 
 const systemPrompt = `${catalogCopyInstructions()}
@@ -135,8 +130,7 @@ function responseSchema(input) {
     type: "array",
     minItems: 1,
     maxItems: 8,
-    uniqueItems: true,
-    items: { type: "string", minLength: 1, maxLength: 160 },
+    items: { type: "string" },
   };
   const required = [
     ...requestedFields,
@@ -150,11 +144,7 @@ function responseSchema(input) {
       additionalProperties: false,
       required: ["value", "evidence"],
       properties: {
-        value: {
-          type: "string",
-          minLength: GENERATED_SUMMARY_MIN_LENGTH,
-          maxLength: GENERATED_SUMMARY_MAX_LENGTH,
-        },
+        value: { type: "string" },
         evidence: evidenceSchema,
       },
     };
@@ -164,7 +154,6 @@ function responseSchema(input) {
     };
     properties.change_reasons = {
       type: "array",
-      uniqueItems: true,
       items: {
         type: "string",
         enum: CATALOG_COPY_CHANGE_REASON_VALUES,
@@ -179,7 +168,6 @@ function responseSchema(input) {
     properties.tags = {
       type: "array",
       maxItems: 6,
-      uniqueItems: true,
       items: {
         type: "object",
         additionalProperties: false,

--- a/tests/unit/enrichment-provider.test.ts
+++ b/tests/unit/enrichment-provider.test.ts
@@ -197,10 +197,16 @@ test("sends the exact model, hardened prompt, requested fields, and strict schem
     type: "object",
     additionalProperties: false,
     properties: {
-      value: { type: "string", minLength: 120, maxLength: 220 },
       evidence: { type: "array", minItems: 1 },
     },
   });
+  expect(schema.properties.summary.properties.value).toEqual({
+    type: "string",
+  });
+  expect(schema.properties.summary.properties.evidence.items).toEqual({
+    type: "string",
+  });
+  expect(JSON.stringify(schema)).not.toContain('"uniqueItems"');
   expect(schema.properties.tags.items.properties.id.enum).toEqual([
     "automate-roleplay-workflows",
   ]);


### PR DESCRIPTION
Removes unsupported strict JSON Schema keywords from the provider-facing enrichment schema while retaining Tavernary prompt guidance and local validation. Verified with the full npm run check gate.