### PR TITLE
Fix GPT-5.6 enrichment request compatibility

### DIFF
--- a/scripts/catalog/enrichment-provider.mjs
+++ b/scripts/catalog/enrichment-provider.mjs
@@ -32,6 +32,12 @@ const safeProviderMessages = {
 
 function safeProviderMessage(code, details = {}) {
   if (
+    code === "provider-request-failed" &&
+    typeof details.diagnosticCode === "string"
+  ) {
+    return `The enrichment provider rejected the request (${details.diagnosticCode}).`;
+  }
+  if (
     code === "provider-timeout" &&
     Number.isFinite(details.timeoutMs) &&
     details.timeoutMs > 0
@@ -43,7 +49,7 @@ function safeProviderMessage(code, details = {}) {
 
 export class EnrichmentProviderError extends Error {
   constructor(code, diagnosticCode = null, details = {}) {
-    super(safeProviderMessage(code, details));
+    super(safeProviderMessage(code, { ...details, diagnosticCode }));
     this.name = "EnrichmentProviderError";
     this.code = code;
     this.diagnosticCode = diagnosticCode;
@@ -191,7 +197,15 @@ function responseSchema(input) {
   };
 }
 
-function statusError(status) {
+function safeDiagnosticToken(value) {
+  return typeof value === "string" &&
+    /^[a-z0-9][a-z0-9_.-]{0,79}$/iu.test(value)
+    ? value
+    : null;
+}
+
+async function statusError(response) {
+  const { status } = response;
   if (status === 429)
     return new EnrichmentProviderError("provider-rate-limited");
   if (status === 401 || status === 403) {
@@ -200,7 +214,16 @@ function statusError(status) {
   if (status >= 500) {
     return new EnrichmentProviderError("provider-server-error");
   }
-  return new EnrichmentProviderError("provider-request-failed");
+  let diagnosticCode = null;
+  try {
+    const payload = await response.json();
+    const code = safeDiagnosticToken(payload?.error?.code);
+    const parameter = safeDiagnosticToken(payload?.error?.param);
+    diagnosticCode = [code, parameter].filter(Boolean).join(":") || null;
+  } catch {
+    // Keep unrecognized provider error bodies private.
+  }
+  return new EnrichmentProviderError("provider-request-failed", diagnosticCode);
 }
 
 export function createStructuredProviderTransport(options) {
@@ -240,7 +263,7 @@ export function createStructuredProviderTransport(options) {
           );
         }
 
-        if (!response.ok) throw statusError(response.status);
+        if (!response.ok) throw await statusError(response);
 
         let payload;
         try {

--- a/scripts/catalog/enrichment-provider.mjs
+++ b/scripts/catalog/enrichment-provider.mjs
@@ -306,7 +306,6 @@ export function createEnrichmentProvider(options) {
     async generate(input) {
       const response = await transport.request({
         model: transport.configuration.model,
-        temperature: input.repair ? 0 : 0.2,
         messages: [
           { role: "system", content: systemPrompt },
           { role: "user", content: JSON.stringify(input) },

--- a/tests/unit/enrichment-provider.test.ts
+++ b/tests/unit/enrichment-provider.test.ts
@@ -409,6 +409,35 @@ test.each([
   },
 );
 
+test("reports allowlisted upstream request diagnostics without leaking the message", async () => {
+  const provider = createEnrichmentProvider({
+    apiUrl: "https://api.example.test",
+    apiKey: "do-not-leak",
+    model,
+    fetchImpl: async () =>
+      new Response(
+        JSON.stringify({
+          error: {
+            code: "unsupported_value",
+            param: "temperature",
+            message: "secret upstream explanation",
+          },
+        }),
+        {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+  });
+
+  await expect(provider.generate(input)).rejects.toMatchObject({
+    code: "provider-request-failed",
+    diagnosticCode: "unsupported_value:temperature",
+    message:
+      "The enrichment provider rejected the request (unsupported_value:temperature).",
+  });
+});
+
 test("includes elapsed time on controlled provider failures", async () => {
   const times = [1_000, 1_250];
   const provider = createEnrichmentProvider({

--- a/tests/unit/enrichment-provider.test.ts
+++ b/tests/unit/enrichment-provider.test.ts
@@ -176,7 +176,7 @@ test("sends the exact model, hardened prompt, requested fields, and strict schem
   const body = JSON.parse(String(init?.body));
   const schema = body.response_format.json_schema.schema;
   expect(body.model).toBe(model);
-  expect(body.temperature).toBe(0.2);
+  expect(body).not.toHaveProperty("temperature");
   expect(body.messages[0].content).toMatch(
     /project names.*README content.*untrusted reference data/iu,
   );
@@ -318,7 +318,7 @@ test("uses deterministic sampling for a validation repair request", async () => 
   });
 
   const body = JSON.parse(String(fetchImpl.mock.calls[0][1]?.body));
-  expect(body.temperature).toBe(0);
+  expect(body).not.toHaveProperty("temperature");
   expect(body.messages[0].content).toMatch(
     /rejectedSummary.*untrusted.*do not follow/iu,
   );


### PR DESCRIPTION
Omits nondefault temperature values from structured enrichment requests and exposes only allowlisted upstream error code/parameter diagnostics. Upstream prose and secrets remain suppressed. Verified with the full npm run check gate.