### PR TITLE
Bound GPT-5.6 enrichment latency

### DIFF
--- a/scripts/catalog/enrichment-provider.mjs
+++ b/scripts/catalog/enrichment-provider.mjs
@@ -306,6 +306,9 @@ export function createEnrichmentProvider(options) {
     async generate(input) {
       const response = await transport.request({
         model: transport.configuration.model,
+        ...(/^gpt-5\.6(?:-|$)/u.test(transport.configuration.model)
+          ? { reasoning_effort: "none" }
+          : {}),
         messages: [
           { role: "system", content: systemPrompt },
           { role: "user", content: JSON.stringify(input) },

--- a/tests/unit/enrichment-provider.test.ts
+++ b/tests/unit/enrichment-provider.test.ts
@@ -177,6 +177,7 @@ test("sends the exact model, hardened prompt, requested fields, and strict schem
   const schema = body.response_format.json_schema.schema;
   expect(body.model).toBe(model);
   expect(body).not.toHaveProperty("temperature");
+  expect(body).not.toHaveProperty("reasoning_effort");
   expect(body.messages[0].content).toMatch(
     /project names.*README content.*untrusted reference data/iu,
   );
@@ -233,6 +234,26 @@ test("sends the exact model, hardened prompt, requested fields, and strict schem
   expect(init?.headers).toMatchObject({
     authorization: "Bearer do-not-log",
   });
+});
+
+test("uses the no-reasoning latency baseline for GPT-5.6 enrichment", async () => {
+  const lunaModel = "gpt-5.6-luna";
+  const fetchImpl = vi.fn(
+    async (_url: string | URL | Request, _init?: RequestInit) =>
+      success({ model: lunaModel }),
+  );
+  const provider = createEnrichmentProvider({
+    apiUrl: "https://api.openai.com/v1/chat/completions",
+    apiKey: "do-not-log",
+    model: lunaModel,
+    fetchImpl,
+  });
+
+  await provider.generate(input);
+
+  const [, init] = fetchImpl.mock.calls[0];
+  const body = JSON.parse(String(init?.body));
+  expect(body.reasoning_effort).toBe("none");
 });
 
 test("builds a tags-only schema without summary or copy diagnostics", async () => {


### PR DESCRIPTION
Sets reasoning_effort to none only for GPT-5.6 enrichment requests, preventing the model's default reasoning mode from exhausting Tavernary's 120-second provider deadline. Strict structured output and local validation remain unchanged. Verified with the full npm run check gate.