### PR TITLE
Publish TavernKeeper V2 scan targets

### DIFF
--- a/config/tavernkeeper-contract.json
+++ b/config/tavernkeeper-contract.json
@@ -1,4 +1,4 @@
 {
-  "target_manifest_schema_version": 1,
+  "target_manifest_schema_version": 2,
   "report_index_schema_version": 2
 }


### PR DESCRIPTION
Advances the public Tavernary target manifest from schema V1 to V2 after the V2 report consumer and TavernKeeper V2 producer were deployed and verified. Verification: 49 focused tests passed; full npm run check passed (208 files, 2,279 tests, build and static export).