### PR TITLE
Add temporary OSV diagnostic

### DIFF
--- a/.github/workflows/diagnose-osv.yml
+++ b/.github/workflows/diagnose-osv.yml
@@ -1,0 +1,62 @@
+name: "Diagnostic: Reproduce OSV-Scanner failure"
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  diagnose:
+    if: ${{ github.actor_id == 2625904 }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch exact public Recursion target
+        shell: bash
+        run: |
+          set -euo pipefail
+          git init "$RUNNER_TEMP/recursion"
+          git -C "$RUNNER_TEMP/recursion" remote add origin https://github.com/MentallyQuill/Recursion.git
+          git -C "$RUNNER_TEMP/recursion" fetch --depth=1 origin 1bce1fa73fe6c0fe8e767c773a832b94bb336720
+          git -C "$RUNNER_TEMP/recursion" checkout --detach FETCH_HEAD
+          test "$(git -C "$RUNNER_TEMP/recursion" rev-parse HEAD)" = 1bce1fa73fe6c0fe8e767c773a832b94bb336720
+      - name: Install checksum-pinned OSV-Scanner
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl --fail --silent --show-error --location --max-redirs 0 \
+            --output "$RUNNER_TEMP/osv-scanner" \
+            https://github.com/google/osv-scanner/releases/download/v2.4.0/osv-scanner_linux_amd64
+          echo "15314940c10d26af9c6649f150b8a47c1262e8fc7e17b1d1029b0e479e8ed8a0  $RUNNER_TEMP/osv-scanner" | sha256sum --check --strict
+          chmod 0755 "$RUNNER_TEMP/osv-scanner"
+      - name: Run TavernKeeper's exact OSV command
+        shell: bash
+        run: |
+          set -euo pipefail
+          printf '# TavernKeeper intentionally ignores target configuration.\n' > "$RUNNER_TEMP/trusted-empty-config.toml"
+          set +e
+          env -i \
+            PATH="$PATH" \
+            TMP="$RUNNER_TEMP" \
+            NO_COLOR=1 \
+            "$RUNNER_TEMP/osv-scanner" scan source \
+              --format=json \
+              --verbosity=error \
+              --no-resolve \
+              --config="$RUNNER_TEMP/trusted-empty-config.toml" \
+              --lockfile="$RUNNER_TEMP/recursion/package-lock.json" \
+              > "$RUNNER_TEMP/osv-stdout.json" \
+              2> "$RUNNER_TEMP/osv-stderr.txt"
+          exit_code=$?
+          set -e
+          echo "OSV_EXIT_CODE=$exit_code"
+          echo "OSV_STDOUT_BYTES=$(wc -c < "$RUNNER_TEMP/osv-stdout.json")"
+          echo "OSV_STDERR_BEGIN"
+          sed -n '1,120p' "$RUNNER_TEMP/osv-stderr.txt"
+          echo "OSV_STDERR_END"
+          {
+            echo "### OSV diagnostic"
+            echo
+            echo "- Exit code: \`$exit_code\`"
+            echo "- Stdout bytes: \`$(wc -c < "$RUNNER_TEMP/osv-stdout.json")\`"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## What changed

- adds one staff-only, secret-free workflow that reproduces TavernKeeper's pinned OSV-Scanner 2.4.0 command against Recursion's exact scanned SHA
- verifies the downloaded binary checksum before execution
- records only the exit code, output byte count, and public-scanner stderr needed to diagnose the closed-safe failure

## Why

Two live TavernKeeper attempts returned the same OSV general-error result before model review. The local Windows host cannot execute the pinned Linux binary, so a short-lived GitHub-hosted Linux diagnostic is needed to identify the root cause without weakening scan behavior.

## Validation

- Prettier check passed for the workflow YAML
- no secrets or write permissions are used
- workflow is restricted to the repository owner's numeric actor ID

This workflow will be removed immediately after the diagnostic run.
