### PR TITLE
Follow OSV release redirect

### DIFF
--- a/.github/workflows/diagnose-osv.yml
+++ b/.github/workflows/diagnose-osv.yml
@@ -24,7 +24,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          curl --fail --silent --show-error --location --max-redirs 0 \
+          curl --fail --silent --show-error --location --max-redirs 5 \
             --output "$RUNNER_TEMP/osv-scanner" \
             https://github.com/google/osv-scanner/releases/download/v2.4.0/osv-scanner_linux_amd64
           echo "15314940c10d26af9c6649f150b8a47c1262e8fc7e17b1d1029b0e479e8ed8a0  $RUNNER_TEMP/osv-scanner" | sha256sum --check --strict


### PR DESCRIPTION
## What changed

- allows the temporary diagnostic downloader to follow at most five redirects to GitHub's release-asset host

## Why

The initial diagnostic stopped at GitHub's expected release-asset redirect before OSV could run. TavernKeeper's production scanner installer already follows this redirect; the temporary reproduction must do the same.

## Validation

- Prettier check passed for the workflow YAML
- the redirect remains bounded

This workflow will be removed immediately after the diagnostic run.
