### PR TITLE
Fix Luna TavernKeeper synthesis compatibility

### DIFF
--- a/scripts/security/tavernkeeper-synthesis-provider.mjs
+++ b/scripts/security/tavernkeeper-synthesis-provider.mjs
@@ -71,7 +71,6 @@ export function createTavernKeeperSynthesisProvider(options) {
     async generate(input) {
       return transport.request({
         model: transport.configuration.model,
-        temperature: 0,
         messages: [
           { role: "system", content: tavernKeeperSynthesisInstructions() },
           { role: "user", content: JSON.stringify(synthesisInput(input)) },

--- a/tests/unit/tavernkeeper-synthesis.test.ts
+++ b/tests/unit/tavernkeeper-synthesis.test.ts
@@ -263,7 +263,7 @@ describe("strict Luna synthesis", () => {
 
     await provider.generate({ report });
 
-    expect(requestBody.temperature).toBe(0);
+    expect(requestBody).not.toHaveProperty("temperature");
     expect(requestBody.response_format).toMatchObject({
       type: "json_schema",
       json_schema: {


### PR DESCRIPTION
## Summary
- omit the unsupported temperature field from TavernKeeper Luna synthesis requests
- retain strict JSON-schema output and existing validation
- assert the provider request stays temperature-free

## Verification
- npm test -- --run tests/unit/tavernkeeper-synthesis.test.ts
- npm run check