### PR TITLE
Use Luna-compatible TavernKeeper schema

### DIFF
--- a/scripts/security/tavernkeeper-assessment-contract.mjs
+++ b/scripts/security/tavernkeeper-assessment-contract.mjs
@@ -29,7 +29,6 @@ export const TAVERNKEEPER_ASSESSMENT_JSON_SCHEMA = {
     malicious_evidence: { type: "string", minLength: 1, maxLength: 300 },
     cited_finding_ids: {
       type: "array",
-      uniqueItems: true,
       maxItems: 256,
       items: { type: "string", pattern: "^[0-9a-f]{64}$" },
     },
@@ -45,7 +44,6 @@ export const TAVERNKEEPER_ASSESSMENT_JSON_SCHEMA = {
             type: "array",
             minItems: 2,
             maxItems: 16,
-            uniqueItems: true,
             items: { type: "string", pattern: "^[0-9a-f]{64}$" },
           },
           resulting_risk: {

--- a/tests/unit/tavernkeeper-synthesis.test.ts
+++ b/tests/unit/tavernkeeper-synthesis.test.ts
@@ -271,6 +271,9 @@ describe("strict Luna synthesis", () => {
         strict: true,
       },
     });
+    expect(JSON.stringify(requestBody.response_format)).not.toContain(
+      "uniqueItems",
+    );
     expect(requestBody.messages[0].content).toContain(
       "synthesizing validated assessments, not rescanning code",
     );


### PR DESCRIPTION
## Summary
- remove unsupported uniqueItems keywords from the provider-facing strict JSON schema
- retain uniqueness enforcement in Tavernary's local validator
- cover the provider schema subset explicitly

## Verification
- npm test -- --run tests/unit/tavernkeeper-synthesis.test.ts
- npm run check