### PR TITLE
feat(catalog): use supplied stale clock SVG

### DIFF
--- a/src/components/icons/tavernkeeper-freshness-clock-icon.tsx
+++ b/src/components/icons/tavernkeeper-freshness-clock-icon.tsx
@@ -1,0 +1,20 @@
+export function TavernKeeperFreshnessClockIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="tavernkeeper-freshness-clock"
+      data-icon="clock"
+      fill="none"
+      focusable="false"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+    >
+      <path
+        d="M12 7V12L14.5 13.5M21 12C21 16.9706 16.9706 21 12 21C7.02944 21 3 16.9706 3 12C3 7.02944 7.02944 3 12 3C16.9706 3 21 7.02944 21 12Z"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="2"
+      />
+    </svg>
+  );
+}

--- a/src/features/catalog/components/tavernkeeper-scan-indicator.tsx
+++ b/src/features/catalog/components/tavernkeeper-scan-indicator.tsx
@@ -15,6 +15,7 @@ import {
 } from "react";
 
 import { TavernKeeperScanIcon } from "@/components/icons/tavernkeeper-scan-icon";
+import { TavernKeeperFreshnessClockIcon } from "@/components/icons/tavernkeeper-freshness-clock-icon";
 import type { TavernKeeperCardStatus } from "@/features/catalog/tavernkeeper-status";
 import { TavernKeeperHistoryStrip } from "./tavernkeeper-history-strip";
 
@@ -310,7 +311,7 @@ export function TavernKeeperScanIndicator({
       >
         <TavernKeeperScanIcon />
         {status.freshness === "stale" ? (
-          <span aria-hidden="true" className="tavernkeeper-freshness-clock" />
+          <TavernKeeperFreshnessClockIcon />
         ) : null}
       </button>
       {open && typeof document !== "undefined"

--- a/src/styles/catalog.css
+++ b/src/styles/catalog.css
@@ -1456,33 +1456,15 @@
   height: 16px;
 }
 
-.tavernkeeper-freshness-clock {
+.tavernkeeper-scan-indicator-trigger .tavernkeeper-freshness-clock {
   position: absolute;
-  right: -2px;
-  bottom: -1px;
-  width: 8px;
-  height: 8px;
+  right: -3px;
+  bottom: -2px;
+  width: 9px;
+  height: 9px;
   box-sizing: border-box;
-  border: 1px solid currentColor;
   border-radius: 50%;
   background: var(--color-tavernkeeper-stale-clock-bg);
-}
-
-.tavernkeeper-freshness-clock::before,
-.tavernkeeper-freshness-clock::after {
-  position: absolute;
-  top: 2px;
-  left: 3px;
-  width: 1px;
-  height: 3px;
-  background: currentColor;
-  content: "";
-  transform-origin: 50% 100%;
-}
-
-.tavernkeeper-freshness-clock::after {
-  height: 2px;
-  transform: rotate(120deg);
 }
 
 .tavernkeeper-scan-indicator-trigger:focus-visible {

--- a/tests/e2e/catalog-mobile-performance.spec.ts
+++ b/tests/e2e/catalog-mobile-performance.spec.ts
@@ -112,6 +112,9 @@ async function catalogCostSnapshot(
       return {
         cards: document.querySelectorAll(".project-card").length,
         documentElements: document.querySelectorAll("*").length,
+        freshnessClocks: document.querySelectorAll(
+          'svg.tavernkeeper-freshness-clock[data-icon="clock"]',
+        ).length,
         historyBlocks: document.querySelectorAll(
           ".tavernkeeper-history-strip i",
         ).length,
@@ -232,10 +235,13 @@ test(
     expect(featureOff.scanGlyphs).toBe(0);
     expect(full.cards).toBeGreaterThan(filtered.cards);
     expect(full.scanGlyphs).toBe(full.cards);
+    expect(full.freshnessClocks).toBe(1);
     expect(
       full.documentElements - featureOff.documentElements,
     ).toBeLessThanOrEqual(full.cards * 4);
-    expect(full.svgs - featureOff.svgs).toBeLessThanOrEqual(full.cards);
+    expect(full.svgs - featureOff.svgs).toBeLessThanOrEqual(
+      full.cards + full.freshnessClocks,
+    );
     expect(full.openPopovers).toBe(0);
     expect(full.historyBlocks).toBe(0);
     expect(full.tooltipAnchors).toBe(0);

--- a/tests/unit/tavernkeeper-scan-indicator.test.tsx
+++ b/tests/unit/tavernkeeper-scan-indicator.test.tsx
@@ -202,7 +202,7 @@ describe("TavernKeeperScanIndicator", () => {
     },
   );
 
-  test("keeps stale risk color and adds an independent accessible clock marker", () => {
+  test("keeps stale risk color and uses the supplied clock SVG", () => {
     render(
       <TavernKeeperScanIndicator
         projectId="stale-low"
@@ -214,9 +214,14 @@ describe("TavernKeeperScanIndicator", () => {
       name: "TavernKeeper scan: Low concern; stale assessment.",
     });
     expect(trigger).toHaveClass("tavernkeeper-scan-indicator-teal");
-    expect(
-      trigger.querySelector(".tavernkeeper-freshness-clock"),
-    ).toBeInTheDocument();
+    const clock = trigger.querySelector(
+      'svg.tavernkeeper-freshness-clock[data-icon="clock"]',
+    );
+    expect(clock).toBeInTheDocument();
+    expect(clock?.querySelector("path")).toHaveAttribute(
+      "d",
+      "M12 7V12L14.5 13.5M21 12C21 16.9706 16.9706 21 12 21C7.02944 21 3 16.9706 3 12C3 7.02944 7.02944 3 12 3C16.9706 3 21 7.02944 21 12Z",
+    );
   });
 
   test("shows labeled history only when it communicates a trend", () => {


### PR DESCRIPTION
## Summary
- replace the CSS-drawn stale assessment clock with the user-supplied SVG path
- inherit the existing scan status color so stale low-concern cards remain teal rather than caution orange
- update the security Help copy to name the visible clock icon

## Verification
- red/green focused unit test for the exact supplied SVG path
- npm run test:scan (12 browser/visual tests)
- npm run check (210 files, 2253 tests, static export verified)

No scan behavior, output, policy, summaries, or queue state changes.