### PR TITLE
Fix TavernKeeper importer continuation outputs

### DIFF
--- a/.github/workflows/import-tavernkeeper-reports.yml
+++ b/.github/workflows/import-tavernkeeper-reports.yml
@@ -54,12 +54,18 @@ jobs:
         run: |
           result="$(npm run --silent security:import-reports)"
           printf '%s\n' "$result"
-          echo "imported=$(jq -er '.imported | select(type == \"number\")' <<< "$result")" >> "$GITHUB_OUTPUT"
-          echo "failed=$(jq -er '.failed | select(type == \"number\")' <<< "$result")" >> "$GITHUB_OUTPUT"
-          echo "pending_due=$(jq -er '.pending_due | select(type == \"number\")' <<< "$result")" >> "$GITHUB_OUTPUT"
-          echo "pending_delayed=$(jq -er '.pending_delayed | select(type == \"number\")' <<< "$result")" >> "$GITHUB_OUTPUT"
-          echo "next_wake_at=$(jq -r '.next_wake_at // \"\"' <<< "$result")" >> "$GITHUB_OUTPUT"
-          echo "chronic_failures=$(jq -er '.chronic_failures | select(type == \"number\")' <<< "$result")" >> "$GITHUB_OUTPUT"
+          imported="$(jq -er '.imported | select(type == "number")' <<< "$result")"
+          failed="$(jq -er '.failed | select(type == "number")' <<< "$result")"
+          pending_due="$(jq -er '.pending_due | select(type == "number")' <<< "$result")"
+          pending_delayed="$(jq -er '.pending_delayed | select(type == "number")' <<< "$result")"
+          next_wake_at="$(jq -r '.next_wake_at // ""' <<< "$result")"
+          chronic_failures="$(jq -er '.chronic_failures | select(type == "number")' <<< "$result")"
+          echo "imported=$imported" >> "$GITHUB_OUTPUT"
+          echo "failed=$failed" >> "$GITHUB_OUTPUT"
+          echo "pending_due=$pending_due" >> "$GITHUB_OUTPUT"
+          echo "pending_delayed=$pending_delayed" >> "$GITHUB_OUTPUT"
+          echo "next_wake_at=$next_wake_at" >> "$GITHUB_OUTPUT"
+          echo "chronic_failures=$chronic_failures" >> "$GITHUB_OUTPUT"
       - name: Validate imported summaries
         run: npm run check
       - name: Commit and publish changed summaries

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -606,6 +606,7 @@ test("reconciles reports independently and wakes TavernKeeper only after a chang
   const reportImportSteps = reportImport.jobs.import.steps as Array<{
     name?: string;
     env?: Record<string, string>;
+    run?: string;
   }>;
   const synthesisStep = reportImportSteps.find(
     (step) =>
@@ -642,6 +643,20 @@ test("reconciles reports independently and wakes TavernKeeper only after a chang
     TAVERNARY_ENRICHMENT_API_KEY: "${{ secrets.TAVERNARY_ENRICHMENT_API_KEY }}",
     TAVERNARY_ENRICHMENT_MODEL: "${{ secrets.TAVERNARY_ENRICHMENT_MODEL }}",
   });
+  for (const output of [
+    "imported",
+    "failed",
+    "pending_due",
+    "pending_delayed",
+    "chronic_failures",
+  ]) {
+    expect(synthesisStep?.run).toContain(
+      `.${output} | select(type == "number")`,
+    );
+  }
+  expect(synthesisStep?.run).toContain('.next_wake_at // ""');
+  expect(synthesisStep?.run).not.toContain('type == \\"number\\"');
+  expect(synthesisStep?.run).not.toContain('.next_wake_at // \\"\\"');
   expect(
     reportImportSteps
       .filter((step) => step !== synthesisStep)


### PR DESCRIPTION
## Summary

- parse importer telemetry with valid `jq` filters
- assign each required value before writing `GITHUB_OUTPUT`, so malformed telemetry fails the step
- prevent escaped-filter regressions in the workflow contract tests

## Live evidence

The first post-merge run of #248 processed reports and published commit `f06f9485`, but its log showed `jq` compile errors for every telemetry field. GitHub therefore received blank job outputs, which would skip immediate continuation whenever `pending_due` is nonzero.

The batch itself reported `imported: 2`, `failed: 2`, `preferred: 19`, `pending_due: 0`, and `pending_delayed: 2`, so report processing and publication were healthy; only continuation telemetry was broken.

## Verification

- `npm run check` — 210 test files and 2,270 tests passed; static export verified
- `npx vitest run tests/unit/workflows.test.ts` — 40 tests passed
- regression test fails on the live over-escaped workflow form and passes on this fix
