### PR TITLE
Fix TavernKeeper popup summary overflow

### DIFF
--- a/docs/superpowers/plans/2026-08-04-tavernkeeper-summary-overflow.md
+++ b/docs/superpowers/plans/2026-08-04-tavernkeeper-summary-overflow.md
@@ -1,0 +1,86 @@
+# TavernKeeper Summary Overflow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent internal TavernKeeper evidence identifiers from breaking the concise mobile scan popup.
+
+**Architecture:** Add a display-only summary normalizer beside the popup component, leaving imported report data unchanged. Add a CSS containment guard for any future unbroken token.
+
+**Tech Stack:** React 19, TypeScript, CSS, Vitest, Testing Library, PostCSS
+
+## Global Constraints
+
+- Preserve exact raw TavernKeeper report data and full-report links.
+- Preserve the seven-character visible scanned SHA and full-SHA accessible name.
+- Do not change TavernKeeper report-site content or assessment risk semantics.
+
+---
+
+### Task 1: Sanitize concise assessment copy
+
+**Files:**
+- Modify: `src/features/catalog/components/tavernkeeper-scan-indicator.tsx`
+- Test: `tests/unit/tavernkeeper-scan-indicator.test.tsx`
+
+**Interfaces:**
+- Consumes: `TavernKeeperReportSummary.summary: string`
+- Produces: `conciseAssessmentSummary(summary: string): string`
+
+- [ ] **Step 1: Write the failing component regression**
+
+Add fixtures containing the live parenthetical finding-ID list and encoded
+citation marker. Assert that the popup retains the human explanation but does
+not render 64-character digests, citation markers, or a dangling incomplete
+sentence.
+
+- [ ] **Step 2: Verify the regression fails**
+
+Run: `npm.cmd test -- tests/unit/tavernkeeper-scan-indicator.test.tsx`
+
+Expected: FAIL because the popup currently renders `assessment.summary`
+verbatim.
+
+- [ ] **Step 3: Implement the minimal display normalizer**
+
+Strip encoded citation spans and parenthetical finding-reference blocks,
+collapse whitespace, and discard the final incomplete sentence only when an
+artifact was removed. Use the normalized copy only in `stateCopy`.
+
+- [ ] **Step 4: Verify the component regression passes**
+
+Run: `npm.cmd test -- tests/unit/tavernkeeper-scan-indicator.test.tsx`
+
+Expected: PASS.
+
+### Task 2: Contain unforeseen long tokens
+
+**Files:**
+- Modify: `src/styles/catalog.css`
+- Test: `tests/unit/tavernkeeper-scan-indicator.test.tsx`
+
+**Interfaces:**
+- Consumes: `.tavernkeeper-summary`
+- Produces: mobile-safe wrapping through `overflow-wrap: anywhere`
+
+- [ ] **Step 1: Write the failing style regression**
+
+Parse `src/styles/catalog.css` and assert that `.tavernkeeper-summary` declares
+`overflow-wrap: anywhere`.
+
+- [ ] **Step 2: Verify the style regression fails**
+
+Run: `npm.cmd test -- tests/unit/tavernkeeper-scan-indicator.test.tsx`
+
+Expected: FAIL because the summary currently has no forced overflow wrapping.
+
+- [ ] **Step 3: Add the minimal CSS guard**
+
+Add a focused `.tavernkeeper-summary` rule with `overflow-wrap: anywhere`.
+
+- [ ] **Step 4: Run focused and full verification**
+
+Run: `npm.cmd test -- tests/unit/tavernkeeper-scan-indicator.test.tsx`
+
+Run: `npm.cmd run check`
+
+Expected: both commands exit successfully with zero failures.

--- a/docs/superpowers/specs/2026-08-04-tavernkeeper-summary-overflow-design.md
+++ b/docs/superpowers/specs/2026-08-04-tavernkeeper-summary-overflow-design.md
@@ -1,0 +1,28 @@
+# TavernKeeper Summary Overflow Design
+
+## Goal
+
+Keep TavernKeeper's concise card popup readable on narrow screens when an
+imported assessment contains internal finding identifiers or encoded citation
+markers.
+
+## Design
+
+The popup will derive display-only copy from the imported assessment summary.
+It will remove encoded citation markers and parenthetical finding-ID lists,
+trim an incomplete trailing sentence when one of those artifacts made the
+source malformed, and preserve the raw imported assessment for report and
+provenance surfaces.
+
+The summary element will also use `overflow-wrap: anywhere` so an unforeseen
+unbroken token cannot widen the fixed-position popup beyond its mobile width.
+The scanned-source link remains unchanged: seven visible SHA characters with
+the complete SHA retained in its URL and accessible name.
+
+## Verification
+
+Component regressions will cover the two production payload shapes shown in
+the mobile screenshots: a parenthetical list of 64-character finding IDs and
+an encoded citation marker. A style assertion will cover the final overflow
+guard, followed by Tavernary's focused component test and full `npm run check`
+gate.

--- a/src/features/catalog/components/tavernkeeper-scan-indicator.tsx
+++ b/src/features/catalog/components/tavernkeeper-scan-indicator.tsx
@@ -19,6 +19,32 @@ import { TavernKeeperFreshnessClockIcon } from "@/components/icons/tavernkeeper-
 import type { TavernKeeperCardStatus } from "@/features/catalog/tavernkeeper-status";
 import { TavernKeeperHistoryStrip } from "./tavernkeeper-history-strip";
 
+const encodedCitationPattern = /\s*\uE200cite\uE202[^\uE201]*\uE201/giu;
+const findingReferencePattern =
+  /\s*\((?:V\d+\s+)?findings?\s+[^)]*\b[0-9a-f]{64}\b[^)]*\)/giu;
+const invisibleFormattingPattern = /[\u200B-\u200D\u2060\uFEFF]/gu;
+
+function conciseAssessmentSummary(summary: string) {
+  const withoutArtifacts = summary
+    .replace(encodedCitationPattern, "")
+    .replace(findingReferencePattern, "")
+    .replace(invisibleFormattingPattern, "");
+  let display = withoutArtifacts.replace(/\s+/gu, " ").trim();
+
+  if (withoutArtifacts !== summary && !/[.!?]["')\]]?$/u.test(display)) {
+    const lastCompleteSentence = Math.max(
+      display.lastIndexOf("."),
+      display.lastIndexOf("!"),
+      display.lastIndexOf("?"),
+    );
+    if (lastCompleteSentence >= 0) {
+      display = display.slice(0, lastCompleteSentence + 1);
+    }
+  }
+
+  return display;
+}
+
 function stateCopy(status: TavernKeeperCardStatus) {
   if (status.report) {
     const freshness =
@@ -27,7 +53,7 @@ function stateCopy(status: TavernKeeperCardStatus) {
         : status.freshness === "unavailable"
           ? " Tavernary cannot confirm the repository's current commit, so freshness is unavailable."
           : "";
-    return `${status.report.summary}${freshness}`;
+    return `${conciseAssessmentSummary(status.report.summary)}${freshness}`;
   }
   if (status.state === "unsupported") {
     return "TavernKeeper scanning is not supported for this project's source.";

--- a/src/styles/catalog.css
+++ b/src/styles/catalog.css
@@ -1507,6 +1507,10 @@
   margin: 0;
 }
 
+.tavernkeeper-summary {
+  overflow-wrap: anywhere;
+}
+
 .tavernkeeper-popover-header {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;

--- a/tests/unit/tavernkeeper-scan-indicator.test.tsx
+++ b/tests/unit/tavernkeeper-scan-indicator.test.tsx
@@ -173,6 +173,42 @@ describe("TavernKeeperScanIndicator", () => {
   });
 
   test.each([
+    {
+      expected:
+        "The project is assessed as low risk. Its test workflow could use tighter token handling, narrower permissions, and pinned action versions.",
+      summary:
+        "The project is assessed as low risk. Its test workflow could use tighter token handling, narrower permissions, and pinned action versions (V5 findings 72484c6e8e8d51696e42a5038b454c513da346f79ef557f0c24db3eefd2e68f3, 7e6ec8fb70e2a68052c34a3d7d7b1a8b011698553c48df62ec39943af8ee0bbd, 817962172966e2e2adae88040c785386dcfaeb3717f1feb8d7b5f1be23d08f6c, and cef063e24672a717652b8ac33af23d6a04d1009c2bd06f733f5d6d8e9e5015cb). A known issue was also found in a development-only helper dependency and does \u200b\u200b",
+    },
+    {
+      expected:
+        "The project has a material vulnerability: when normal JSON parsing fails, it may execute the AI's response as JavaScript. A manipulated or malicious AI response could therefore run code inside the user's SillyTavern session. Users should avoid untrusted AI endpoints or content until this fallback is removed and replaced with safe, non-executing JSON repair.",
+      summary:
+        "The project has a material vulnerability: when normal JSON parsing fails, it may execute the AI's response as JavaScript. A manipulated or malicious AI response could therefore run code inside the user's SillyTavern session. Users should avoid untrusted AI endpoints or content until this fallback is removed and replaced with safe, non-executing JSON repair. \uE200cite\uE202e1f6254c527f8d5fd529e09c3c7959fa59e8afbbbabfa395a3ce291339df0ba6\uE201",
+    },
+  ])(
+    "keeps internal finding references out of concise assessment copy",
+    ({ expected, summary }) => {
+      const report = scanReport({ summary });
+      render(
+        <TavernKeeperScanIndicator
+          projectId="internal-finding-reference"
+          status={{ ...redStatus, report, history: [report] }}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button"));
+
+      const conciseSummary = screen
+        .getByRole("dialog")
+        .querySelector(".tavernkeeper-summary");
+      expect(conciseSummary).toHaveTextContent(expected);
+      expect(conciseSummary).not.toHaveTextContent(/[0-9a-f]{64}/iu);
+      expect(conciseSummary).not.toHaveTextContent(/cite/iu);
+      expect(report.summary).toBe(summary);
+    },
+  );
+
+  test.each([
     [tealStatus, tealReport.summary],
     [
       {
@@ -570,6 +606,26 @@ describe("TavernKeeperScanIndicator", () => {
           declaration.type === "decl" &&
           declaration.prop === "transition" &&
           declaration.value === "none",
+      ),
+    ).toBe(true);
+  });
+
+  test("wraps unforeseen long summary tokens within the popover", () => {
+    const stylesheet = postcss.parse(
+      readFileSync("src/styles/catalog.css", "utf8"),
+    );
+    const summaryRule = stylesheet.nodes.find(
+      (rule): rule is Rule =>
+        rule.type === "rule" && rule.selector === ".tavernkeeper-summary",
+    );
+
+    expect(summaryRule).toBeDefined();
+    expect(
+      summaryRule?.nodes.some(
+        (declaration) =>
+          declaration.type === "decl" &&
+          declaration.prop === "overflow-wrap" &&
+          declaration.value === "anywhere",
       ),
     ).toBe(true);
   });


### PR DESCRIPTION
## Summary

- remove internal TavernKeeper finding IDs and encoded citation markers from concise card-popup copy
- trim the malformed dangling sentence present in the affected imported assessment
- keep raw imported reports and exact scanned-commit links unchanged
- force unforeseen long summary tokens to wrap within the mobile popup

## Root cause

TavernKeeper assessment prose can contain 64-character internal finding IDs or encoded citation markers. Tavernary rendered that upstream summary verbatim in the concise popup, allowing unbroken internal tokens to overflow the fixed mobile panel.

## Validation

- `npm.cmd test -- tests/unit/tavernkeeper-scan-indicator.test.tsx` (23 passed)
- `npm.cmd run check` (211 files, 2,294 tests, production build, and static export passed)
- independent pre-merge review: no findings
