### PR TITLE
Fix TavernKeeper public scan prose

### DIFF
--- a/scripts/security/tavernkeeper-assessment-contract.d.mts
+++ b/scripts/security/tavernkeeper-assessment-contract.d.mts
@@ -4,10 +4,11 @@ import type {
   TavernaryAssessmentV1,
 } from "./tavernkeeper-reports.mjs";
 
-export const TAVERNKEEPER_SYNTHESIS_POLICY_VERSION: "2";
+export const TAVERNKEEPER_SYNTHESIS_POLICY_VERSION: "3";
 export const TAVERNKEEPER_ASSESSMENT_JSON_SCHEMA: Record<string, unknown>;
 export type TavernaryAssessmentDiagnostic =
   | "response_schema"
+  | "public_text_references"
   | "unknown_candidate_ids"
   | "missing_candidate_ids"
   | "count_mismatch"

--- a/scripts/security/tavernkeeper-assessment-contract.mjs
+++ b/scripts/security/tavernkeeper-assessment-contract.mjs
@@ -1,4 +1,4 @@
-export const TAVERNKEEPER_SYNTHESIS_POLICY_VERSION = "2";
+export const TAVERNKEEPER_SYNTHESIS_POLICY_VERSION = "3";
 
 const riskLevels = ["low", "material", "high"];
 const digestPattern = /^[0-9a-f]{64}$/u;

--- a/scripts/security/tavernkeeper-assessment-contract.mjs
+++ b/scripts/security/tavernkeeper-assessment-contract.mjs
@@ -2,6 +2,7 @@ export const TAVERNKEEPER_SYNTHESIS_POLICY_VERSION = "2";
 
 const riskLevels = ["low", "material", "high"];
 const digestPattern = /^[0-9a-f]{64}$/u;
+const publicReferencePattern = /(?:\b[0-9a-f]{64}\b|\uE200cite\uE202|\uE201)/iu;
 const unsafeTextPattern =
   /[\u0000-\u001f\u007f-\u009f\u202a-\u202e\u2066-\u2069<>]/u;
 
@@ -267,6 +268,15 @@ export function validateTavernaryAssessment(assessment, report) {
     validateStoredAssessmentShape(assessment);
   } catch {
     assessmentFailure("response_schema", requirements);
+  }
+  const publicText = [
+    assessment.headline,
+    assessment.summary,
+    assessment.malicious_evidence,
+    ...assessment.interaction_chains.map((chain) => chain.explanation),
+  ];
+  if (publicText.some((value) => publicReferencePattern.test(value))) {
+    assessmentFailure("public_text_references", requirements);
   }
   const known = new Set(requirements.allowed_candidate_ids);
   const cited = new Set(assessment.cited_finding_ids);

--- a/scripts/security/tavernkeeper-import-state.d.mts
+++ b/scripts/security/tavernkeeper-import-state.d.mts
@@ -1,5 +1,6 @@
 export type TavernaryAssessmentDiagnostic =
   | "response_schema"
+  | "public_text_references"
   | "unknown_candidate_ids"
   | "missing_candidate_ids"
   | "count_mismatch"

--- a/scripts/security/tavernkeeper-import-state.mjs
+++ b/scripts/security/tavernkeeper-import-state.mjs
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 
 const diagnostics = new Set([
   "response_schema",
+  "public_text_references",
   "unknown_candidate_ids",
   "missing_candidate_ids",
   "count_mismatch",

--- a/scripts/security/tavernkeeper-synthesis-provider.mjs
+++ b/scripts/security/tavernkeeper-synthesis-provider.mjs
@@ -9,7 +9,7 @@ export function tavernKeeperSynthesisInstructions() {
 
 Most projects in this open-source, often vibe-coded community are made in good faith, but rare projects have attempted API-key phishing or theft, trojan delivery, harmful payloads, and bot infection. Judge the validated evidence in that context without treating ordinary SillyTavern extension behavior or scanner keywords as malicious by themselves.
 
-Produce a concise project-level assessment for nontechnical Tavernary visitors. Preserve material uncertainty and distinguish malicious evidence from ordinary security weaknesses. Cite only IDs listed in allowed_candidate_ids for every caution or concern. Observation IDs are never valid citations. Copy required_counts exactly. You may not lower the deterministic evidence floor. You may escalate beyond it only when two or more cited findings form a supported causal interaction, expressed in interaction_chains. Return only the required structured object.`;
+Produce a concise project-level assessment for nontechnical Tavernary visitors. Preserve material uncertainty and distinguish malicious evidence from ordinary security weaknesses. Put cited IDs only in cited_finding_ids and interaction_chains.finding_ids, using IDs listed in allowed_candidate_ids. Never put finding IDs or citation markers in visitor-facing prose. Observation IDs are never valid citations. Copy required_counts exactly. You may not lower the deterministic evidence floor. You may escalate beyond it only when two or more cited findings form a supported causal interaction, expressed in interaction_chains. Return only the required structured object.`;
 }
 
 function synthesisInput(input) {

--- a/src/features/catalog/components/tavernkeeper-scan-indicator.tsx
+++ b/src/features/catalog/components/tavernkeeper-scan-indicator.tsx
@@ -24,8 +24,10 @@ const findingReferencePattern =
   /\s*\((?:V\d+\s+)?findings?\s+[^)]*\b[0-9a-f]{64}\b[^)]*\)/giu;
 const bracketedFindingReferencePattern =
   /\s*\[[0-9a-f]{64}(?:,\s*[0-9a-f]{64})*\]/giu;
-const findingReferenceSuffixPattern =
-  /\s*(?:Findings:\s*)?[\[(【]?[0-9a-f]{64}[\s\S]*$/iu;
+const danglingFindingReferencePattern =
+  /\s*\[(?=[0-9a-f]{64}(?:,|$))[\s\S]*$/iu;
+const bareFindingReferencePattern =
+  /(?:Findings:\s*)?[\[(【]?[0-9a-f]{64}\b[\])】]?/giu;
 const invisibleFormattingPattern = /[\u200B-\u200D\u2060\uFEFF]/gu;
 
 function conciseAssessmentSummary(summary: string) {
@@ -33,9 +35,13 @@ function conciseAssessmentSummary(summary: string) {
     .replace(encodedCitationPattern, "")
     .replace(findingReferencePattern, "")
     .replace(bracketedFindingReferencePattern, "")
-    .replace(findingReferenceSuffixPattern, "")
+    .replace(danglingFindingReferencePattern, "")
+    .replace(bareFindingReferencePattern, "")
     .replace(invisibleFormattingPattern, "");
-  let display = withoutArtifacts.replace(/\s+/gu, " ").trim();
+  let display = withoutArtifacts
+    .replace(/\s+([,.;!?])/gu, "$1")
+    .replace(/\s+/gu, " ")
+    .trim();
 
   if (withoutArtifacts !== summary && !/[.!?]["')\]]?$/u.test(display)) {
     const lastCompleteSentence = Math.max(

--- a/src/features/catalog/components/tavernkeeper-scan-indicator.tsx
+++ b/src/features/catalog/components/tavernkeeper-scan-indicator.tsx
@@ -22,7 +22,10 @@ import { TavernKeeperHistoryStrip } from "./tavernkeeper-history-strip";
 const encodedCitationPattern = /\s*\uE200cite\uE202[^\uE201]*\uE201/giu;
 const findingReferencePattern =
   /\s*\((?:V\d+\s+)?findings?\s+[^)]*\b[0-9a-f]{64}\b[^)]*\)/giu;
-const bracketedFindingReferencePattern = /\s*\[[0-9a-f]{64}\]/giu;
+const bracketedFindingReferencePattern =
+  /\s*\[[0-9a-f]{64}(?:,\s*[0-9a-f]{64})*\]/giu;
+const findingReferenceSuffixPattern =
+  /\s*(?:Findings:\s*)?[\[(【]?[0-9a-f]{64}[\s\S]*$/iu;
 const invisibleFormattingPattern = /[\u200B-\u200D\u2060\uFEFF]/gu;
 
 function conciseAssessmentSummary(summary: string) {
@@ -30,6 +33,7 @@ function conciseAssessmentSummary(summary: string) {
     .replace(encodedCitationPattern, "")
     .replace(findingReferencePattern, "")
     .replace(bracketedFindingReferencePattern, "")
+    .replace(findingReferenceSuffixPattern, "")
     .replace(invisibleFormattingPattern, "");
   let display = withoutArtifacts.replace(/\s+/gu, " ").trim();
 
@@ -41,6 +45,8 @@ function conciseAssessmentSummary(summary: string) {
     );
     if (lastCompleteSentence >= 0) {
       display = display.slice(0, lastCompleteSentence + 1);
+    } else if (display) {
+      display += ".";
     }
   }
 

--- a/tests/unit/tavernkeeper-import-state.test.ts
+++ b/tests/unit/tavernkeeper-import-state.test.ts
@@ -38,9 +38,11 @@ describe("TavernKeeper report import quarantine state", () => {
       validateTavernKeeperImportState({
         schema_version: 2,
         updated_at: at,
-        quarantines: [quarantine()],
+        quarantines: [quarantine({ diagnostic: "public_text_references" })],
       }),
-    ).toMatchObject({ quarantines: [quarantine()] });
+    ).toMatchObject({
+      quarantines: [quarantine({ diagnostic: "public_text_references" })],
+    });
   });
 
   test.each([

--- a/tests/unit/tavernkeeper-reports.test.ts
+++ b/tests/unit/tavernkeeper-reports.test.ts
@@ -641,7 +641,7 @@ describe("TavernKeeper V5 report import", () => {
         if (currentReport.repository_id === 42)
           throw new TavernKeeperSynthesisError(
             "invalid-output",
-            "count_mismatch",
+            "public_text_references",
           );
         return synthesisFor(secondEntry);
       },
@@ -671,7 +671,7 @@ describe("TavernKeeper V5 report import", () => {
           report_digest: index.reports[0].report_digest,
           repository_id: 42,
           synthesis_policy_version: TAVERNKEEPER_SYNTHESIS_POLICY_VERSION,
-          diagnostic: "count_mismatch",
+          diagnostic: "public_text_references",
           attempts: 1,
         },
       ],
@@ -679,7 +679,7 @@ describe("TavernKeeper V5 report import", () => {
     expect(outcome.created_or_updated).toEqual([
       expect.objectContaining({
         report_digest: index.reports[0].report_digest,
-        diagnostic: "count_mismatch",
+        diagnostic: "public_text_references",
       }),
     ]);
   });

--- a/tests/unit/tavernkeeper-scan-indicator.test.tsx
+++ b/tests/unit/tavernkeeper-scan-indicator.test.tsx
@@ -204,9 +204,9 @@ describe("TavernKeeperScanIndicator", () => {
     },
     {
       expected:
-        "The project uses vulnerable production dependencies, including one medium-severity issue.",
+        "The project uses vulnerable production dependencies, including one medium-severity issue and one high-severity issue.",
       summary:
-        "The project uses vulnerable production dependencies, including one medium-severity issue (28ee3138d3d8994ad41b170ee691b8035a20cb6b3f8d6d3272d972131596b848) and one high-severity issue (986f02e9c6e58bd1f45358afa192618ec56d1e1fc097b14effc22a5c2597ab).",
+        "The project uses vulnerable production dependencies, including one medium-severity issue (28ee3138d3d8994ad41b170ee691b8035a20cb6b3f8d6d3272d972131596b848) and one high-severity issue (986f02e9c6e58bd1f45358afa192618ec56d1e1fc097b14effc22a5c2597abcc).",
     },
     {
       expected: "No credible malicious behavior was validated.",

--- a/tests/unit/tavernkeeper-scan-indicator.test.tsx
+++ b/tests/unit/tavernkeeper-scan-indicator.test.tsx
@@ -191,6 +191,28 @@ describe("TavernKeeperScanIndicator", () => {
       summary:
         "The project is assessed as low risk for users. Its test workflow could use safer GitHub token handling, narrower permissions, and pinned action versions [72484c6e8e8d51696e42a5038b454c513da346f79ef557f0c24db3eefd2e68f3] [7e6ec8fb70e2a68052c34a3d7d7b1a8b011698553c48df62ec39943af8ee0bbd] [817962172966e2e2adae88040c785386dcfaeb3717f1feb8d7b5f1be23d08f6c] [cef063e24672a717652b8ac33af23d6a04d1009c2bd06f733f5d6d8e9e5015cb]. A known issue also affects a developer testing/build tool, not the installed S",
     },
+    {
+      expected:
+        "The eight material findings are known vulnerabilities in dependencies used by the project's test tooling, not in the installed VectFox extension, so direct user impact is unlikely.",
+      summary:
+        "The eight material findings are known vulnerabilities in dependencies used by the project's test tooling, not in the installed VectFox extension, so direct user impact is unlikely [0397056563b1b7873056136a413c67c2a2d3235db1db74ea738dba1d83819202,09be780f6d03ede2c2fe1a97bb9f8682f1662fa9883ba73242a46050450c0391,53076ef905302530238a497417d76b71218ce2485bfe8be5990c2fd9f0da774c,66f3348967d97ad1ac6aefe40446c9cf2b2f7304a491c1bc8922a9d6d585b66d,7a9b663e3b6cf212d742ee2e39d66445d38ad46d311be1fb5506c885896",
+    },
+    {
+      expected: "The validated evidence supports a low-risk assessment.",
+      summary:
+        "The validated evidence supports a low-risk assessment. Findings: 0b57f46e6a48a2af0fd147370c4d36cad8be2bb73f629c751f7c54b0bb8b04a3, 14a66334365238113c6ae7edc276bf763ada97c62141b3ea60a7125543bbff4c",
+    },
+    {
+      expected:
+        "The project uses vulnerable production dependencies, including one medium-severity issue.",
+      summary:
+        "The project uses vulnerable production dependencies, including one medium-severity issue (28ee3138d3d8994ad41b170ee691b8035a20cb6b3f8d6d3272d972131596b848) and one high-severity issue (986f02e9c6e58bd1f45358afa192618ec56d1e1fc097b14effc22a5c2597ab).",
+    },
+    {
+      expected: "No credible malicious behavior was validated.",
+      summary:
+        "No credible malicious behavior was validated.【010d9a8ee67bb15dcce292d009f91ddacfb62dda24d9b017f6d794f02fc5dd】【0a5120939b9cfe9a1fd05017621d304bd9ba97d4552b789d95b5f8b15bed413】",
+    },
   ])(
     "keeps internal finding references out of concise assessment copy",
     ({ expected, summary }) => {

--- a/tests/unit/tavernkeeper-synthesis.test.ts
+++ b/tests/unit/tavernkeeper-synthesis.test.ts
@@ -208,6 +208,47 @@ describe("Tavernary final assessment contract", () => {
     ).toMatchObject({ diagnostic: "response_schema" });
   });
 
+  test.each([
+    ["headline", { headline: `Low concern ${candidateId}` }],
+    ["summary", { summary: `Visible explanation ${candidateId}` }],
+    [
+      "malicious evidence",
+      { malicious_evidence: `No malicious behavior ${candidateId}` },
+    ],
+    [
+      "interaction explanation",
+      {
+        interaction_chains: [
+          {
+            finding_ids: [candidateId, "e".repeat(64)],
+            resulting_risk: "material",
+            explanation: `Combined behavior ${candidateId}`,
+          },
+        ],
+      },
+    ],
+    [
+      "encoded citation",
+      { summary: "Visible explanation \uE200cite\uE202reference\uE201" },
+    ],
+  ])("rejects internal references in public %s prose", (_label, overrides) => {
+    const error = validationFailure(() =>
+      validateTavernaryAssessment(lowOutput(overrides), reportWith([])),
+    );
+
+    expect(error).toMatchObject({
+      diagnostic: "public_text_references",
+      repair: {
+        allowed_candidate_ids: [],
+        required_counts: {
+          minor_cautions: 0,
+          material_concerns: 0,
+          high_danger: 0,
+        },
+      },
+    });
+  });
+
   test("returns exact deterministic counts when model counts differ", () => {
     const report = reportWith([assessment({ disposition: "minor_weakness" })]);
     const error = validationFailure(() =>
@@ -423,6 +464,9 @@ describe("strict Luna synthesis", () => {
     expect(requestBody.messages[0].content).toContain(
       "Observation IDs are never valid citations",
     );
+    expect(requestBody.messages[0].content).toContain(
+      "Never put finding IDs or citation markers in visitor-facing prose",
+    );
     const projected = JSON.parse(requestBody.messages[1].content);
     expect(projected).toMatchObject({
       allowed_candidate_ids: [candidateId],
@@ -465,6 +509,33 @@ describe("strict Luna synthesis", () => {
       assessed_at: "2026-08-02T12:06:00.000Z",
       assessment: { risk_level: "low" },
     });
+  });
+
+  test("repairs public prose that leaks structured finding IDs", async () => {
+    const report = await fixture();
+    const leakedSummary = "The extension is low risk [" + "f".repeat(64) + "].";
+    const generate = vi
+      .fn()
+      .mockResolvedValueOnce({
+        output: lowOutput({ summary: leakedSummary }),
+        metadata: { requestedModel: "gpt-5.6-luna" },
+      })
+      .mockResolvedValueOnce({
+        output: lowOutput({ summary: "The extension is low risk." }),
+        metadata: { requestedModel: "gpt-5.6-luna" },
+      });
+
+    const result = await synthesizeTavernKeeperReport(report, {
+      provider: { generate },
+      now: () => new Date("2026-08-02T12:06:00.000Z"),
+    });
+
+    expect(generate).toHaveBeenCalledTimes(2);
+    expect(generate.mock.calls[1][0].repair).toMatchObject({
+      diagnostic: "public_text_references",
+      allowed_candidate_ids: [],
+    });
+    expect(result.assessment.summary).toBe("The extension is low risk.");
   });
 
   test("stops before sending an identical validation repair", async () => {


### PR DESCRIPTION
## What changed

- reject finding IDs and citation markers in visitor-facing TavernKeeper assessment prose
- retry synthesis with a bounded repair diagnostic and quarantine terminal failures safely
- bump synthesis policy to v3 so existing assessments are regenerated under the corrected contract
- sanitize legacy popup summaries without mutating imported report data or discarding later risk prose

## Root cause

The synthesis prompt conflated structured finding citations with visitor-facing prose. Existing display cleanup handled a few citation forms but not comma-separated, dangling, plain, parenthesized, or corner-bracket finding IDs, allowing long internal identifiers to overflow the mobile popup.

## Verification

- `npm.cmd run check`
- 2,305 unit tests passed
- 156 tracked reports and 4 quarantined imports validated during the full gate
- latest merged report dataset: 161 tracked reports and 4 quarantined imports validated
- repository-wide legacy audit: 22 affected public-text fields, 0 residual internal references after display cleanup
- independent review completed with no remaining actionable findings
