### PR TITLE
fix(security): scan GitHub preset repositories

### DIFF
--- a/docs/superpowers/plans/2026-08-04-github-preset-tavernkeeper-eligibility.md
+++ b/docs/superpowers/plans/2026-08-04-github-preset-tavernkeeper-eligibility.md
@@ -1,0 +1,276 @@
+# GitHub Preset TavernKeeper Eligibility Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every published, active, healthy GitHub repository eligible for TavernKeeper scanning regardless of whether its Tavernary card is an extension, frontend, or preset.
+
+**Architecture:** Tavernary remains the eligibility authority and continues publishing exact-SHA repository targets. Remove only the obsolete preset-kind exclusions at the manifest, catalog-status, and staff-resolver boundaries; keep every existing repository identity, source health, authorization, and exact-SHA guard. TavernKeeper already accepts `preset` targets, so no cross-repository scanner code or report-contract change is required.
+
+**Tech Stack:** TypeScript, Node.js ESM, Vitest, Next.js static export, GitHub Actions.
+
+## Global Constraints
+
+- Scan the entire exact-SHA GitHub repository for presets through the existing TavernKeeper pipeline.
+- Project kind must not determine eligibility.
+- Non-GitHub URLs, Codeberg, GitHub organization pages without one repository identity, inactive sources, unhealthy or stale snapshots, identity mismatches, and malformed SHAs remain ineligible.
+- Do not add arbitrary clone URLs, user-selected branches, scan modes, or repository execution.
+- Preserve advisory scan language, immutable report identity, queue behavior, and report schemas.
+
+---
+
+### Task 1: Publish preset repositories in the target manifest
+
+**Files:**
+- Modify: `tests/unit/tavernkeeper-targets.test.ts:257-325`
+- Modify: `scripts/security/tavernkeeper-targets.mjs:12-65`
+
+**Interfaces:**
+- Consumes: `buildTavernKeeperTargets(...)` with V2 or V3 project metadata.
+- Produces: V3 repository entries whose sorted `project_kinds` may be `["preset"]` or include `preset` alongside other card kinds.
+
+- [ ] **Step 1: Write failing target-manifest tests**
+
+Change the shared-source expectation to retain both kinds and the earliest catalog date:
+
+```ts
+expect(manifest.repositories[0]).toMatchObject({
+  project_kinds: ["extension", "preset"],
+  catalog_priority: {
+    first_cataloged_at: "2026-07-01T00:00:00.000Z",
+  },
+});
+```
+
+Replace the preset-omission test with a V3 preset-only behavior test using `rankedProjectIds: ["preset-card"]` and assert the hand-derived repository entry:
+
+```ts
+expect(manifest.repositories).toEqual([
+  {
+    source_id: "github-42",
+    provider: "github",
+    repository_id: 42,
+    repository: "owner/preset",
+    target_sha: "a".repeat(40),
+    canonical_url: "https://github.com/owner/preset",
+    project_kinds: ["preset"],
+    catalog_priority: {
+      top_30: true,
+      first_cataloged_at: "2026-07-01T00:00:00.000Z",
+      popularity_rank: 1,
+    },
+  },
+]);
+```
+
+- [ ] **Step 2: Run the manifest test and verify RED**
+
+Run: `npm.cmd test -- tests/unit/tavernkeeper-targets.test.ts`
+
+Expected: FAIL because preset metadata is discarded and the preset-only repository is omitted.
+
+- [ ] **Step 3: Implement the minimal manifest change**
+
+Delete `supportedProjectKinds` and the `continue` that drops valid preset project metadata. Keep `validProjectKinds`, publication filtering, source/snapshot identity checks, deduplication, and ranking unchanged.
+
+- [ ] **Step 4: Run the manifest test and verify GREEN**
+
+Run: `npm.cmd test -- tests/unit/tavernkeeper-targets.test.ts`
+
+Expected: all target-manifest tests pass.
+
+### Task 2: Treat GitHub-backed preset cards as scan-eligible
+
+**Files:**
+- Modify: `tests/unit/tavernkeeper-status.test.ts:59-166`
+- Modify: `src/features/catalog/tavernkeeper-status.ts:201-216`
+- Modify: `scripts/catalog/build.mjs:427-433`
+- Modify: `tests/unit/build-catalog.test.ts:222-377`
+
+**Interfaces:**
+- Consumes: an active GitHub source, optional current snapshot, assessed reports, and preferred report IDs.
+- Produces: the existing gray/current/stale/unavailable/risk-colored `TavernKeeperCardStatus` without a project-kind override.
+
+- [ ] **Step 1: Write failing card-status tests**
+
+Add a helper that passes `projectKind: "preset"` to the current function, then assert observable behavior:
+
+```ts
+expect(derivePreset(null)).toMatchObject({
+  state: "gray",
+  freshness: "unassessed",
+  currentSha,
+});
+expect(derivePreset(report())).toMatchObject({
+  state: "teal",
+  freshness: "current",
+  report: expect.objectContaining({ scannedSha: currentSha }),
+});
+expect(derivePreset(report({ target_sha: olderSha }))).toMatchObject({
+  state: "teal",
+  freshness: "stale",
+});
+expect(
+  derivePreset(null, { ...snapshot, source_health: "unavailable" }),
+).toMatchObject({ state: "gray", freshness: "unavailable" });
+```
+
+Keep a separate test proving a Codeberg source remains fully unsupported. Update the sibling extension/preset catalog test so both cards project the same assessment instead of the preset being unsupported.
+
+- [ ] **Step 2: Run the status and catalog tests and verify RED**
+
+Run: `npm.cmd test -- tests/unit/tavernkeeper-status.test.ts tests/unit/build-catalog.test.ts`
+
+Expected: FAIL because `projectKind === "preset"` short-circuits to unsupported.
+
+- [ ] **Step 3: Implement the minimal status change**
+
+Remove `projectKind` from the `deriveTavernKeeperCardStatus` parameter and type contract, remove the preset branch from the unsupported guard, and stop passing `record.kind` from `buildCatalog`. Leave `isActiveGithubSource`, report identity, scanner policy, freshness, and history logic unchanged.
+
+- [ ] **Step 4: Run the status and catalog tests and verify GREEN**
+
+Run: `npm.cmd test -- tests/unit/tavernkeeper-status.test.ts tests/unit/build-catalog.test.ts`
+
+Expected: both files pass with GitHub presets using normal scan states and non-GitHub sources remaining unsupported.
+
+### Task 3: Accept presets in protected targeted scans
+
+**Files:**
+- Modify: `tests/unit/resolve-tavernkeeper-scan-request.test.ts:34-79`
+- Modify: `scripts/security/resolve-tavernkeeper-scan-request.mjs:7-54`
+
+**Interfaces:**
+- Consumes: one canonical GitHub repository URL, an authorized numeric actor ID, source records, and published project records.
+- Produces: `{ sourceId, repositoryId, repositoryUrl }` for any active published project kind backed by the registered repository.
+
+- [ ] **Step 1: Write a failing preset-resolution test**
+
+Move the preset case out of the rejection table and assert the real resolver output:
+
+```ts
+test("accepts a published preset repository", () => {
+  expect(
+    resolve({ projects: [{ ...recursionProject, kind: "preset" }] }),
+  ).toEqual({
+    sourceId: recursionSource.id,
+    repositoryId: recursionSource.repository_id,
+    repositoryUrl: "https://github.com/MentallyQuill/Recursion",
+  });
+});
+```
+
+- [ ] **Step 2: Run the resolver test and verify RED**
+
+Run: `npm.cmd test -- tests/unit/resolve-tavernkeeper-scan-request.test.ts`
+
+Expected: FAIL with the published-project rejection because presets are filtered out.
+
+- [ ] **Step 3: Implement the minimal resolver change**
+
+Delete `supportedProjectKinds` and filter published source IDs only by `project.listing_status === "active"`. Retain actor authorization, exact canonical URL validation, active GitHub source checks, positive repository identity, registered source ID shape, and canonical URL equality.
+
+- [ ] **Step 4: Run the resolver test and verify GREEN**
+
+Run: `npm.cmd test -- tests/unit/resolve-tavernkeeper-scan-request.test.ts`
+
+Expected: all resolver tests pass.
+
+### Task 4: Update normative and historical documentation
+
+**Files:**
+- Modify: `docs/tavernkeeper-integration.md:52-65`
+- Modify: `docs/tavernkeeper-live-acceptance.md:1-6`
+- Reference: `docs/superpowers/specs/2026-08-04-github-preset-tavernkeeper-eligibility-design.md`
+
+**Interfaces:**
+- Consumes: approved source-based eligibility design.
+- Produces: current integration guidance plus an explicit supersession note on the historical canary record.
+
+- [ ] **Step 1: Update current integration guidance**
+
+Describe the schema-version-3 manifest, exact source-health/identity boundary, and eligibility for published extension, frontend, and preset cards. State that eligible preset targets scan the entire repository.
+
+- [ ] **Step 2: Preserve history while marking the old policy obsolete**
+
+Add a dated note near the top of `docs/tavernkeeper-live-acceptance.md` linking to the new design and explaining that the recorded preset exclusion was superseded; do not rewrite the historical canary events.
+
+- [ ] **Step 3: Format and inspect the complete diff**
+
+Run: `npm.cmd exec prettier -- --write scripts/security/tavernkeeper-targets.mjs scripts/security/resolve-tavernkeeper-scan-request.mjs src/features/catalog/tavernkeeper-status.ts scripts/catalog/build.mjs tests/unit/tavernkeeper-targets.test.ts tests/unit/tavernkeeper-status.test.ts tests/unit/resolve-tavernkeeper-scan-request.test.ts tests/unit/build-catalog.test.ts docs/tavernkeeper-integration.md docs/tavernkeeper-live-acceptance.md docs/superpowers/specs/2026-08-04-github-preset-tavernkeeper-eligibility-design.md docs/superpowers/plans/2026-08-04-github-preset-tavernkeeper-eligibility.md`
+
+Run: `git diff --check && git diff --stat && git diff`
+
+Expected: no whitespace errors and only the approved eligibility, tests, and documentation paths change.
+
+- [ ] **Step 4: Commit the implementation**
+
+```text
+fix(security): scan GitHub preset repos
+
+Replace the obsolete kind-based exclusion with the existing active,
+healthy, exact-SHA GitHub repository boundary.
+```
+
+### Task 5: Verify generated production coverage and the full gate
+
+**Files:**
+- Generated and ignored: `public/security/tavernkeeper-targets.json`
+- Generated and ignored: `src/generated/catalog.json`
+
+**Interfaces:**
+- Consumes: current registry projects, sources, snapshots, and TavernKeeper contract configuration.
+- Produces: a validated V3 target manifest and complete Tavernary verification evidence.
+
+- [ ] **Step 1: Run all focused regression tests together**
+
+Run: `npm.cmd test -- tests/unit/tavernkeeper-targets.test.ts tests/unit/tavernkeeper-status.test.ts tests/unit/resolve-tavernkeeper-scan-request.test.ts tests/unit/build-catalog.test.ts`
+
+Expected: all focused tests pass with zero failures.
+
+- [ ] **Step 2: Build and inspect the production manifest**
+
+Run: `npm.cmd run catalog:build`
+
+Parse `public/security/tavernkeeper-targets.json` and compare it to active published preset records plus source/snapshot identity. Assert that every active, healthy, non-stale, exact-SHA GitHub preset repository is present with `project_kinds` containing `preset`; print the repository count and any missing repositories.
+
+Expected: zero missing eligible preset repositories.
+
+- [ ] **Step 3: Run the complete repository gate**
+
+Run: `npm.cmd run check`
+
+Expected: formatting, lint, palette audit, catalog validation, security report validation, catalog build, typecheck, all Vitest tests, production build, and static-export verification pass.
+
+- [ ] **Step 4: Confirm branch scope and commit state**
+
+Run: `git status --short && git diff origin/main...HEAD --stat && git log --oneline origin/main..HEAD`
+
+Expected: clean status and only the design, plan, eligibility implementation, regression tests, and documentation commits.
+
+### Task 6: Publish, review, merge, and verify production handoff
+
+**Files:**
+- No new source files.
+
+**Interfaces:**
+- Consumes: verified feature branch.
+- Produces: merged PR, exact merged SHA, deployed Tavernary manifest, and a TavernKeeper reconciliation attempt that sees preset targets.
+
+- [ ] **Step 1: Push the feature branch**
+
+Run: `git push -u origin codex/github-preset-tavernkeeper-scans`
+
+- [ ] **Step 2: Open a ready PR**
+
+Create a PR titled `fix(security): scan GitHub preset repositories` with the policy rationale, exact scope, red-green evidence, full-gate result, and production verification plan.
+
+- [ ] **Step 3: Monitor and address required checks**
+
+Use GitHub CLI with network permission to inspect every required check and failure log. Make only root-cause fixes within the approved scope, rerun local verification, push, and wait for a fresh successful check suite.
+
+- [ ] **Step 4: Merge through the protected branch flow**
+
+Merge only after the PR is reviewable, required checks pass, and branch protection permits integration. Record the exact merged `main` SHA.
+
+- [ ] **Step 5: Verify deployment and scanner intake**
+
+Verify the exact merged SHA's Pages workflow and environment deployment, fetch a fresh deployed V3 target manifest, and confirm every currently eligible preset repository is present. Then inspect the corresponding TavernKeeper reconciliation run/state to prove the new targets were accepted into its normal exact-SHA pipeline; do not claim completed assessments until their reports have actually published and Tavernary has imported them.

--- a/docs/superpowers/specs/2026-08-04-github-preset-tavernkeeper-eligibility-design.md
+++ b/docs/superpowers/specs/2026-08-04-github-preset-tavernkeeper-eligibility-design.md
@@ -1,0 +1,71 @@
+# GitHub Preset TavernKeeper Eligibility Design
+
+**Status:** Approved for implementation on 2026-08-04.
+
+## Purpose
+
+TavernKeeper eligibility is determined by whether a published Tavernary project is backed by an active, healthy GitHub repository with a stable repository ID and an exact 40-character head SHA. Project kind does not affect eligibility.
+
+This policy supersedes the earlier assumption that presets should be excluded because they do not execute as extensions or applications. A preset repository can still contain dangerous links, prompt instructions, executable examples, regex scripts, helper code, or other security-relevant material. TavernKeeper therefore scans the entire exact-SHA repository for GitHub-backed presets through the same pipeline used for extensions and frontends.
+
+## Eligibility Contract
+
+A project is eligible when all of the following are true:
+
+- The project is published and active in Tavernary.
+- Its source is a single GitHub repository, not an organization page or arbitrary URL.
+- The source is active and has a positive immutable GitHub repository ID.
+- Tavernary has a matching healthy GitHub snapshot with no stale marker.
+- The snapshot repository identity matches the registered source identity.
+- The snapshot supplies a lowercase 40-character head SHA.
+
+The project may be an extension, frontend, or preset. Non-GitHub URLs, Codeberg sources, GitHub organization pages without a single repository identity, inactive sources, unhealthy snapshots, stale snapshots, identity mismatches, and malformed or missing SHAs remain ineligible.
+
+## Architecture and Data Flow
+
+Tavernary remains the eligibility authority. Its target-manifest builder publishes one repository target per eligible GitHub repository at the exact observed SHA. Preset-only repositories carry `project_kinds: ["preset"]`; repositories shared by multiple cards carry the sorted unique kinds represented by their eligible published cards.
+
+TavernKeeper already accepts `preset` in its target contract and scan-session types. It consumes the expanded manifest without a scanner or report-schema change, inventories and scans the entire repository, publishes the existing immutable technical report, and wakes Tavernary through the existing reconciliation path.
+
+Tavernary's card-status projection uses the same source boundary. An eligible GitHub-backed preset with no assessment is gray and unassessed or unavailable according to snapshot state. When an assessment exists, the preset receives the normal risk color, exact-SHA freshness state, report link, and history behavior. Unsupported state is reserved for sources that are not active GitHub repositories.
+
+The protected staff-targeted scan resolver accepts an active preset card when its canonical URL resolves to the same registered GitHub repository identity. It continues rejecting arbitrary or unregistered repositories and continues dispatching only the repository ID as a non-authoritative hint.
+
+## Implementation Scope
+
+The change removes the obsolete preset-kind exclusion from three existing Tavernary boundaries:
+
+1. Target-manifest metadata construction.
+2. Catalog card scan-status derivation.
+3. Staff targeted-scan request resolution.
+
+Existing GitHub identity, health, exact-SHA, publication, authorization, wake, and report-validation checks remain unchanged. No new scanner mode, source adapter, queue lane, report schema, public API, or user-controlled clone input is introduced.
+
+Normative TavernKeeper integration documentation will describe source-based eligibility. Historical acceptance documentation will retain its record of the earlier rollout but state that its preset exclusion was later superseded by this design.
+
+## Failure Handling and Safety
+
+- A missing or unhealthy snapshot prevents manifest publication but does not relabel an otherwise GitHub-backed card as a permanently unsupported source; the card uses the existing unavailable state.
+- Repository identity conflicts and malformed SHAs continue to fail closed.
+- TavernKeeper continues treating checked-out repositories as untrusted data and does not execute target dependencies, scripts, builds, tests, Actions, or executables.
+- Existing bounded retries, failure-domain isolation, exact-SHA report identity, and advisory, not guarantee, language remain unchanged.
+
+## Verification
+
+Regression coverage must prove:
+
+- A healthy preset-only GitHub source appears in the V3 target manifest with `project_kinds: ["preset"]` and its existing popularity rank.
+- A GitHub-backed preset follows gray, assessed, stale, and unavailable card states instead of unsupported state.
+- Non-GitHub sources remain unsupported.
+- The staff resolver accepts a published preset repository and still rejects unsupported source types, inactive sources, unregistered repositories, and unauthorized operators.
+- Existing extension/frontend behavior remains unchanged.
+- The generated production target manifest contains every currently active, healthy, exact-SHA GitHub preset repository.
+
+Focused unit tests run first through a red-green cycle. Tavernary's complete `npm.cmd run check` gate and static-export verification run before publication. After merge, the exact merged SHA, Pages deployment, deployed target manifest, TavernKeeper reconciliation, and eventual imported preset assessment state are verified through the existing production workflow.
+
+## Out of Scope
+
+- Scanning arbitrary preset download URLs, Reddit posts, Codeberg repositories, or GitHub organization pages.
+- Limiting scans to files believed to be preset artifacts.
+- Adding preset-specific risk rules or changing TavernKeeper's assessment model.
+- Changing catalog ranking, report presentation, moderation, or listing visibility.

--- a/docs/tavernkeeper-integration.md
+++ b/docs/tavernkeeper-integration.md
@@ -28,7 +28,7 @@ Risk and freshness are independent:
 - Red is a `high` final risk: credible malicious behavior or a critical,
   high-confidence, readily exploitable vulnerability.
 - Gray means an eligible source has no complete final V5 assessment.
-- Dark teal identifies presets and source types TavernKeeper does not support.
+- Dark teal identifies source types TavernKeeper does not support.
 
 A stale assessment keeps its risk color and receives a separate clock marker.
 Stale teal remains teal, stale orange remains orange, and stale red remains
@@ -51,17 +51,20 @@ Results never hide, delist, quarantine, rank, or otherwise moderate a listing.
 
 ## Public contracts and evidence binding
 
-Tavernary publishes its unchanged schema-version-2 target manifest at
+Tavernary publishes its schema-version-3 target manifest at
 `https://tavernary.org/security/tavernkeeper-targets.json`. The checked-in
 schema is
-[`data/schemas/tavernkeeper-targets.v2.schema.json`](../data/schemas/tavernkeeper-targets.v2.schema.json).
+[`data/schemas/tavernkeeper-targets.v3.schema.json`](../data/schemas/tavernkeeper-targets.v3.schema.json).
 It contains only active, healthy public GitHub sources with a positive immutable
 repository ID and a lowercase 40-character target SHA. It contains no command,
 clone URL, branch, scan mode, token budget, or requester-controlled workflow
 parameter.
 
-Eligibility is limited to published extension and frontend cards. Preset-only
-sources are omitted even when their files are hosted on GitHub.
+Eligibility includes published extension, frontend, and preset cards backed by
+a single GitHub repository. TavernKeeper scans the entire exact-SHA repository
+for every eligible kind. Non-GitHub URLs, Codeberg sources, and GitHub
+organization pages without one immutable repository identity remain
+unsupported.
 
 Tavernary accepts only TavernKeeper Preferred Index V5 and Technical Report V5:
 

--- a/docs/tavernkeeper-live-acceptance.md
+++ b/docs/tavernkeeper-live-acceptance.md
@@ -1,5 +1,11 @@
 # TavernKeeper contextual V5 live acceptance
 
+> **Policy supersession (2026-08-04):** This document is a historical record of
+> the first contextual V5 canaries. Its preset exclusion was superseded by the
+> [GitHub preset eligibility design](superpowers/specs/2026-08-04-github-preset-tavernkeeper-eligibility-design.md).
+> Published presets backed by a healthy exact-SHA GitHub repository now use the
+> same full-repository scan pipeline as extensions and frontends.
+
 This record captures the first two complete production canaries for the
 contextual V5 pipeline. Both scans used the ordinary staff-targeted handshake:
 Tavernary refreshed an exact catalog source, TavernKeeper scanned the immutable

--- a/scripts/catalog/build.mjs
+++ b/scripts/catalog/build.mjs
@@ -425,7 +425,6 @@ export async function buildCatalog(options = {}) {
     const source = registry.sourcesById.get(record.source_id);
     const snapshot = snapshotsBySource.get(record.source_id);
     const tavernKeeper = deriveTavernKeeperCardStatus({
-      projectKind: record.kind,
       source,
       snapshot,
       assessedReports: assessedTavernKeeperReports,

--- a/scripts/security/resolve-tavernkeeper-scan-request.mjs
+++ b/scripts/security/resolve-tavernkeeper-scan-request.mjs
@@ -5,7 +5,6 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { canonicalSourceUrl } from "../../src/features/catalog/source-record.mjs";
 
 const rootDirectory = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
-const supportedProjectKinds = new Set(["extension", "frontend"]);
 
 async function readJson(path) {
   return JSON.parse(await readFile(resolve(rootDirectory, path), "utf8"));
@@ -45,11 +44,7 @@ export function resolveScanRequest({
   const repositoryUrl = canonicalGitHubRepositoryUrl(repositoryUrlInput);
   const publishedSourceIds = new Set(
     projects
-      .filter(
-        (project) =>
-          project.listing_status === "active" &&
-          supportedProjectKinds.has(project.kind),
-      )
+      .filter((project) => project.listing_status === "active")
       .map((project) => project.source_id),
   );
   const source = sources.find(

--- a/scripts/security/tavernkeeper-targets.mjs
+++ b/scripts/security/tavernkeeper-targets.mjs
@@ -11,7 +11,6 @@ const defaultOutputPath = resolve(
 );
 const fullShaPattern = /^[0-9a-f]{40}$/u;
 const validProjectKinds = new Set(["extension", "frontend", "preset"]);
-const supportedProjectKinds = new Set(["extension", "frontend"]);
 const collator = new Intl.Collator("en", { sensitivity: "base" });
 
 function validateContractVersion(value) {
@@ -61,7 +60,6 @@ function metadataBySource(
       !validProjectKinds.has(project.kind)
     )
       throw new Error("Published TavernKeeper project metadata is invalid.");
-    if (!supportedProjectKinds.has(project.kind)) continue;
     const catalogedAt = new Date(project.cataloged_at);
     if (!Number.isFinite(catalogedAt.getTime()))
       throw new Error("Published TavernKeeper catalog date is invalid.");

--- a/src/features/catalog/tavernkeeper-status.ts
+++ b/src/features/catalog/tavernkeeper-status.ts
@@ -199,19 +199,17 @@ function unsupportedStatus(): TavernKeeperCardStatus {
 }
 
 export function deriveTavernKeeperCardStatus({
-  projectKind,
   source,
   snapshot,
   assessedReports,
   preferredReportIds,
 }: {
-  projectKind?: string;
   source: TavernKeeperSource | null | undefined;
   snapshot: TavernKeeperSnapshot | null | undefined;
   assessedReports: readonly TavernKeeperAssessedReport[];
   preferredReportIds: readonly string[];
 }): TavernKeeperCardStatus {
-  if (projectKind === "preset" || !isActiveGithubSource(source)) {
+  if (!isActiveGithubSource(source)) {
     return unsupportedStatus();
   }
 

--- a/tests/unit/build-catalog.test.ts
+++ b/tests/unit/build-catalog.test.ts
@@ -372,8 +372,10 @@ test("builds sibling extension and preset cards from one source snapshot", async
     ],
   });
   expect(catalog.projects[1].tavernKeeper).toMatchObject({
-    state: "unsupported",
-    freshness: "unsupported",
+    state: "teal",
+    riskLevel: "low",
+    freshness: "current",
+    report: expect.objectContaining({ scannedSha: "a".repeat(40) }),
   });
   expect(catalog.schemaVersion).toBe(6);
   expect(

--- a/tests/unit/resolve-tavernkeeper-scan-request.test.ts
+++ b/tests/unit/resolve-tavernkeeper-scan-request.test.ts
@@ -40,6 +40,16 @@ describe("staff TavernKeeper scan request resolution", () => {
     });
   });
 
+  test("accepts a published preset repository", () => {
+    expect(
+      resolve({ projects: [{ ...recursionProject, kind: "preset" }] }),
+    ).toEqual({
+      sourceId: recursionSource.id,
+      repositoryId: recursionSource.repository_id,
+      repositoryUrl: "https://github.com/MentallyQuill/Recursion",
+    });
+  });
+
   test.each([
     "https://github.com/MentallyQuill/Recursion/",
     "https://github.com/MentallyQuill/Recursion.git",
@@ -71,11 +81,6 @@ describe("staff TavernKeeper scan request resolution", () => {
       resolve({ sources: [{ ...recursionSource, status: "inactive" }] }),
     ).toThrow(/published Tavernary/iu);
     expect(() => resolve({ projects: [] })).toThrow(/published Tavernary/iu);
-    expect(() =>
-      resolve({
-        projects: [{ ...recursionProject, kind: "preset" }],
-      }),
-    ).toThrow(/published Tavernary/iu);
   });
 
   test("tracks only sorted unique positive numeric operator IDs", async () => {

--- a/tests/unit/tavernkeeper-status.test.ts
+++ b/tests/unit/tavernkeeper-status.test.ts
@@ -141,28 +141,23 @@ describe("deriveTavernKeeperCardStatus", () => {
     });
   });
 
-  test("returns the super-dark unsupported state for presets and non-GitHub sources", () => {
-    for (const input of [
-      { projectKind: "preset", source },
-      { source: { ...source, type: "codeberg" } },
-    ]) {
-      expect(
-        deriveTavernKeeperCardStatus({
-          ...input,
-          snapshot,
-          assessedReports: [report()],
-          preferredReportIds: [report().report_id],
-        }),
-      ).toEqual({
-        state: "unsupported",
-        riskLevel: null,
-        freshness: "unsupported",
-        currentSha: null,
-        report: null,
-        history: [],
-        historyUrl: null,
-      });
-    }
+  test("returns the super-dark unsupported state for non-GitHub sources", () => {
+    expect(
+      deriveTavernKeeperCardStatus({
+        source: { ...source, type: "codeberg" },
+        snapshot,
+        assessedReports: [report()],
+        preferredReportIds: [report().report_id],
+      }),
+    ).toEqual({
+      state: "unsupported",
+      riskLevel: null,
+      freshness: "unsupported",
+      currentSha: null,
+      report: null,
+      history: [],
+      historyUrl: null,
+    });
   });
 
   test("matches report identity and the active scanner policy", () => {

--- a/tests/unit/tavernkeeper-targets.test.ts
+++ b/tests/unit/tavernkeeper-targets.test.ts
@@ -202,7 +202,7 @@ describe("TavernKeeper target manifest", () => {
       repositories: [
         { repository_id: 100, catalog_priority: { popularity_rank: 4 } },
         { repository_id: 200, catalog_priority: { popularity_rank: 3 } },
-        { repository_id: 300, catalog_priority: { popularity_rank: 2 } },
+        { repository_id: 300, catalog_priority: { popularity_rank: 1 } },
       ],
     });
   });
@@ -258,7 +258,7 @@ describe("TavernKeeper target manifest", () => {
     ]);
   });
 
-  test("publishes V2 metadata only from supported cards sharing a GitHub source", () => {
+  test("publishes V2 metadata from every card sharing a GitHub source", () => {
     const manifest = buildTargets({
       contractVersion: 2,
       generatedAt,
@@ -293,19 +293,19 @@ describe("TavernKeeper target manifest", () => {
           repository: "owner/repo",
           target_sha: "a".repeat(40),
           canonical_url: "https://github.com/owner/repo",
-          project_kinds: ["extension"],
+          project_kinds: ["extension", "preset"],
           catalog_priority: {
             top_30: true,
-            first_cataloged_at: "2026-07-02T00:00:00.000Z",
+            first_cataloged_at: "2026-07-01T00:00:00.000Z",
           },
         },
       ],
     });
   });
 
-  test("omits sources published only as unsupported presets", () => {
+  test("publishes preset-only GitHub sources with their V3 priority", () => {
     const manifest = buildTargets({
-      contractVersion: 2,
+      contractVersion: 3,
       generatedAt,
       publishedSourceIds: new Set(["github-42"]),
       sources: [source("github-42", 42, "owner/preset")],
@@ -318,10 +318,26 @@ describe("TavernKeeper target manifest", () => {
           cataloged_at: "2026-07-01T00:00:00.000Z",
         },
       ],
+      rankedProjectIds: ["preset-card"],
       topProjectIds: new Set(["preset-card"]),
     });
 
-    expect(manifest.repositories).toEqual([]);
+    expect(manifest.repositories).toEqual([
+      {
+        source_id: "github-42",
+        provider: "github",
+        repository_id: 42,
+        repository: "owner/preset",
+        target_sha: "a".repeat(40),
+        canonical_url: "https://github.com/owner/preset",
+        project_kinds: ["preset"],
+        catalog_priority: {
+          top_30: true,
+          first_cataloged_at: "2026-07-01T00:00:00.000Z",
+          popularity_rank: 1,
+        },
+      },
+    ]);
   });
 
   test("requires an explicit supported contract version", () => {


### PR DESCRIPTION
## Summary
- make TavernKeeper eligibility depend on active, healthy, exact-SHA GitHub repository identity instead of project kind
- publish preset-only repositories and include preset cards in shared repository metadata/ranking
- project preset cards through normal unassessed, assessed, stale, and unavailable states
- allow protected staff-targeted scans for published preset repositories
- document the superseding source-based security policy

## Security rationale
Preset repositories can contain dangerous links, prompt instructions, executable examples, regex scripts, helper code, and other security-relevant material. TavernKeeper scans the entire immutable repository exactly as it does for extensions and frontends.

## Verification
- Red-green regression cycles for target manifest, card state, and targeted scan resolution
- Focused: 4 files, 59 tests passed
- Full check: formatting, lint, palette audit, catalog validation, security validation, typecheck, 211 files / 2,310 tests, production build, and static export passed
- Generated V3 manifest: 316 repositories; all 6 eligible GitHub preset repositories present at matching exact SHAs; 0 unsupported eligible preset cards

## Post-merge proof
Verify the exact merged SHA deployment, fresh public V3 target manifest, and TavernKeeper reconciliation intake. Completed preset assessments are not claimed until reports publish and Tavernary imports them.