### PR TITLE
Preserve required citations during synthesis repair

### DIFF
--- a/scripts/security/tavernkeeper-assessment-contract.mjs
+++ b/scripts/security/tavernkeeper-assessment-contract.mjs
@@ -252,6 +252,7 @@ function repairFor(requirements, extra = {}) {
   return {
     ...extra,
     allowed_candidate_ids: requirements.allowed_candidate_ids,
+    required_candidate_ids: requirements.required_candidate_ids,
     required_counts: requirements.required_counts,
     evidence_floor: requirements.evidence_floor,
   };

--- a/tests/unit/tavernkeeper-synthesis.test.ts
+++ b/tests/unit/tavernkeeper-synthesis.test.ts
@@ -384,16 +384,22 @@ describe("Tavernary final assessment contract", () => {
   });
 
   test("rejects escalation beyond the floor without a cited interaction chain", () => {
+    const report = reportWith([assessment({ disposition: "minor_weakness" })]);
     expect(
       validationFailure(() =>
         validateTavernaryAssessment(
-          lowOutput({ risk_level: "material" }),
-          reportWith([]),
+          lowOutput({
+            risk_level: "material",
+            minor_cautions: 1,
+            cited_finding_ids: [candidateId],
+          }),
+          report,
         ),
       ),
     ).toMatchObject({
       diagnostic: "unsupported_escalation",
       repair: {
+        required_candidate_ids: [candidateId],
         evidence_floor: "low",
         rejected_risk_level: "material",
         required_risk_level: "low",


### PR DESCRIPTION
## Summary

- include the full required candidate ID set in every TavernKeeper synthesis repair payload
- cover unsupported-escalation repair with a material cited finding

## Production evidence

- targeted retry for issue #265 corrected risk but then failed with missing_candidate_ids

## Verification

- npm run check
- 211 test files and 2310 tests passed
- production static build and export verification passed