### PR TITLE
Distinguish immediate-danger TavernKeeper advisories

### DIFF
--- a/.github/workflows/import-tavernkeeper-reports.yml
+++ b/.github/workflows/import-tavernkeeper-reports.yml
@@ -76,7 +76,7 @@ jobs:
           printf 'remaining=%s\n' "$remaining" >> "$GITHUB_OUTPUT"
           printf 'created_or_updated=%s\n' "$created_or_updated" >> "$GITHUB_OUTPUT"
           printf 'resolved=%s\n' "$resolved" >> "$GITHUB_OUTPUT"
-          printf '## TavernKeeper report import\n\n- Imported: %s\n- Retained: %s\n- Quarantined: %s\n- Skipped quarantines: %s\n- Remaining: %s\n' \
+          printf '## TavernKeeper report import\n\n- Imported: %s\n- Retained: %s\n- Narrative fallbacks: %s\n- Skipped fallback retries: %s\n- Remaining: %s\n' \
             "$imported" "$retained" "$quarantined" "$skipped_quarantines" "$remaining" >> "$GITHUB_STEP_SUMMARY"
       - name: Validate imported summaries
         run: npm run check
@@ -127,7 +127,7 @@ jobs:
           RESOLVED: ${{ steps.import.outputs.resolved }}
         shell: bash
         run: |
-          gh label create tavernkeeper-import --color B60205 --description "TavernKeeper report import quarantine" --force
+          gh label create tavernkeeper-import --color B60205 --description "TavernKeeper narrative enrichment fallback" --force
 
           jq -c '.[]' <<< "$CREATED_OR_UPDATED" | while read -r incident; do
             incident_key="$(jq -r '.incident_key' <<< "$incident")"
@@ -146,15 +146,15 @@ jobs:
             if [[ -z "$existing" ]]; then
               gh issue create \
                 --label tavernkeeper-import \
-                --title "[tavernkeeper-import] report synthesis quarantined" \
-                --body "Tavernary rejected bounded structured synthesis output for one immutable report.\n\nReport incident key: \`$incident_key\`\nRepository: \`$repository\`\nRepository ID: \`$repository_id\`\nTarget commit: \`$target_sha\`\nReport digest: \`$report_digest\`\nSynthesis policy: \`$policy\`\nDiagnostic: \`$diagnostic\`\nAttempts: \`$attempts\`\nRun: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\n\nOther valid reports continue importing."
+                --title "[tavernkeeper-import] narrative enrichment fallback" \
+                --body "Tavernary published a deterministic assessment because optional narrative enrichment failed for one immutable report.\n\nReport incident key: \`$incident_key\`\nRepository: \`$repository\`\nRepository ID: \`$repository_id\`\nTarget commit: \`$target_sha\`\nReport digest: \`$report_digest\`\nSynthesis policy: \`$policy\`\nDiagnostic: \`$diagnostic\`\nAttempts: \`$attempts\`\nRun: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\n\nThe validated report remains published with policy-owned fallback copy."
             else
               number="$(jq -r '.number' <<< "$existing")"
               state="$(jq -r '.state' <<< "$existing")"
               if [[ "$state" == "CLOSED" ]]; then
-                gh issue reopen "$number" --comment "The exact report-policy quarantine recurred on run $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID."
+                gh issue reopen "$number" --comment "The exact narrative enrichment fallback recurred on run $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID."
               else
-                gh issue comment "$number" --body "The explicit retry remained invalid at attempt $attempts on run $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID."
+                gh issue comment "$number" --body "The explicit narrative retry still used fallback at attempt $attempts on run $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID."
               fi
             fi
           done
@@ -167,7 +167,7 @@ jobs:
               | .[0].number // empty
             ' <<< "$issues")"
             if [[ -n "$number" ]]; then
-              gh issue close "$number" --comment "This exact report-policy quarantine is no longer active."
+              gh issue close "$number" --comment "This exact narrative enrichment fallback is no longer active."
             fi
           done
 

--- a/data/security/tavernkeeper-report-summaries.json
+++ b/data/security/tavernkeeper-report-summaries.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 5,
+  "schema_version": 6,
   "generated_at": "2026-08-05T04:39:53.430Z",
   "preferred_report_ids": [
     "4efc45df08f6177f4a0a910e33d8cf1cfeb2ba000fd91ebf161bb6983e378244",
@@ -252,6 +252,8 @@
       "assessed_at": "2026-08-04T22:35:23.338Z",
       "synthesis_policy_version": "2",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -333,6 +335,8 @@
       "assessed_at": "2026-08-04T22:35:25.921Z",
       "synthesis_policy_version": "2",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No significant security concerns identified",
@@ -414,6 +418,8 @@
       "assessed_at": "2026-08-05T00:58:42.937Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -495,6 +501,8 @@
       "assessed_at": "2026-08-05T00:45:25.813Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -576,6 +584,8 @@
       "assessed_at": "2026-08-05T01:05:19.589Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -657,6 +667,8 @@
       "assessed_at": "2026-08-05T01:05:25.934Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -738,6 +750,8 @@
       "assessed_at": "2026-08-05T01:11:22.057Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "Low risk: no concerning behavior was validated",
@@ -819,6 +833,8 @@
       "assessed_at": "2026-08-05T01:30:45.427Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -900,6 +916,8 @@
       "assessed_at": "2026-08-05T01:43:41.344Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -981,6 +999,8 @@
       "assessed_at": "2026-08-05T01:24:23.828Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -1062,6 +1082,8 @@
       "assessed_at": "2026-08-05T03:09:31.220Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -1143,6 +1165,8 @@
       "assessed_at": "2026-08-05T03:37:50.490Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -1224,6 +1248,8 @@
       "assessed_at": "2026-08-05T00:58:52.220Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "Low risk: customization code execution is an expected feature",
@@ -1305,6 +1331,8 @@
       "assessed_at": "2026-08-05T02:56:25.714Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -1386,6 +1414,8 @@
       "assessed_at": "2026-08-05T02:43:21.047Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -1467,6 +1497,8 @@
       "assessed_at": "2026-08-05T03:49:59.206Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -1548,6 +1580,8 @@
       "assessed_at": "2026-08-05T03:03:35.102Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -1629,6 +1663,8 @@
       "assessed_at": "2026-08-05T03:57:43.811Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [
           "05501171f0f514cddceea5229fc07e4ec526376d9a644453594e87c21d5e5136",
@@ -1735,6 +1771,8 @@
       "assessed_at": "2026-08-05T01:11:36.476Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [
           "0a8447d0767a1afb00c05158daed5d8e6638693dc34080464e5c3b5c06bee959",
@@ -1847,6 +1885,8 @@
       "assessed_at": "2026-08-05T01:11:44.722Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [
           "0a8447d0767a1afb00c05158daed5d8e6638693dc34080464e5c3b5c06bee959",
@@ -1961,6 +2001,8 @@
       "assessed_at": "2026-08-05T04:05:26.221Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [
           "01782d1baf8020f9ffbec8a5c3e1ce3ca7b669ddea807036d4abf0d1b206dc1f",
@@ -2079,6 +2121,8 @@
       "assessed_at": "2026-08-05T02:09:59.559Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [
           "0397056563b1b7873056136a413c67c2a2d3235db1db74ea738dba1d83819202",
@@ -2184,6 +2228,8 @@
       "assessed_at": "2026-08-05T02:36:43.682Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "Low risk: calculator behavior was reviewed and appears safe",
@@ -2265,6 +2311,8 @@
       "assessed_at": "2026-08-05T03:09:20.151Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [
           "2394af6d0f052a1d5e6f0aed531b4e504e143d94e17bb4e6d8824159946161be",
@@ -2356,6 +2404,8 @@
       "assessed_at": "2026-08-05T03:03:28.833Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [
           "0744177ad4162c332c77ad80404ee28ef29fd946aafb89a8781a936025f217fb",
@@ -2447,6 +2497,8 @@
       "assessed_at": "2026-08-05T01:43:44.141Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "Low risk: customizable template logic behaves as expected",
@@ -2528,6 +2580,8 @@
       "assessed_at": "2026-08-05T01:05:23.443Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -2609,6 +2663,8 @@
       "assessed_at": "2026-08-05T00:34:17.442Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -2690,6 +2746,8 @@
       "assessed_at": "2026-08-05T01:24:35.558Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -2771,6 +2829,8 @@
       "assessed_at": "2026-08-05T03:57:53.506Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [
           "72484c6e8e8d51696e42a5038b454c513da346f79ef557f0c24db3eefd2e68f3",
@@ -2858,6 +2918,8 @@
       "assessed_at": "2026-08-05T00:51:46.176Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -2939,6 +3001,8 @@
       "assessed_at": "2026-08-05T00:51:43.628Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -3020,6 +3084,8 @@
       "assessed_at": "2026-08-05T00:51:38.818Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -3101,6 +3167,8 @@
       "assessed_at": "2026-08-05T03:09:26.429Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [
           "2aab7bfb162eff8229dd95e8abb8e7c21e45f3348f8acd84856b28d523c599ac",
@@ -3185,6 +3253,8 @@
       "assessed_at": "2026-08-05T01:50:23.094Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -3266,6 +3336,8 @@
       "assessed_at": "2026-08-05T01:56:48.823Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No security concern identified",
@@ -3347,6 +3419,8 @@
       "assessed_at": "2026-08-04T22:41:42.365Z",
       "synthesis_policy_version": "2",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [
           "000192e612cc3de4282c7ab587838f715e41e6a9fd303f20f2d003cd38648159",
@@ -3438,6 +3512,8 @@
       "assessed_at": "2026-08-05T01:05:17.620Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -3519,6 +3595,8 @@
       "assessed_at": "2026-08-04T22:35:20.457Z",
       "synthesis_policy_version": "2",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [
           "0397056563b1b7873056136a413c67c2a2d3235db1db74ea738dba1d83819202",
@@ -3624,6 +3702,8 @@
       "assessed_at": "2026-08-05T01:24:32.818Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -3705,6 +3785,8 @@
       "assessed_at": "2026-08-05T00:40:46.775Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -3786,6 +3868,8 @@
       "assessed_at": "2026-08-05T01:17:52.284Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -3867,6 +3951,8 @@
       "assessed_at": "2026-08-05T00:58:49.057Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [
           "1125c7c351b6452dc82bd60edab80d47f285b41e36387ea38be90749ad23d0ae",
@@ -3953,6 +4039,8 @@
       "assessed_at": "2026-08-05T01:30:38.023Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -4034,6 +4122,8 @@
       "assessed_at": "2026-08-05T03:44:10.907Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [
           "608d05f7bbb5bec7376152cfb28270280567a165764a5fa3c9527414e710e1f0",
@@ -4122,6 +4212,8 @@
       "assessed_at": "2026-08-05T01:05:21.539Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -4203,6 +4295,8 @@
       "assessed_at": "2026-08-05T00:40:49.451Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -4284,6 +4378,8 @@
       "assessed_at": "2026-08-05T00:45:15.350Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -4365,6 +4461,8 @@
       "assessed_at": "2026-08-05T00:58:45.497Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -4446,6 +4544,8 @@
       "assessed_at": "2026-08-05T03:37:45.248Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -4527,6 +4627,8 @@
       "assessed_at": "2026-08-05T01:36:55.527Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No meaningful security concerns identified",
@@ -4608,6 +4710,8 @@
       "assessed_at": "2026-08-05T02:36:35.654Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -4689,6 +4793,8 @@
       "assessed_at": "2026-08-05T01:50:27.698Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -4770,6 +4876,8 @@
       "assessed_at": "2026-08-05T02:09:47.205Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -4851,6 +4959,8 @@
       "assessed_at": "2026-08-05T00:40:43.867Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -4932,6 +5042,8 @@
       "assessed_at": "2026-08-05T02:49:43.520Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [
           "0cc4b32c220080cd7520532c8a9d2c6777f0cf70410346b1c9d2890889688a97",
@@ -5023,6 +5135,8 @@
       "assessed_at": "2026-08-05T01:36:50.642Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -5104,6 +5218,8 @@
       "assessed_at": "2026-08-05T00:40:54.310Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -5185,6 +5301,8 @@
       "assessed_at": "2026-08-05T02:03:18.632Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -5266,6 +5384,8 @@
       "assessed_at": "2026-08-05T02:16:33.839Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -5347,6 +5467,8 @@
       "assessed_at": "2026-08-05T02:50:01.807Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns were identified",
@@ -5428,6 +5550,8 @@
       "assessed_at": "2026-08-05T00:34:22.819Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -5509,6 +5633,8 @@
       "assessed_at": "2026-08-05T02:50:05.816Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "Low risk: no security concerns identified",
@@ -5590,6 +5716,8 @@
       "assessed_at": "2026-08-05T01:30:40.179Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -5671,6 +5799,8 @@
       "assessed_at": "2026-08-05T01:11:26.170Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -5752,6 +5882,8 @@
       "assessed_at": "2026-08-05T01:56:53.697Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -5833,6 +5965,8 @@
       "assessed_at": "2026-08-05T00:45:22.983Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -5914,6 +6048,8 @@
       "assessed_at": "2026-08-05T02:23:29.760Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -5995,6 +6131,8 @@
       "assessed_at": "2026-08-05T01:56:46.145Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -6076,6 +6214,8 @@
       "assessed_at": "2026-08-05T02:56:35.134Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -6157,6 +6297,8 @@
       "assessed_at": "2026-08-05T01:43:38.968Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -6238,6 +6380,8 @@
       "assessed_at": "2026-08-05T00:34:15.131Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -6319,6 +6463,8 @@
       "assessed_at": "2026-08-05T01:30:35.791Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -6400,6 +6546,8 @@
       "assessed_at": "2026-08-05T03:44:02.188Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -6481,6 +6629,8 @@
       "assessed_at": "2026-08-05T01:17:57.777Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns were identified",
@@ -6562,6 +6712,8 @@
       "assessed_at": "2026-08-05T02:56:30.394Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -6643,6 +6795,8 @@
       "assessed_at": "2026-08-04T22:35:32.958Z",
       "synthesis_policy_version": "2",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [
           "0f3e794a795b7e5c87ae810d2813f08e11aa0d0ebce30ef298bbe5a5c0eb6f2b",
@@ -6742,6 +6896,8 @@
       "assessed_at": "2026-08-04T22:41:44.966Z",
       "synthesis_policy_version": "2",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -6823,6 +6979,8 @@
       "assessed_at": "2026-08-05T00:51:48.499Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -6904,6 +7062,8 @@
       "assessed_at": "2026-08-05T02:56:28.052Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -6985,6 +7145,8 @@
       "assessed_at": "2026-08-05T00:40:51.969Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -7066,6 +7228,8 @@
       "assessed_at": "2026-08-05T00:45:28.254Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -7147,6 +7311,8 @@
       "assessed_at": "2026-08-05T00:45:20.728Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [
           "0b57f46e6a48a2af0fd147370c4d36cad8be2bb73f629c751f7c54b0bb8b04a3",
@@ -7241,6 +7407,8 @@
       "assessed_at": "2026-08-05T01:24:30.758Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -7322,6 +7490,8 @@
       "assessed_at": "2026-08-05T02:36:46.240Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns were identified",
@@ -7403,6 +7573,8 @@
       "assessed_at": "2026-08-05T01:11:28.736Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns were identified",
@@ -7484,6 +7656,8 @@
       "assessed_at": "2026-08-05T02:49:33.289Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -7565,6 +7739,8 @@
       "assessed_at": "2026-08-05T04:05:35.235Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -7646,6 +7822,8 @@
       "assessed_at": "2026-08-05T02:09:52.187Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -7727,6 +7905,8 @@
       "assessed_at": "2026-08-05T02:43:26.542Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -7808,6 +7988,8 @@
       "assessed_at": "2026-08-05T02:02:47.409Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -7889,6 +8071,8 @@
       "assessed_at": "2026-08-05T03:03:38.162Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -7970,6 +8154,8 @@
       "assessed_at": "2026-08-05T02:02:50.176Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -8051,6 +8237,8 @@
       "assessed_at": "2026-08-05T04:43:27.053Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -8132,6 +8320,8 @@
       "assessed_at": "2026-08-05T04:25:10.748Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -8213,6 +8403,8 @@
       "assessed_at": "2026-08-05T00:51:41.047Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -8294,6 +8486,8 @@
       "assessed_at": "2026-08-05T01:24:28.391Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [
           "4710183c6d2e1e2b8b866180e7f50e50edf9f10e892a3dacce12fffb651ef1a4",
@@ -8390,6 +8584,8 @@
       "assessed_at": "2026-08-05T02:16:36.901Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -8471,6 +8667,8 @@
       "assessed_at": "2026-08-05T01:36:48.510Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [
           "1125c7c351b6452dc82bd60edab80d47f285b41e36387ea38be90749ad23d0ae",
@@ -8557,6 +8755,8 @@
       "assessed_at": "2026-08-05T00:34:19.898Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -8638,6 +8838,8 @@
       "assessed_at": "2026-08-05T02:30:14.863Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns were identified",
@@ -8719,6 +8921,8 @@
       "assessed_at": "2026-08-05T03:03:22.108Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns were identified",
@@ -8800,6 +9004,8 @@
       "assessed_at": "2026-08-05T02:43:28.963Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -8881,6 +9087,8 @@
       "assessed_at": "2026-08-04T22:48:15.148Z",
       "synthesis_policy_version": "2",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -8962,6 +9170,8 @@
       "assessed_at": "2026-08-05T03:31:33.364Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns were identified",
@@ -9043,6 +9253,8 @@
       "assessed_at": "2026-08-04T22:53:27.370Z",
       "synthesis_policy_version": "2",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -9124,6 +9336,8 @@
       "assessed_at": "2026-08-05T02:16:31.300Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -9205,6 +9419,8 @@
       "assessed_at": "2026-08-05T02:30:34.334Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -9286,6 +9502,8 @@
       "assessed_at": "2026-08-05T04:13:51.376Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -9367,6 +9585,8 @@
       "assessed_at": "2026-08-05T03:03:19.541Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [
           "47ac09260dcb257fb2e745b6c36e48ae7eaa7e19aad18151cc1e66ab3b4470ad",
@@ -9451,6 +9671,8 @@
       "assessed_at": "2026-08-05T03:31:23.423Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -9532,6 +9754,8 @@
       "assessed_at": "2026-08-05T03:09:28.684Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -9613,6 +9837,8 @@
       "assessed_at": "2026-08-05T03:37:40.935Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -9694,6 +9920,8 @@
       "assessed_at": "2026-08-05T02:30:31.425Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [
           "010d9a8ee67bb15dcce292d009f91ddacfbfb62dda24d9b017f6d794f02fc5dd",
@@ -9814,6 +10042,8 @@
       "assessed_at": "2026-08-05T01:30:42.486Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -9895,6 +10125,8 @@
       "assessed_at": "2026-08-05T01:50:30.066Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -9976,6 +10208,8 @@
       "assessed_at": "2026-08-05T02:36:40.690Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -10057,6 +10291,8 @@
       "assessed_at": "2026-08-04T23:04:55.357Z",
       "synthesis_policy_version": "2",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -10138,6 +10374,8 @@
       "assessed_at": "2026-08-05T02:16:42.522Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [
           "1cb4e63e88efd74db7aa42a81ab3ff2c708f88d6aede33bc8b16b77029f7114d",
@@ -10222,6 +10460,8 @@
       "assessed_at": "2026-08-05T01:56:44.117Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -10303,6 +10543,8 @@
       "assessed_at": "2026-08-05T02:03:21.135Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -10384,6 +10626,8 @@
       "assessed_at": "2026-08-05T01:18:00.166Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -10465,6 +10709,8 @@
       "assessed_at": "2026-08-05T00:58:40.140Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -10546,6 +10792,8 @@
       "assessed_at": "2026-08-04T23:17:23.377Z",
       "synthesis_policy_version": "2",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -10627,6 +10875,8 @@
       "assessed_at": "2026-08-05T02:36:37.854Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -10708,6 +10958,8 @@
       "assessed_at": "2026-08-04T23:17:25.570Z",
       "synthesis_policy_version": "2",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -10789,6 +11041,8 @@
       "assessed_at": "2026-08-05T03:37:42.976Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -10870,6 +11124,8 @@
       "assessed_at": "2026-08-04T23:17:21.128Z",
       "synthesis_policy_version": "2",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [
           "3ffb97ca2c16dd5255a173f1c529aa683f282e4386c2b3932b4039853b679e55",
@@ -10955,6 +11211,8 @@
       "assessed_at": "2026-08-05T03:44:04.900Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -11036,6 +11294,8 @@
       "assessed_at": "2026-08-05T03:49:56.644Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -11117,6 +11377,8 @@
       "assessed_at": "2026-08-05T01:36:58.137Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -11198,6 +11460,8 @@
       "assessed_at": "2026-08-05T01:17:55.014Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -11279,6 +11543,8 @@
       "assessed_at": "2026-08-05T04:36:56.361Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [
           "28ee3138d3d8994ad41b170ee691b8035a20cb6b3f8d6d3272d972131596b848",
@@ -11364,6 +11630,8 @@
       "assessed_at": "2026-08-04T23:23:53.709Z",
       "synthesis_policy_version": "2",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "Low risk: flagged code is limited to self-contained tests",
@@ -11445,6 +11713,8 @@
       "assessed_at": "2026-08-04T23:30:21.353Z",
       "synthesis_policy_version": "2",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -11526,6 +11796,8 @@
       "assessed_at": "2026-08-04T23:30:16.989Z",
       "synthesis_policy_version": "2",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [
           "cd8865121e6cdd7a7ba8570b5a1bec9536028900063e0494c731825e64e47e21"
@@ -11609,6 +11881,8 @@
       "assessed_at": "2026-08-04T23:30:19.156Z",
       "synthesis_policy_version": "2",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -11690,6 +11964,8 @@
       "assessed_at": "2026-08-05T03:50:03.618Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [
           "11cc889293f4562ffcfffa043f2010370c2ddbad4e92355f3a422817edd47e0e",
@@ -11780,6 +12056,8 @@
       "assessed_at": "2026-08-04T23:36:12.857Z",
       "synthesis_policy_version": "2",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -11861,6 +12139,8 @@
       "assessed_at": "2026-08-05T02:49:58.036Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [
           "08633dadb41ec10441cbc0c27a7a375a6249210cceefc9c3e3444e9def7548a4",
@@ -11953,6 +12233,8 @@
       "assessed_at": "2026-08-05T03:31:25.711Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns were identified",
@@ -12034,6 +12316,8 @@
       "assessed_at": "2026-08-05T02:09:49.799Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -12115,6 +12399,8 @@
       "assessed_at": "2026-08-04T23:49:48.681Z",
       "synthesis_policy_version": "2",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -12196,6 +12482,8 @@
       "assessed_at": "2026-08-05T01:50:20.763Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [
           "18d989f265aef2f7b6dacd369934bea8b9edb7ffe2636827c95cabecad33ee6a",
@@ -12281,6 +12569,8 @@
       "assessed_at": "2026-08-04T23:49:44.114Z",
       "synthesis_policy_version": "2",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -12362,6 +12652,8 @@
       "assessed_at": "2026-08-04T23:49:46.939Z",
       "synthesis_policy_version": "2",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -12443,6 +12735,8 @@
       "assessed_at": "2026-08-04T23:59:43.575Z",
       "synthesis_policy_version": "2",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -12524,6 +12818,8 @@
       "assessed_at": "2026-08-05T04:05:30.459Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -12605,6 +12901,8 @@
       "assessed_at": "2026-08-05T02:23:25.440Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -12686,6 +12984,8 @@
       "assessed_at": "2026-08-05T00:05:57.527Z",
       "synthesis_policy_version": "2",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -12767,6 +13067,8 @@
       "assessed_at": "2026-08-05T00:05:50.720Z",
       "synthesis_policy_version": "2",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -12848,6 +13150,8 @@
       "assessed_at": "2026-08-05T00:05:55.221Z",
       "synthesis_policy_version": "2",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [
           "07500f7a07de3eed5bb38ae932799ccd2a207de623aa06b6b66608d2a7bfc8b9",
@@ -12933,6 +13237,8 @@
       "assessed_at": "2026-08-05T00:06:01.869Z",
       "synthesis_policy_version": "2",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [
           "6874632f7972d64b5fc19fea546247241213fe5680c7617910b7312303228b07",
@@ -13018,6 +13324,8 @@
       "assessed_at": "2026-08-05T00:13:09.672Z",
       "synthesis_policy_version": "2",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -13099,6 +13407,8 @@
       "assessed_at": "2026-08-05T00:13:11.676Z",
       "synthesis_policy_version": "2",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -13180,6 +13490,8 @@
       "assessed_at": "2026-08-05T01:56:51.368Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -13261,6 +13573,8 @@
       "assessed_at": "2026-08-05T00:13:14.937Z",
       "synthesis_policy_version": "2",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No material security concerns identified",
@@ -13342,6 +13656,8 @@
       "assessed_at": "2026-08-05T02:23:47.598Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [
           "0a8447d0767a1afb00c05158daed5d8e6638693dc34080464e5c3b5c06bee959",
@@ -13454,6 +13770,8 @@
       "assessed_at": "2026-08-05T00:19:59.168Z",
       "synthesis_policy_version": "2",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -13535,6 +13853,8 @@
       "assessed_at": "2026-08-05T01:43:46.930Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -13616,6 +13936,8 @@
       "assessed_at": "2026-08-05T02:43:24.178Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -13697,6 +14019,8 @@
       "assessed_at": "2026-08-05T03:31:31.055Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -13778,6 +14102,8 @@
       "assessed_at": "2026-08-05T03:37:48.184Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "Low risk: flagged code is confined to test harnesses",
@@ -13859,6 +14185,8 @@
       "assessed_at": "2026-08-05T04:43:18.567Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -13940,6 +14268,8 @@
       "assessed_at": "2026-08-05T02:56:32.718Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -14021,6 +14351,8 @@
       "assessed_at": "2026-08-05T04:05:32.840Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -14102,6 +14434,8 @@
       "assessed_at": "2026-08-05T00:27:37.507Z",
       "synthesis_policy_version": "2",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [
           "0ea66c1b36331b9b578b5e985d55feba956bf976890587aec22044288c31e483",
@@ -14187,6 +14521,8 @@
       "assessed_at": "2026-08-05T03:50:05.893Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -14268,6 +14604,8 @@
       "assessed_at": "2026-08-05T04:30:03.211Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -14349,6 +14687,8 @@
       "assessed_at": "2026-08-05T02:23:37.816Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [
           "0a8447d0767a1afb00c05158daed5d8e6638693dc34080464e5c3b5c06bee959",
@@ -14461,6 +14801,8 @@
       "assessed_at": "2026-08-05T01:50:25.272Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns were identified",
@@ -14542,6 +14884,8 @@
       "assessed_at": "2026-08-05T04:30:05.409Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -14623,6 +14967,8 @@
       "assessed_at": "2026-08-05T02:16:45.674Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No security concern identified",
@@ -14704,6 +15050,8 @@
       "assessed_at": "2026-08-05T02:23:27.767Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -14785,6 +15133,8 @@
       "assessed_at": "2026-08-05T04:13:49.088Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -14866,6 +15216,8 @@
       "assessed_at": "2026-08-05T01:36:52.802Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -14947,6 +15299,8 @@
       "assessed_at": "2026-08-05T03:31:28.470Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -15028,6 +15382,8 @@
       "assessed_at": "2026-08-05T02:10:02.023Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -15109,6 +15465,8 @@
       "assessed_at": "2026-08-05T03:57:49.307Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -15190,6 +15548,8 @@
       "assessed_at": "2026-08-05T02:30:20.242Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -15271,6 +15631,8 @@
       "assessed_at": "2026-08-05T01:43:36.781Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [
           "1e6c9b50acf9062c73c9c86c582c3e0a223a68767368c535e994e322975b8f42"
@@ -15354,6 +15716,8 @@
       "assessed_at": "2026-08-05T03:57:55.468Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -15435,6 +15799,8 @@
       "assessed_at": "2026-08-05T03:09:14.733Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns were identified",
@@ -15516,6 +15882,8 @@
       "assessed_at": "2026-08-05T02:30:17.700Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -15597,6 +15965,8 @@
       "assessed_at": "2026-08-05T03:43:59.019Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -15678,6 +16048,8 @@
       "assessed_at": "2026-08-05T04:30:07.601Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -15759,6 +16131,8 @@
       "assessed_at": "2026-08-05T04:36:58.303Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -15840,6 +16214,8 @@
       "assessed_at": "2026-08-05T04:43:20.706Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -15921,6 +16297,8 @@
       "assessed_at": "2026-08-05T03:43:56.033Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -16002,6 +16380,8 @@
       "assessed_at": "2026-08-05T03:49:53.221Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -16083,6 +16463,8 @@
       "assessed_at": "2026-08-05T04:43:25.011Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [
           "83a486b9de7f2e4cdbb7718857176a5e003cef9f105f1e3d298840d0d75e4ae3",
@@ -16169,6 +16551,8 @@
       "assessed_at": "2026-08-05T03:57:47.058Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [
           "23b730bfca3c554c75936f8248b3f99739340a1a528e840d363a51b9c6d286c3",
@@ -16253,6 +16637,8 @@
       "assessed_at": "2026-08-05T04:05:28.437Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -16334,6 +16720,8 @@
       "assessed_at": "2026-08-05T04:13:12.417Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -16415,6 +16803,8 @@
       "assessed_at": "2026-08-05T04:13:46.887Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -16496,6 +16886,8 @@
       "assessed_at": "2026-08-05T04:20:17.920Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -16577,6 +16969,8 @@
       "assessed_at": "2026-08-05T04:20:20.255Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -16658,6 +17052,8 @@
       "assessed_at": "2026-08-05T04:20:13.690Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -16739,6 +17135,8 @@
       "assessed_at": "2026-08-05T04:20:11.439Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [
           "1125c7c351b6452dc82bd60edab80d47f285b41e36387ea38be90749ad23d0ae",
@@ -16825,6 +17223,8 @@
       "assessed_at": "2026-08-05T04:25:08.616Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -16906,6 +17306,8 @@
       "assessed_at": "2026-08-05T04:20:15.774Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -16987,6 +17389,8 @@
       "assessed_at": "2026-08-05T04:25:04.398Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -17068,6 +17472,8 @@
       "assessed_at": "2026-08-05T04:25:02.252Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -17149,6 +17555,8 @@
       "assessed_at": "2026-08-05T04:25:06.539Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -17230,6 +17638,8 @@
       "assessed_at": "2026-08-05T04:30:00.603Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [
           "e8768e17147cd57ba169ba080f39d3d9a953636882326ddcb80f3f7649b5a54b",
@@ -17314,6 +17724,8 @@
       "assessed_at": "2026-08-05T04:29:57.005Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns found",
@@ -17395,6 +17807,8 @@
       "assessed_at": "2026-08-05T04:36:53.014Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -17476,6 +17890,8 @@
       "assessed_at": "2026-08-05T04:36:24.763Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [],
         "headline": "No validated security concerns identified",
@@ -17557,6 +17973,8 @@
       "assessed_at": "2026-08-05T04:43:16.446Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [
           "0cd323dc09034feb7b338bf0d623da9ebd7ce923b1bda9fed90630a36965d7aa",

--- a/docs/superpowers/plans/2026-08-04-tavernkeeper-immediate-danger-policy.md
+++ b/docs/superpowers/plans/2026-08-04-tavernkeeper-immediate-danger-policy.md
@@ -1,0 +1,460 @@
+# TavernKeeper Immediate-Danger Policy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reserve red for deterministic immediate-danger evidence, guarantee
+that every valid red report publishes on Tavernary, reset the four obsolete red
+reports, and rescan their current exact commits.
+
+**Architecture:** TavernKeeper contextual policy 2 validates item-level high
+recommendations against an exact evidence predicate. Tavernary independently
+derives the project level and structured danger basis from the validated V5
+report, treats model prose as optional enrichment, and publishes a static
+fallback when enrichment fails. The release uses a paused durable queue,
+ordered cross-repository merges, an exact four-report reset, protected targeted
+workflows, and live exact-SHA verification.
+
+**Tech Stack:** TypeScript 6, Node.js 24, React 19, Next.js 16, Zod, Vitest,
+Playwright, GitHub Actions, GitHub CLI, GitHub Pages.
+
+## Global Constraints
+
+- Red means immediate user danger at the exact scanned commit.
+- Critical dependency severity alone never selects red.
+- Red danger basis is `malicious_or_compromised`,
+  `critical_exploitable_vulnerability`, or `mixed`.
+- Valid technical reports always publish on Tavernary even when optional prose
+  synthesis fails.
+- Red never automatically hides, quarantines, delists, or downranks a project.
+- Scanner policy remains `3`; TavernKeeper contextual policy becomes `2` with
+  prompt `contextual-review-v2`.
+- TavernKeeper Technical Report and Preferred Index remain V5.
+- Tavernary tracked summary schema becomes V6 and synthesis policy becomes `4`.
+- Only the four report identities listed in the approved design may be deleted.
+- Use TDD for every behavior change and preserve unrelated worktree/user files.
+
+---
+
+### Task 1: Tavernary deterministic advisory contract
+
+**Files:**
+- Modify: `scripts/security/tavernkeeper-assessment-contract.mjs`
+- Modify: `scripts/security/tavernkeeper-assessment-contract.d.mts`
+- Modify: `tests/unit/tavernkeeper-synthesis.test.ts`
+
+**Interfaces:**
+- Produces: `deriveProjectAdvisory(items): { risk_level, danger_basis }`
+- Produces: `buildDeterministicAssessment(report): TavernaryAssessment`
+- Changes: `validateTavernaryAssessment()` requires the model risk to equal the
+  deterministic project risk; interaction prose cannot elevate it.
+
+- [ ] **Step 1: Add failing advisory decision-table tests**
+
+  Cover low, material, malicious red, vulnerability red, mixed red, a critical
+  but merely plausible dependency, and model attempts to raise or lower risk.
+  Assert this exact shape:
+
+  ```js
+  expect(deriveProjectAdvisory(items)).toEqual({
+    risk_level: "high",
+    danger_basis: "critical_exploitable_vulnerability",
+  });
+  ```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+  Run:
+  `npm.cmd test -- tests/unit/tavernkeeper-synthesis.test.ts`
+
+  Expected: failure because `deriveProjectAdvisory` and deterministic fallback
+  do not exist and interaction escalation is still allowed.
+
+- [ ] **Step 3: Implement the pure projector and fallback**
+
+  The qualifying predicates are:
+
+  ```js
+  const malicious =
+    item.disposition === "credible_malicious_behavior" &&
+    item.confidence === "high";
+  const exploitable =
+    item.disposition === "material_vulnerability" &&
+    item.confidence === "high" &&
+    item.impact === "critical" &&
+    item.exploitability === "readily_exploitable";
+  ```
+
+  High is returned only when either predicate is present; mixed is returned
+  when both are present. Otherwise any `material_vulnerability` is material and
+  expected/minor-only reports are low. Build deterministic policy-owned copy,
+  exact validated counts, required candidate citations, and no interaction
+  chains.
+
+- [ ] **Step 4: Require exact deterministic risk**
+
+  Replace the lowerable-floor/rank logic with equality against
+  `deriveProjectAdvisory(reportItems(report)).risk_level`. Use
+  `below_evidence_floor` for a lower model result and
+  `unsupported_escalation` for a higher result.
+
+- [ ] **Step 5: Run focused tests GREEN and commit**
+
+  Run:
+  `npm.cmd test -- tests/unit/tavernkeeper-synthesis.test.ts`
+
+  Commit:
+  `feat(security): derive immediate-danger risk`
+
+### Task 2: Tavernary nonblocking synthesis publication
+
+**Files:**
+- Modify: `scripts/security/tavernkeeper-reports.mjs`
+- Modify: `scripts/security/tavernkeeper-reports.d.mts`
+- Modify: `scripts/security/tavernkeeper-synthesis.mjs`
+- Modify: `scripts/security/tavernkeeper-synthesis.d.mts`
+- Modify: `scripts/security/import-tavernkeeper-reports.mjs`
+- Modify: `scripts/security/import-tavernkeeper-reports.d.mts`
+- Modify: `scripts/security/tavernkeeper-import-state.mjs`
+- Modify: `scripts/security/tavernkeeper-import-state.d.mts`
+- Modify: `tests/unit/tavernkeeper-reports.test.ts`
+- Modify: `tests/unit/tavernkeeper-import-state.test.ts`
+- Modify: `data/security/tavernkeeper-report-summaries.json`
+
+**Interfaces:**
+- Stored summary V6 adds top-level report fields
+  `danger_basis: DangerBasis` and
+  `assessment_source: "model" | "deterministic_fallback"`.
+- `trackedEntry(entry, synthesis, advisory, source)` persists those fields.
+- A known `TavernKeeperSynthesisError` produces a preferred deterministic entry
+  and a nonblocking incident instead of omitting the report.
+
+- [ ] **Step 1: Replace blocking-quarantine tests with failing fallback tests**
+
+  For invalid output, provider timeout/rate limit/server/network errors, and
+  provider-security errors, assert:
+
+  ```ts
+  expect(outcome.snapshot.preferred_report_ids).toContain(entry.report_id);
+  expect(outcome.snapshot.reports[0]).toMatchObject({
+    danger_basis: "critical_exploitable_vulnerability",
+    assessment_source: "deterministic_fallback",
+    assessment: { risk_level: "high" },
+  });
+  ```
+
+  Keep digest/origin/schema/evidence failures blocking. Assert one failed
+  narrative does not stop later valid imports.
+
+- [ ] **Step 2: Run focused tests and verify RED**
+
+  Run:
+  `npm.cmd test -- tests/unit/tavernkeeper-reports.test.ts tests/unit/tavernkeeper-import-state.test.ts`
+
+- [ ] **Step 3: Implement V6 storage and fallback reconciliation**
+
+  Bump `TAVERNKEEPER_SYNTHESIS_POLICY_VERSION` to `4`. Validate upstream
+  Technical Report/Index as V5 but stored snapshots as schema 6. Add the two
+  required stored fields. Catch only known synthesis errors; create the
+  deterministic assessment with `synthesis_model: "deterministic-policy-v4"`,
+  preserve a sanitized incident, add the report to preferred IDs, and continue
+  the batch. Unknown programming errors still fail the batch.
+
+- [ ] **Step 4: Migrate tracked data mechanically**
+
+  Set the root snapshot to `schema_version: 6`. Every existing low/material
+  entry receives `danger_basis: "none"` and `assessment_source: "model"`.
+  Validate the resulting file with the production reader; do not modify report
+  identities, timestamps, model names, prose, or preferred IDs.
+
+- [ ] **Step 5: Update incident semantics**
+
+  Retain durable sanitized failure state and explicit retry capability, but do
+  not let it filter preferred IDs or prevent a matching fallback entry. Resolve
+  obsolete policy-3 quarantines under synthesis policy 4.
+
+- [ ] **Step 6: Run focused tests GREEN and commit**
+
+  Run:
+  `npm.cmd test -- tests/unit/tavernkeeper-reports.test.ts tests/unit/tavernkeeper-import-state.test.ts tests/unit/tavernkeeper-synthesis.test.ts`
+
+  Commit:
+  `fix(security): publish deterministic scan fallback`
+
+### Task 3: Tavernary danger-basis UI and policy copy
+
+**Files:**
+- Modify: `src/features/catalog/tavernkeeper-status.ts`
+- Modify: `src/features/catalog/components/tavernkeeper-scan-indicator.tsx`
+- Modify: `src/app/about/page.tsx`
+- Modify: `.github/workflows/import-tavernkeeper-reports.yml`
+- Modify: `tests/unit/tavernkeeper-status.test.ts`
+- Modify: `tests/unit/tavernkeeper-scan-indicator.test.tsx`
+- Modify: `tests/unit/about-page.test.tsx`
+- Modify: `tests/unit/workflows.test.ts`
+- Modify: `docs/superpowers/specs/2026-07-31-tavernkeeper-cross-repository-security-design.md`
+
+**Interfaces:**
+- `TavernKeeperReportSummary.dangerBasis` exposes the stored structured value.
+- Red public label is `Immediate danger`.
+- Red popovers render a `Danger basis` row with fixed policy-owned text.
+
+- [ ] **Step 1: Add failing UI and documentation tests**
+
+  Assert red accessible text says `Immediate danger`, the malicious and
+  vulnerability bases render different text, material does not imply malware,
+  About says red remains listed for awareness, and workflow incidents say
+  `narrative enrichment` rather than report quarantine.
+
+- [ ] **Step 2: Run focused tests and verify RED**
+
+  Run:
+  `npm.cmd test -- tests/unit/tavernkeeper-status.test.ts tests/unit/tavernkeeper-scan-indicator.test.tsx tests/unit/about-page.test.tsx tests/unit/workflows.test.ts`
+
+- [ ] **Step 3: Implement typed projection and copy**
+
+  Map danger bases to:
+
+  ```ts
+  {
+    malicious_or_compromised: "Credible malicious or compromised behavior",
+    critical_exploitable_vulnerability:
+      "Critical, readily exploitable vulnerability",
+    mixed: "Malicious or compromised behavior and an exploitable vulnerability",
+  }
+  ```
+
+  Show the row only for high reports. Update canonical design sections 4.2,
+  15.3, 17, 17.1, publication, testing, and completion so the older document
+  agrees with the approved corrective design.
+
+- [ ] **Step 4: Run focused tests GREEN and commit**
+
+  Commit:
+  `feat(security): explain immediate danger`
+
+### Task 4: Tavernary verification, PR, merge, and deployment
+
+**Files:**
+- Verify all Tavernary files changed in Tasks 1-3.
+
+- [ ] **Step 1: Run repository gates**
+
+  Run `npm.cmd run check` and the focused scan browser/visual commands required
+  by CI. Verify generated catalog data exists before typecheck.
+
+- [ ] **Step 2: Review the complete diff**
+
+  Confirm no unrelated registry/catalog data changed, the four projects remain
+  listed, technical-report failures remain fail-closed, and every known
+  synthesis failure has a preferred fallback test.
+
+- [ ] **Step 3: Push and open a ready PR**
+
+  Push `codex/immediate-danger-policy-design`, open a ready PR against Tavernary
+  `main`, and record its URL/head SHA. Do not use a draft PR.
+
+- [ ] **Step 4: Verify checks and merge**
+
+  Wait for all required GitHub checks. Address failures through new commits,
+  then merge through the protected repository and record the merge SHA.
+
+- [ ] **Step 5: Verify Tavernary Pages**
+
+  Verify the Pages workflow/environment deploys the exact merge SHA. Use a
+  fresh request and hydrated browser check for the About copy and a deterministic
+  report fixture/card projection.
+
+### Task 5: TavernKeeper contextual policy 2
+
+**Files:**
+- Rename: `config/contextual-review.v1.json` to
+  `config/contextual-review.v2.json`
+- Modify: `src/config/policy.ts`
+- Modify: `src/model/contextual-prompt.ts`
+- Modify: `src/model/contextual-review-contract.ts`
+- Modify: `src/cli/scan.ts` and every runtime policy path found by
+  `rg "contextual-review\\.v1|contextual-review-v1"`
+- Modify: `tests/contextual-prompt.test.ts`
+- Modify: `tests/contextual-review-contract.test.ts`
+- Modify: `tests/contextual-review.test.ts`
+- Modify: version-sensitive fixtures/tests found by the same search.
+
+**Interfaces:**
+- `ContextualReviewPolicy` accepts only version `2`, prompt
+  `contextual-review-v2`, schema `contextual-assessment-v1`.
+- `riskContradictsDisposition()` enforces the approved immediate-danger item
+  predicate.
+
+- [ ] **Step 1: Add failing policy and contract tests**
+
+  Reject material high when confidence is medium, impact is high, or
+  exploitability is plausible. Reject credible malicious behavior below high
+  confidence. Accept only high-confidence credible malicious behavior and
+  high-confidence critical readily exploitable material vulnerabilities as
+  high.
+
+- [ ] **Step 2: Run focused tests and verify RED**
+
+  Run:
+  `npm.cmd test -- tests/contextual-prompt.test.ts tests/contextual-review-contract.test.ts tests/contextual-review.test.ts`
+
+- [ ] **Step 3: Implement policy 2**
+
+  Update the versioned config, runtime paths, policy schema, prompt constants,
+  and validator. Add explicit prompt language requiring shipped-version,
+  runtime-reachability, attacker-control, and concrete-harm analysis for
+  dependency advisories.
+
+- [ ] **Step 4: Run focused tests GREEN and commit**
+
+  Commit:
+  `fix(policy): reserve red for immediate danger`
+
+### Task 6: TavernKeeper presentation, queue priority, and documentation
+
+**Files:**
+- Modify: `src/site/presentation.ts`
+- Modify: `src/site/render-landing.ts`
+- Modify: `src/publish/render-report.ts`
+- Modify: `src/publish/render-history.ts`
+- Modify: `src/queue/backlog.ts`
+- Modify: `tests/site-presentation.test.ts`
+- Modify: `tests/site-build.test.ts`
+- Modify: `tests/backlog.test.ts`
+- Modify: `README.md`
+- Modify: `docs/architecture.md`
+- Modify: `docs/operations.md`
+- Modify: `docs/superpowers/specs/2026-08-03-tavernkeeper-reports-site-design.md`
+
+**Interfaces:**
+- Site risk labels become low/material/immediate-danger with explicit red basis.
+- Due `staff_requested` queue entries sort before ordinary due entries, then by
+  ticket.
+
+- [ ] **Step 1: Add failing site and queue tests**
+
+  Assert immediate-danger copy and danger basis on red pages. Assert critical
+  plausible dependency evidence is material. Assert a higher-ticket staff
+  request is selected before a lower-ticket ordinary entry while delayed staff
+  work, emergency pause, and retry protection remain unchanged.
+
+- [ ] **Step 2: Run focused tests and verify RED**
+
+  Run:
+  `npm.cmd test -- tests/site-presentation.test.ts tests/site-build.test.ts tests/backlog.test.ts`
+
+- [ ] **Step 3: Implement presentation and scheduling**
+
+  Add a report-item advisory projector using the same decision table. Replace
+  `High concern`/`High danger` project-level copy with `Immediate danger` and
+  fixed basis text. Sort available queue entries by
+  `Number(right.staff_requested === true) - Number(left.staff_requested === true)`
+  and then ticket.
+
+- [ ] **Step 4: Reconcile public documentation**
+
+  State that red projects stay published for awareness, severity alone does not
+  select red, and staff-targeted work receives queue priority without bypassing
+  safety holds.
+
+- [ ] **Step 5: Run focused tests GREEN and commit**
+
+  Commit:
+  `feat(site): distinguish immediate danger`
+
+### Task 7: TavernKeeper verification, PR, merge, and deployment
+
+- [ ] **Step 1: Run the complete TavernKeeper gate**
+
+  Run the repository's full formatting, lint, typecheck, unit,
+  workflow-policy, package, and production-site build commands from
+  `package.json`/README.
+
+- [ ] **Step 2: Review the complete diff**
+
+  Confirm scanner policy remains 3, Report/Index remain V5, contextual policy
+  is 2 everywhere, no report artifact is deleted yet, and queue priority cannot
+  bypass holds.
+
+- [ ] **Step 3: Push, open a ready PR, verify checks, and merge**
+
+  Record PR URL, head SHA, merge SHA, and required check conclusions.
+
+- [ ] **Step 4: Verify Pages deploys the policy merge SHA**
+
+  Verify fresh report-site policy copy and that the four existing reports are
+  still present immediately before the reset.
+
+### Task 8: Exact four-report reset PR
+
+**Files:**
+- Modify: `reports/index.json`
+- Delete: the four approved immutable report directories.
+- Delete: each corresponding single-entry repository history directory.
+- Regenerate: `.site` only through the supported build; do not hand-edit it.
+
+- [ ] **Step 1: Reverify destructive targets and queue state**
+
+  Compare repository ID, SHA, report ID, report count, and history count to the
+  approved table. Verify no active scan targets those IDs. Pause through the
+  supported staff operation if not already paused.
+
+- [ ] **Step 2: Remove only exact matching artifacts**
+
+  Fail if any identity differs or any history contains more than the one
+  approved entry. Remove four preferred-index entries, four immutable trees,
+  and four now-empty history trees.
+
+- [ ] **Step 3: Rebuild and verify locally**
+
+  Run report/index validation and the production site build. Assert all four IDs
+  and old URLs are absent and unrelated report count equals prior count minus
+  four.
+
+- [ ] **Step 4: Commit, push, open a ready reset PR, verify, and merge**
+
+  Use a dedicated reset commit. Record PR URL, head/merge SHA, and checks.
+
+- [ ] **Step 5: Verify Pages deletion live**
+
+  Confirm fresh index no longer contains the four IDs, old report/history URLs
+  return not found, and unrelated report pages still load.
+
+### Task 9: Reconciliation, four rescans, and live completion
+
+- [ ] **Step 1: Reconcile Tavernary**
+
+  Dispatch the protected import workflow. Verify the four obsolete incidents
+  resolve, no old summary is preferred, and Tavernary main remains valid.
+
+- [ ] **Step 2: Dispatch four protected targeted workflows**
+
+  Dispatch the canonical URLs from the approved design one at a time through
+  Tavernary's `targeted-tavernkeeper-scan.yml`. Record workflow run IDs.
+
+- [ ] **Step 3: Verify durable queue entries**
+
+  Confirm refreshed exact SHA, `staff_requested: true`, unique repository ID,
+  and staff-first ordering for all four before resuming.
+
+- [ ] **Step 4: Resume and monitor scans**
+
+  Resume through the supported staff workflow. Follow all four through scan,
+  contextual policy 2, publication, Pages, Tavernary import, and Tavernary
+  deployment. Do not hardcode an expected color.
+
+- [ ] **Step 5: Perform live exact-SHA UI verification**
+
+  For every project, record report ID/digest, contextual policy 2, scanner
+  policy 3, public technical report, current SHA/freshness, Tavernary summary,
+  and hydrated desktop/mobile popover. If any result is red, prove it remains
+  listed and displays the correct danger basis.
+
+- [ ] **Step 6: Close out**
+
+  Confirm the ordinary queue is running, unrelated work was preserved, all PRs
+  are merged, all production SHAs are recorded, and the approved definition of
+  done is satisfied.

--- a/docs/superpowers/specs/2026-07-31-tavernkeeper-cross-repository-security-design.md
+++ b/docs/superpowers/specs/2026-07-31-tavernkeeper-cross-repository-security-design.md
@@ -26,17 +26,17 @@ release model is `deepseek/deepseek-v4-flash-0731:thinking` through NanoGPT.
 
 TavernKeeper publishes the complete sanitized technical record: deterministic
 evidence, contextual assessments, coverage, limitations, and exact-SHA links.
-Tavernary imports that structured record and uses its strict-JSON Luna model to
-synthesize the repository-level grade and concise layman's summary. Tavernary
-enforces deterministic evidence floors around Luna's result, so green items
-cannot cancel yellow or red evidence and the final grade cannot be lowered
-beneath supported high-confidence findings.
+Tavernary imports that structured record, deterministically derives the
+repository-level grade and danger basis, and uses its strict-JSON Luna model
+only to enrich the concise layman's summary. Prose synthesis cannot raise or
+lower the project grade.
 
 Production is fully automated. Humans may trigger, pause, resume, or force a
 rescan, but no production report, finding disposition, project grade, or card
 update waits for manual review. If required scanner coverage, model context,
-schema validation, evidence binding, or publication fails, no degraded result
-is published.
+schema validation, or evidence binding fails, no result is published. Optional
+Tavernary narrative enrichment may degrade to fixed policy-owned copy without
+hiding an otherwise valid report.
 
 The two repositories communicate asynchronously through public versioned JSON
 contracts and least-privilege GitHub App wake events. GitHub Actions performs
@@ -121,8 +121,10 @@ semantic `risk_level` and maps it to Tavernary's theme colors:
 - `material` / orange: one or more credible security weaknesses could plausibly
   harm users and should be considered, but the evidence does not support a
   high-danger conclusion.
-- `high` / red: credible malicious behavior or a severe, readily exploitable
-  vulnerability was identified.
+- `high` / red: strong evidence shows immediate danger at the exact scanned
+  commit. This requires high-confidence credible malicious or compromised
+  behavior, or a high-confidence critical and readily exploitable vulnerability.
+  Upstream advisory severity alone is insufficient.
 
 Teal is not limited to a perfect repository. A project with ordinary cautions
 remains teal when those cautions do not create meaningful danger. The panel and
@@ -134,7 +136,10 @@ Tavernary also presents:
 - Super-dark teal for an unsupported source or project kind.
 
 Color is always paired with text. Public copy uses `Low concern`,
-`Material concern`, and `High danger` rather than `safe` or `clean`.
+`Material concern`, and `Immediate danger` rather than `safe` or `clean`. Every
+red result separately identifies malicious/compromised behavior, a critical
+readily exploitable vulnerability, or both. Red does not automatically hide or
+delist the project; visibility provides community awareness.
 
 ### 4.3 Freshness
 
@@ -531,7 +536,8 @@ matches; the model cannot invent uncited repository facts.
   danger
 - `material`: a credible, plausibly exploitable weakness that could harm users
   but probably does not represent malicious intent
-- `high`: credible malicious behavior or a severe, readily exploitable flaw
+- `high`: high-confidence credible malicious behavior, or a high-confidence
+  critical flaw that is readily exploitable in the shipped runtime path
 
 Intent and technical impact are separate. A severe accidental vulnerability may
 be high risk without being labeled malicious. A suspicious-looking capability
@@ -574,9 +580,9 @@ exact SHA, policy versions, report ID/digest, counts, report URL, and technical
 history URL.
 
 Tavernary validates the index, then fetches a newly preferred immutable V5
-report for synthesis. Full finding records are not hydrated into the public
-catalog bundle. Tavernary stores only its bounded final card projection and
-assessment history after successful synthesis.
+report for deterministic assessment and optional narrative enrichment. Full
+finding records are not hydrated into the public catalog bundle. Tavernary
+stores only its bounded final card projection and assessment history.
 
 ### 16.3 Contract evolution
 
@@ -589,44 +595,46 @@ The Tavernary target manifest remains V2 because its identity contract is
 independent and unchanged. Future report-contract changes require a new schema
 version and a coordinated reader-before-writer rollout.
 
-## 17. Tavernary repository-level synthesis
+## 17. Tavernary repository-level assessment
 
-Tavernary gives Luna the validated V5 assessments, counts, project identity,
-exact SHA, and a Tavernary-owned synthesis policy. Luna does not receive target
-credentials, model-provider secrets, raw secret values, hidden reasoning, or an
-unbounded repository corpus. It synthesizes the already reviewed evidence; it
-does not replace TavernKeeper's source-context review.
+Tavernary first derives `risk_level` and `danger_basis` from the validated V5
+assessments and observations. It then gives Luna those assessments, counts,
+project identity, exact SHA, and the required deterministic project advisory.
+Luna does not receive target credentials, model-provider secrets, raw secret
+values, hidden reasoning, or an unbounded repository corpus. It enriches the
+already reviewed evidence; it does not replace TavernKeeper's source-context
+review or select the project color.
 
 The strict-JSON output contains:
 
-- Final `risk_level`: `low`, `material`, or `high`
+- Required `risk_level`: `low`, `material`, or `high`, exactly matching the
+  deterministic project advisory
 - Plain-language headline and one- or two-sentence concise summary
 - Minor-caution, material-concern, and high-danger counts
 - A concise malicious-evidence statement
 - Finding IDs supporting every material claim
-- Optional interaction chains explaining why multiple findings combine into a
-  higher project-level risk
+- Optional interaction chains explaining relationships without changing risk
 - TavernKeeper report ID and exact SHA
 
-### 17.1 Evidence floors
+### 17.1 Deterministic project advisory
 
-Tavernary calculates a minimum permitted grade before accepting Luna's output:
+Tavernary calculates the exact grade before accepting Luna's output:
 
 - A high-confidence `credible_malicious_behavior` assessment creates a `high`
   floor.
 - A high-confidence critical and readily exploitable vulnerability creates a
   `high` floor even without malicious intent.
-- A medium-or-higher confidence material vulnerability creates a `material`
-  floor.
+- Any other contextualized material vulnerability creates a `material` result.
 - Expected behavior and minor weaknesses remain within the `low` range.
 
-Green findings never cancel yellow or red evidence. Luna may escalate beyond a
-floor only when it cites a supported causal interaction between findings. For
-example, multiple material weaknesses may combine into high danger. Luna may
-not lower the result beneath the computed floor or make an uncited claim.
+Green findings never cancel orange or red evidence. Luna may not raise or lower
+the result. If combined evidence creates immediate danger, TavernKeeper must
+emit a bound observation that itself meets the immediate-danger predicate.
 
-Schema, citation, count, floor, and identity validation occurs after synthesis.
-Invalid output retries and cannot update the public assessment.
+Schema, citation, count, deterministic-risk, and identity validation occurs
+after synthesis. Invalid output retries; if it remains invalid or the provider
+is unavailable, Tavernary publishes fixed deterministic copy and records a
+nonblocking narrative-enrichment incident.
 
 ## 18. Publication and atomicity
 
@@ -643,10 +651,10 @@ Tavernary.
 
 Tavernary imports only reports from the configured TavernKeeper origin and
 valid immutable path. It validates identity, SHA, policy, digest, schemas,
-counts, citations, and URLs before invoking Luna. Only a fully validated final
-assessment updates Tavernary's tracked card projection and deploys. A technical
-report may exist on TavernKeeper while Tavernary synthesis retries, but it is
-not linked from the Tavernary card until the final assessment succeeds.
+counts, citations, and URLs before optional narrative enrichment. Every valid
+report receives a deterministic tracked assessment and remains eligible for
+the Tavernary card. Synthesis failure never removes a report from the preferred
+set; it publishes policy-owned fallback copy instead.
 
 Cross-repository publication cannot be one transaction, so each boundary is
 idempotent and fail-closed. A failure never overwrites the last valid tracked
@@ -672,7 +680,7 @@ TavernKeeper Scan Results
 
 For an assessed project, the panel contains:
 
-- `Low concern`, `Material concern`, or `High danger`
+- `Low concern`, `Material concern`, or `Immediate danger`
 - Tavernary's one- or two-sentence layman's summary
 - A qualifier such as `3 minor cautions` or `No material concerns`
 - Exact scanned SHA source-tree link, completion date, assessment date, and

--- a/docs/superpowers/specs/2026-08-04-tavernkeeper-immediate-danger-policy-design.md
+++ b/docs/superpowers/specs/2026-08-04-tavernkeeper-immediate-danger-policy-design.md
@@ -1,0 +1,368 @@
+# TavernKeeper Immediate-Danger Policy and Red-Publication Design
+
+- **Status:** Proposed for review; product direction approved
+- **Date:** 2026-08-04
+- **Canonical location:** Tavernary
+- **Repositories:** `MentallyQuill/Tavernary` and
+  `MentallyQuill/TavernKeeper`
+
+This design supersedes the color-selection and synthesis-publication rules in
+sections 4.2, 15.3, 17, 17.1, and related acceptance language of the
+2026-07-31 cross-repository security design. Implementation must update that
+canonical design, both repositories' public policy documentation, and
+operations guidance so the repository does not retain two contradictory risk
+definitions.
+
+## 1. Decision
+
+Red will mean **immediate user danger at the exact scanned commit**. It will not
+mean that a scanner found a dependency advisory whose upstream severity is
+critical.
+
+Tavernary and TavernKeeper will use these public levels:
+
+- **Low concern / teal:** the completed review did not identify a material
+  security concern. This is not a safety certification.
+- **Material concern / orange:** the review identified a credible weakness,
+  suspicious behavior with unresolved applicability, or a vulnerability that
+  deserves user attention but does not meet the immediate-danger threshold.
+- **Immediate danger / red:** strong evidence shows that installing or using
+  this exact commit presents an immediate danger. Users should not install or
+  use it until the danger is resolved.
+- **Not assessed / gray:** no complete, current assessment is available.
+
+Red is an action recommendation, not a synonym for maliciousness. Every red
+result must separately identify its danger basis as one of:
+
+- `malicious_or_compromised`: high-confidence evidence of deliberately harmful
+  or compromised behavior;
+- `critical_exploitable_vulnerability`: a high-confidence, critical-impact
+  vulnerability that is readily exploitable in the shipped project;
+- `mixed`: both bases are present.
+
+The public label and text must distinguish these bases. A non-malicious but
+immediately exploitable vulnerability may be red. A critical dependency
+advisory without demonstrated shipped reachability and ready exploitability is
+not red.
+
+## 2. Why the current behavior is wrong
+
+TavernKeeper contextual policy 1 permits any `material_vulnerability` to carry
+`recommended_risk: high`. The TavernKeeper report directory then colors the
+entire project red when any item has that recommendation.
+
+Tavernary applies a stricter project evidence rule: high requires
+high-confidence credible malicious behavior, or a high-confidence critical and
+readily exploitable material vulnerability. Its prose-synthesis model returned
+high for four reports that did not satisfy that rule. Tavernary rejected the
+unsupported escalation and quarantined the synthesis result, so the projects
+did not appear as assessed cards even though their technical reports were
+public.
+
+This creates both product failures the policy must prevent:
+
+1. dependency advisory severity can overstate ordinary community-extension
+   risk and desensitize users to red; and
+2. a valid future red technical report can disappear from Tavernary because a
+   secondary prose-generation step failed.
+
+## 3. Policy invariants
+
+The implementation must enforce all of these invariants:
+
+1. Scanner severity locates evidence; it never directly selects a public color.
+2. Project risk is deterministic and cannot be raised or lowered by prose
+   synthesis.
+3. A valid report meeting the immediate-danger rule always publishes on
+   Tavernary, even when model synthesis is unavailable or invalid.
+4. Red never automatically hides, quarantines, delists, or downranks a project.
+   Visibility is necessary for community awareness. Moderation remains a
+   separate human-reviewed process.
+5. Red always includes a public danger basis. Users can distinguish a malicious
+   or compromised project from a non-malicious exploitable flaw.
+6. Teal never says safe, trusted, clean, certified, or verified.
+7. Every assessment remains bound to an immutable repository ID and exact
+   commit SHA.
+8. Invalid report identity, digest, schema, or evidence binding still fails
+   closed. The no-hide guarantee begins only after Tavernary has validated the
+   technical report itself.
+
+## 4. Deterministic decision table
+
+The same pure decision table will be covered by fixtures in both repositories.
+It evaluates TavernKeeper assessments and observations after their V5 schema
+and evidence bindings have been validated.
+
+| Evidence at the scanned commit | Project level | Danger basis |
+| --- | --- | --- |
+| At least one `credible_malicious_behavior` item with `confidence: high` | red / immediate danger | `malicious_or_compromised` |
+| At least one `material_vulnerability` item with `confidence: high`, `impact: critical`, and `exploitability: readily_exploitable` | red / immediate danger | `critical_exploitable_vulnerability` |
+| Both qualifying forms | red / immediate danger | `mixed` |
+| Other contextualized material vulnerabilities or unresolved suspicious security behavior | orange / material concern | `none` |
+| Expected behavior and minor weaknesses only | teal / low concern | `none` |
+
+A model-generated interaction chain may explain related findings, but it may
+not independently elevate a project to red. If combined evidence truly creates
+immediate danger, TavernKeeper's contextual reviewer must emit a bound
+observation that itself satisfies the decision table.
+
+For dependency advisories, `critical` upstream severity is insufficient on its
+own. Red requires evidence that the affected version is present in the shipped
+project, the vulnerable path is reachable in the SillyTavern extension's real
+runtime role, an attacker or untrusted input can exercise it, and exploitation
+can cause critical user harm without speculative prerequisites. Failure to
+establish that chain produces orange or teal according to the remaining
+evidence.
+
+## 5. TavernKeeper changes
+
+### 5.1 Contextual policy 2
+
+TavernKeeper will introduce contextual-review policy 2 and prompt
+`contextual-review-v2`. Scanner policy remains version 3 because scanner
+selection and execution do not change. Technical Report and Preferred Index
+remain V5 because the existing fields already carry the correlated
+disposition, impact, exploitability, confidence, and recommendation needed by
+the rule.
+
+The prompt and validated contract will require:
+
+- `recommended_risk: high` only for an item meeting the immediate-danger
+  decision table;
+- `credible_malicious_behavior` only when confidence is high;
+- non-qualifying `material_vulnerability` items to use
+  `recommended_risk: material`;
+- explicit examination of dependency role, shipped version, runtime
+  reachability, attacker control, and concrete harm; and
+- no inference from scanner or advisory severity alone.
+
+The validator, not prompt compliance alone, enforces these rules. Invalid model
+output receives the existing bounded repair attempts and otherwise fails the
+scan rather than publishing a policy-contradictory report.
+
+### 5.2 Report-site presentation
+
+The reports landing page, history, and report summaries will use
+`Low concern`, `Material concern`, and `Immediate danger`. Red cards and report
+headers will state the derived danger basis. Finding-level technical severity
+and advisory data remain visible; they are not relabeled or discarded.
+
+The landing filter currently described as the highest recommendation will be
+defined by the deterministic project decision. This prevents an upstream
+critical advisory from branding the project red while preserving the advisory
+inside the full report.
+
+### 5.3 Targeted queue priority
+
+The existing Tavernary targeted-scan workflow is the authorized requeue path.
+It resolves an exact published GitHub URL to an immutable repository ID,
+refreshes the target SHA, and dispatches only that ID to TavernKeeper.
+
+TavernKeeper currently marks these entries `staff_requested` but schedules all
+due entries by ticket only. Batch planning will sort due staff-requested entries
+before ordinary entries while retaining ticket order within each group. Staff
+requests still respect an emergency pause, active-scan coalescing, retry delay,
+and the global maximum batch size.
+
+### 5.4 Policy documentation
+
+TavernKeeper's README, architecture, operations, report-site advisory copy, and
+versioned contextual-policy documentation will define red as immediate danger
+and explain dependency reachability. Any language equating the maximum scanner
+or advisory severity with the project level will be removed.
+
+## 6. Tavernary changes
+
+### 6.1 Deterministic color and danger basis
+
+Tavernary will derive `risk_level` and `danger_basis` from the validated V5
+report using the decision table. The synthesis provider will no longer choose
+the project color. Its job is limited to bounded headline, summary, explanatory
+counts, citations, malicious-evidence wording, and interaction explanations.
+
+The tracked Tavernary summary contract will store the deterministic danger
+basis so UI code never infers maliciousness from color or free-form prose. The
+summary policy/schema version will be bumped and existing low/material entries
+will migrate with `danger_basis: none`; there are no currently published high
+Tavernary summaries to migrate.
+
+### 6.2 Nonblocking narrative fallback
+
+For every valid V5 report, Tavernary first constructs a safe deterministic
+assessment. It then attempts optional model synthesis. A valid model response
+may replace only the explanatory prose and cited interaction detail. It cannot
+replace the deterministic color or danger basis.
+
+If synthesis returns invalid output, times out, is rate limited, is
+unavailable, or fails its provider-security boundary, Tavernary will publish
+the deterministic assessment instead of omitting the report. Fallback copy is
+fixed policy-owned text and includes:
+
+- the deterministic public level;
+- the exact danger basis for red;
+- the validated finding counts;
+- a statement that the detailed generated summary was unavailable; and
+- a link to the complete TavernKeeper technical report.
+
+Synthesis failures may remain visible to maintainers as nonblocking enrichment
+incidents and may be retried. They must not remove the report ID from
+`preferred_report_ids`, suppress its card status, or prevent site deployment.
+The existing four blocking `unsupported_escalation` quarantines will resolve
+when their obsolete reports leave the TavernKeeper preferred index.
+
+### 6.3 Public card copy
+
+The scan popover will use:
+
+- `Low concern`
+- `Material concern`
+- `Immediate danger`
+
+For red, it will add a dedicated `Danger basis` row with human text for
+malicious/compromised behavior, a critical readily exploitable vulnerability,
+or both. Material reports continue to show advisory and finding details without
+implying malware. The About page will document the same policy and state that
+red projects remain listed to provide community awareness.
+
+Tavernary's canonical cross-repository security design, About copy, importer
+operations documentation, and maintainer incident language will be updated in
+the same change. A synthesis incident will be called a narrative-enrichment
+incident rather than a project/report quarantine.
+
+## 7. Exact report reset
+
+The following four current reports were created under contextual policy 1 and
+are the complete destructive reset scope:
+
+| Repository | Repository ID | Scanned SHA | Report ID |
+| --- | ---: | --- | --- |
+| `bmen25124/SillyTavern-Flowchart` | `1073040696` | `b7c091b0ba227df5913453c311bdf264d7c454be` | `26739aff81e20755a030668422b0905530cf33daa868f00849dca2a0c7d17ff3` |
+| `AventurasTeam/Aventuras` | `1126279204` | `babb1a0d69288bffafe4ca80fa3ed96847c52229` | `b2e3d941a135807741f81f5598e3fe993c9f6ebc5bd7b513682c8d0a73129f25` |
+| `bmen25124/SillyTavern-Character-Creator` | `956654271` | `8ddf5ba08188fa8044469518d540c7dded4db701` | `6fb95c8c0f96125ad3cf0d906f15ae13fa8f436190ae80851d4fcfdbdfababe6` |
+| `twitter/twemoji` | `26291683` | `bad3bceeafc901ace42a3dfe0421db6388daafb9` | `4efc45df08f6177f4a0a910e33d8cf1cfeb2ba000fd91ebf161bb6983e378244` |
+
+For each exact identity, the reset removes:
+
+- its entry from `reports/index.json`;
+- its immutable `reports/github/<repository-id>/<sha>/3/<report-id>/`
+  directory; and
+- its corresponding repository-history entry and generated history page. If
+  that was the repository's only report, the empty history directory is
+  removed.
+
+The generated site is rebuilt from source artifacts; generated `.site` files
+are not hand-edited. No other report, queue entry, retry, worktree, or user-owned
+file is touched. Git commit history preserves recoverability and the reset is a
+dedicated reviewable change.
+
+## 8. Migration and production order
+
+The release is deliberately ordered so no report can be rescanned under the old
+policy or disappear behind prose synthesis:
+
+1. Reverify the four exact identities against current TavernKeeper main and the
+   live reports index; verify their current Tavernary source IDs, healthy target
+   SHAs, quarantine records, and absence from active scans.
+2. Pause TavernKeeper through the supported staff operation with a bounded
+   policy-migration reason.
+3. Implement, review, merge, deploy, and hydrate-verify Tavernary's
+   deterministic classification, danger-basis UI, and nonblocking fallback.
+4. Implement, review, merge, and deploy TavernKeeper contextual policy 2,
+   immediate-danger presentation, and staff queue priority.
+5. Commit the exact four-report reset on current TavernKeeper main. Rebuild and
+   verify the report site, merge, deploy Pages, and prove the four old report
+   URLs and preferred-index entries are absent while unrelated reports remain.
+6. Run Tavernary report reconciliation. Verify all four obsolete blocking
+   quarantines resolve and the current published snapshot remains valid.
+7. Dispatch Tavernary's protected targeted workflow once for each canonical
+   repository URL:
+   - `https://github.com/bmen25124/SillyTavern-Flowchart`
+   - `https://github.com/AventurasTeam/Aventuras`
+   - `https://github.com/bmen25124/SillyTavern-Character-Creator`
+   - `https://github.com/twitter/twemoji`
+8. Verify four exact current-SHA queue entries are accepted with
+   `staff_requested: true`, are ordered ahead of ordinary due work, and do not
+   duplicate active or queued targets.
+9. Resume TavernKeeper and follow all four through scan, policy-2 contextual
+   review, publication, Pages deployment, Tavernary import, Tavernary Pages
+   deployment, and hydrated live cards.
+
+The expected outcome from the evidence currently visible is orange rather than
+red, but acceptance does not hardcode a desired result. Each new report must be
+allowed to reach whichever level contextual policy 2 and the deterministic
+decision table support.
+
+If a gate fails before resumption, the queue remains paused. Before rescanning,
+the dedicated reset commit can be reverted to restore the old artifacts. After
+new policy-2 reports exist, recovery is fix-forward; old policy-1 product
+results are not silently restored.
+
+## 9. Verification
+
+### 9.1 TavernKeeper automated proof
+
+Tests will cover:
+
+- a critical dependency advisory with only plausible or uncertain runtime
+  exploitability produces material, not high;
+- only the two immediate-danger evidence forms permit high;
+- credible malicious disposition without high confidence is rejected;
+- prompt repair cannot bypass the validator;
+- landing, history, and report pages label and subtype red correctly;
+- staff-requested due entries precede ordinary due tickets without bypassing
+  pauses or retry timing;
+- the exact reset removes only the four identified reports; and
+- all type, unit, formatting, workflow-policy, package, and production-site
+  checks pass.
+
+### 9.2 Tavernary automated proof
+
+Tests will cover:
+
+- deterministic low, material, malicious red, vulnerability red, and mixed red
+  projections;
+- model output cannot raise or lower risk or alter danger basis;
+- invalid-output, timeout, rate-limit, provider, and security-boundary synthesis
+  failures still publish a valid red preferred summary using fallback copy;
+- only invalid technical-report identity, digest, schema, or evidence binding
+  remains blocking;
+- existing summaries and import incidents migrate without losing unrelated
+  history;
+- card text and accessible labels distinguish malicious red from vulnerability
+  red; and
+- unit, type, lint, build, static export, browser, and colored visual coverage
+  pass.
+
+### 9.3 Live proof
+
+Completion requires evidence for both repositories' source, merged remote SHA,
+Actions checks, exact Pages deployment SHA, fresh public JSON, and hydrated UI.
+For each of the four rescans, record:
+
+- current Tavernary target SHA and accepted TavernKeeper queue ticket;
+- contextual policy 2, prompt version 2, scanner policy 3, report ID, and report
+  digest;
+- public technical report and history URL;
+- deterministic project level and danger basis;
+- Tavernary imported summary identity and freshness;
+- live desktop and mobile card/popover behavior; and
+- proof that a red result, if any, remains published and visible.
+
+## 10. Definition of done
+
+The migration is complete only when:
+
+1. The four policy-1 red report artifacts are absent from the current public
+   TavernKeeper product and remain recoverable through Git history.
+2. Contextual policy 2 prevents advisory severity alone from producing red.
+3. Tavernary derives color and danger basis deterministically from validated
+   report evidence.
+4. Every valid future red report publishes on Tavernary even when optional
+   synthesis fails.
+5. Red public UI distinguishes malicious/compromised behavior from a critical
+   readily exploitable vulnerability and never auto-hides the listing.
+6. All four projects are requeued at their refreshed exact SHAs and complete
+   the normal production scan path.
+7. Their new reports, Tavernary assessments, exact-SHA links, freshness, and
+   hydrated public UI are verified live.
+8. The ordinary queue resumes without losing or mutating unrelated work.

--- a/scripts/build-tavernkeeper-test-export.mjs
+++ b/scripts/build-tavernkeeper-test-export.mjs
@@ -120,9 +120,11 @@ async function fixtureReports() {
       assessed_at: `2026-07-${String(ordinal).padStart(2, "0")}T12:05:00.000Z`,
       synthesis_policy_version: "1",
       synthesis_model: "gpt-5.6-luna",
+      danger_basis: high ? "malicious_or_compromised" : "none",
+      assessment_source: "model",
       assessment: {
         risk_level: riskLevel,
-        headline: high ? "High concern" : "Low concern",
+        headline: high ? "Immediate danger" : "Low concern",
         summary: high
           ? "The combined reviewed behavior could expose credentials to an untrusted endpoint."
           : "The reviewed behavior matches the extension's stated purpose, with no material concerns.",
@@ -145,7 +147,7 @@ async function fixtureReports() {
   }
 
   return {
-    schema_version: 5,
+    schema_version: 6,
     generated_at: "2026-07-31T12:00:00.000Z",
     preferred_report_ids: [
       (13).toString(16).padStart(64, "0"),

--- a/scripts/security/import-tavernkeeper-reports.d.mts
+++ b/scripts/security/import-tavernkeeper-reports.d.mts
@@ -1,5 +1,5 @@
 import type {
-  TavernKeeperAssessmentSnapshotV5,
+  TavernKeeperAssessmentSnapshotV6,
   TavernKeeperScanReportV5,
   TavernKeeperSourceRegistryEntry,
   TavernarySynthesisProjection,
@@ -52,7 +52,7 @@ export interface TavernKeeperImportIncident {
 }
 
 export interface TavernKeeperImportOutcome {
-  snapshot: TavernKeeperAssessmentSnapshotV5;
+  snapshot: TavernKeeperAssessmentSnapshotV6;
   import_state: TavernKeeperImportState;
   imported: number;
   retained: number;
@@ -68,4 +68,4 @@ export function reconcileTavernKeeperReports(
 ): Promise<TavernKeeperImportOutcome>;
 export function importTavernKeeperReports(
   options?: TavernKeeperImportOptions,
-): Promise<TavernKeeperAssessmentSnapshotV5>;
+): Promise<TavernKeeperAssessmentSnapshotV6>;

--- a/scripts/security/import-tavernkeeper-reports.mjs
+++ b/scripts/security/import-tavernkeeper-reports.mjs
@@ -3,7 +3,11 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { isDeepStrictEqual } from "node:util";
 
-import { TAVERNKEEPER_SYNTHESIS_POLICY_VERSION } from "./tavernkeeper-assessment-contract.mjs";
+import {
+  buildDeterministicAssessment,
+  deriveProjectAdvisory,
+  TAVERNKEEPER_SYNTHESIS_POLICY_VERSION,
+} from "./tavernkeeper-assessment-contract.mjs";
 import {
   migrateTavernKeeperImportState,
   quarantineTavernKeeperReport,
@@ -42,13 +46,15 @@ function indexProjection(entry) {
     assessed_at: _assessedAt,
     synthesis_policy_version: _policy,
     synthesis_model: _model,
+    danger_basis: _dangerBasis,
+    assessment_source: _assessmentSource,
     assessment: _assessment,
     ...indexEntry
   } = entry;
   return indexEntry;
 }
 
-function trackedEntry(entry, synthesis) {
+function trackedEntry(entry, synthesis, dangerBasis, assessmentSource) {
   if (
     synthesis.report_id !== entry.report_id ||
     synthesis.target_sha !== entry.target_sha ||
@@ -63,7 +69,20 @@ function trackedEntry(entry, synthesis) {
     assessed_at: synthesis.assessed_at,
     synthesis_policy_version: synthesis.synthesis_policy_version,
     synthesis_model: synthesis.synthesis_model,
+    danger_basis: dangerBasis,
+    assessment_source: assessmentSource,
     assessment: synthesis.assessment,
+  };
+}
+
+function fallbackSynthesis(report, assessedAt) {
+  return {
+    report_id: report.report_id,
+    target_sha: report.target_sha,
+    assessed_at: assessedAt,
+    synthesis_policy_version: TAVERNKEEPER_SYNTHESIS_POLICY_VERSION,
+    synthesis_model: "deterministic-policy-v4",
+    assessment: buildDeterministicAssessment(report),
   };
 }
 
@@ -91,12 +110,17 @@ function createDefaultSynthesis(options) {
   };
 }
 
-function matchingTrackedEntry(existing, entry) {
+function matchingIndexEntry(existing, entry) {
   return (
     existing !== undefined &&
-    existing.synthesis_policy_version ===
-      TAVERNKEEPER_SYNTHESIS_POLICY_VERSION &&
     isDeepStrictEqual(indexProjection(existing), entry)
+  );
+}
+
+function matchingTrackedEntry(existing, entry) {
+  return (
+    matchingIndexEntry(existing, entry) &&
+    existing.synthesis_policy_version === TAVERNKEEPER_SYNTHESIS_POLICY_VERSION
   );
 }
 
@@ -245,14 +269,16 @@ export async function reconcileTavernKeeperReports(options = {}) {
       );
     }
     const report = await fetchAndValidateTavernKeeperReport(entry, options);
+    const advisory = deriveProjectAdvisory([
+      ...report.assessments,
+      ...report.observations,
+    ]);
     let synthesis;
+    let assessmentSource = "model";
     try {
       synthesis = await synthesize(report);
     } catch (error) {
-      if (
-        error instanceof TavernKeeperSynthesisError &&
-        error.kind === "invalid-output"
-      ) {
+      if (error instanceof TavernKeeperSynthesisError) {
         importState = quarantineTavernKeeperReport(
           importState,
           entry,
@@ -266,19 +292,28 @@ export async function reconcileTavernKeeperReports(options = {}) {
           ),
         );
         quarantined += 1;
-        continue;
+        assessmentSource = "deterministic_fallback";
+        synthesis = fallbackSynthesis(report, now);
+      } else {
+        throw error;
       }
-      throw error;
     }
-    const tracked = trackedEntry(entry, synthesis);
-    const recovered = currentQuarantine(importState, entry.report_digest);
-    if (recovered !== undefined) resolved.push(incidentProjection(recovered));
-    importState = removeTavernKeeperQuarantine(
-      importState,
-      entry.report_digest,
-      TAVERNKEEPER_SYNTHESIS_POLICY_VERSION,
-      now,
+    const tracked = trackedEntry(
+      entry,
+      synthesis,
+      advisory.danger_basis,
+      assessmentSource,
     );
+    const recovered = currentQuarantine(importState, entry.report_digest);
+    if (assessmentSource === "model") {
+      if (recovered !== undefined) resolved.push(incidentProjection(recovered));
+      importState = removeTavernKeeperQuarantine(
+        importState,
+        entry.report_digest,
+        TAVERNKEEPER_SYNTHESIS_POLICY_VERSION,
+        now,
+      );
+    }
     additions.push(tracked);
     existing.set(entry.report_id, tracked);
     imported += 1;
@@ -303,14 +338,13 @@ export async function reconcileTavernKeeperReports(options = {}) {
     reports.map((entry) => [entry.report_id, entry]),
   );
   const preferredReportIds = index.reports.flatMap((entry) =>
-    currentQuarantine(importState, entry.report_digest) === undefined &&
-    matchingTrackedEntry(retainedById.get(entry.report_id), entry)
+    matchingIndexEntry(retainedById.get(entry.report_id), entry)
       ? [entry.report_id]
       : [],
   );
   const snapshot = validateStoredReportIndex(
     {
-      schema_version: 5,
+      schema_version: 6,
       generated_at: index.generated_at,
       preferred_report_ids: preferredReportIds,
       reports,
@@ -322,9 +356,7 @@ export async function reconcileTavernKeeperReports(options = {}) {
   await writeReportSummaries(importState, importStatePath);
 
   const remaining = index.reports.filter(
-    (entry) =>
-      !matchingTrackedEntry(retainedById.get(entry.report_id), entry) &&
-      currentQuarantine(importState, entry.report_digest) === undefined,
+    (entry) => !matchingTrackedEntry(retainedById.get(entry.report_id), entry),
   ).length;
   return {
     snapshot,

--- a/scripts/security/tavernkeeper-assessment-contract.d.mts
+++ b/scripts/security/tavernkeeper-assessment-contract.d.mts
@@ -4,7 +4,7 @@ import type {
   TavernaryAssessmentV1,
 } from "./tavernkeeper-reports.mjs";
 
-export const TAVERNKEEPER_SYNTHESIS_POLICY_VERSION: "3";
+export const TAVERNKEEPER_SYNTHESIS_POLICY_VERSION: "4";
 export const TAVERNKEEPER_ASSESSMENT_JSON_SCHEMA: Record<string, unknown>;
 export type TavernaryAssessmentDiagnostic =
   | "response_schema"

--- a/scripts/security/tavernkeeper-assessment-contract.d.mts
+++ b/scripts/security/tavernkeeper-assessment-contract.d.mts
@@ -42,6 +42,26 @@ export function validateStoredAssessmentShape(
 export function deriveEvidenceFloor(
   assessments: readonly TavernKeeperContextualItemV5[],
 ): TavernKeeperRiskLevel;
+export type TavernKeeperDangerBasis =
+  | "none"
+  | "malicious_or_compromised"
+  | "critical_exploitable_vulnerability"
+  | "mixed";
+export function deriveProjectAdvisory(
+  assessments: readonly TavernKeeperContextualItemV5[],
+): {
+  risk_level: TavernKeeperRiskLevel;
+  danger_basis: TavernKeeperDangerBasis;
+};
+export function buildDeterministicAssessment(report: {
+  candidates: Array<{ candidate_id: string }>;
+  assessments: TavernKeeperContextualItemV5[];
+  observations: Array<
+    Omit<TavernKeeperContextualItemV5, "candidate_id"> & {
+      related_candidate_ids: string[];
+    }
+  >;
+}): TavernaryAssessmentV1;
 export function tavernKeeperAssessmentRequirements(report: {
   candidates: Array<{ candidate_id: string }>;
   assessments: TavernKeeperContextualItemV5[];

--- a/scripts/security/tavernkeeper-assessment-contract.mjs
+++ b/scripts/security/tavernkeeper-assessment-contract.mjs
@@ -1,4 +1,4 @@
-export const TAVERNKEEPER_SYNTHESIS_POLICY_VERSION = "3";
+export const TAVERNKEEPER_SYNTHESIS_POLICY_VERSION = "4";
 
 const riskLevels = ["low", "material", "high"];
 const digestPattern = /^[0-9a-f]{64}$/u;

--- a/scripts/security/tavernkeeper-assessment-contract.mjs
+++ b/scripts/security/tavernkeeper-assessment-contract.mjs
@@ -164,32 +164,47 @@ export function validateStoredAssessmentShape(assessment) {
   return assessment;
 }
 
-function isHighFloor(item) {
-  return (
-    item.confidence === "high" &&
-    (item.disposition === "credible_malicious_behavior" ||
-      (item.disposition === "material_vulnerability" &&
-        item.impact === "critical" &&
-        item.exploitability === "readily_exploitable"))
-  );
+function isMaterialFloor(item) {
+  return item.disposition === "material_vulnerability";
 }
 
-function isMaterialFloor(item) {
-  return (
-    item.disposition === "material_vulnerability" &&
-    ["medium", "high"].includes(item.confidence)
+export function deriveProjectAdvisory(assessments) {
+  if (!Array.isArray(assessments)) {
+    throw new Error(
+      "TavernKeeper assessments are required for project advisory",
+    );
+  }
+  const malicious = assessments.some(
+    (item) =>
+      item.disposition === "credible_malicious_behavior" &&
+      item.confidence === "high",
   );
+  const exploitable = assessments.some(
+    (item) =>
+      item.disposition === "material_vulnerability" &&
+      item.confidence === "high" &&
+      item.impact === "critical" &&
+      item.exploitability === "readily_exploitable",
+  );
+  if (malicious || exploitable) {
+    return {
+      risk_level: "high",
+      danger_basis:
+        malicious && exploitable
+          ? "mixed"
+          : malicious
+            ? "malicious_or_compromised"
+            : "critical_exploitable_vulnerability",
+    };
+  }
+  if (assessments.some(isMaterialFloor)) {
+    return { risk_level: "material", danger_basis: "none" };
+  }
+  return { risk_level: "low", danger_basis: "none" };
 }
 
 export function deriveEvidenceFloor(assessments) {
-  if (!Array.isArray(assessments)) {
-    throw new Error(
-      "TavernKeeper assessments are required for evidence floors",
-    );
-  }
-  if (assessments.some(isHighFloor)) return "high";
-  if (assessments.some(isMaterialFloor)) return "material";
-  return "low";
+  return deriveProjectAdvisory(assessments).risk_level;
 }
 
 function reportItems(report) {
@@ -246,6 +261,51 @@ export function tavernKeeperAssessmentRequirements(report) {
     required_counts: expectedCounts(report),
     evidence_floor: deriveEvidenceFloor(reportItems(report)),
   };
+}
+
+export function buildDeterministicAssessment(report) {
+  const items = reportItems(report);
+  const advisory = deriveProjectAdvisory(items);
+  const requirements = tavernKeeperAssessmentRequirements(report);
+  const counts = requirements.required_counts;
+  const copy = {
+    low: {
+      headline: "Low concern",
+      summary:
+        "TavernKeeper did not identify a material security concern at the scanned commit. The detailed generated summary was unavailable; review the complete technical report for findings and limitations.",
+      malicious_evidence:
+        "No evidence of malicious behavior was identified in the completed review.",
+    },
+    material: {
+      headline: "Material security concerns identified",
+      summary:
+        "TavernKeeper identified material security concerns at the scanned commit. The detailed generated summary was unavailable; review the complete technical report before installing or using this project.",
+      malicious_evidence:
+        "No high-confidence evidence of malicious or compromised behavior met the immediate-danger threshold.",
+    },
+    high: {
+      headline: "Immediate danger identified",
+      summary:
+        "TavernKeeper identified immediate-danger evidence at the scanned commit. The detailed generated summary was unavailable; review the complete technical report before installing or using this project.",
+      malicious_evidence:
+        advisory.danger_basis === "malicious_or_compromised"
+          ? "The report contains high-confidence evidence of credible malicious or compromised behavior."
+          : advisory.danger_basis === "mixed"
+            ? "The report contains high-confidence evidence of malicious or compromised behavior and a critical, readily exploitable vulnerability."
+            : "No credible malicious behavior was identified; the immediate-danger result is based on a critical, readily exploitable vulnerability.",
+    },
+  }[advisory.risk_level];
+  return validateStoredAssessmentShape({
+    risk_level: advisory.risk_level,
+    headline: copy.headline,
+    summary: copy.summary,
+    minor_cautions: counts.minor_cautions,
+    material_concerns: counts.material_concerns,
+    high_danger: counts.high_danger,
+    malicious_evidence: copy.malicious_evidence,
+    cited_finding_ids: requirements.required_candidate_ids,
+    interaction_chains: [],
+  });
 }
 
 function repairFor(requirements, extra = {}) {
@@ -321,12 +381,7 @@ export function validateTavernaryAssessment(assessment, report) {
   if (riskRank < floorRank) {
     assessmentFailure("below_evidence_floor", requirements);
   }
-  if (
-    riskRank > floorRank &&
-    !assessment.interaction_chains.some(
-      (chain) => chain.resulting_risk === assessment.risk_level,
-    )
-  ) {
+  if (riskRank > floorRank) {
     assessmentFailure("unsupported_escalation", requirements, {
       rejected_risk_level: assessment.risk_level,
       required_risk_level: floor,

--- a/scripts/security/tavernkeeper-import-state.d.mts
+++ b/scripts/security/tavernkeeper-import-state.d.mts
@@ -7,7 +7,16 @@ export type TavernaryAssessmentDiagnostic =
   | "interaction_chain_ids"
   | "below_evidence_floor"
   | "unsupported_escalation"
-  | "provider_response_invalid";
+  | "provider_response_invalid"
+  | "provider-timeout"
+  | "provider-rate-limited"
+  | "provider-server-error"
+  | "provider-authentication-failed"
+  | "provider-request-failed"
+  | "provider-network-error"
+  | "provider-model-mismatch"
+  | "synthesis-clock-invalid"
+  | "synthesis-boundary-failed";
 
 export interface TavernKeeperReportQuarantine {
   report_id: string;

--- a/scripts/security/tavernkeeper-import-state.mjs
+++ b/scripts/security/tavernkeeper-import-state.mjs
@@ -11,6 +11,15 @@ const diagnostics = new Set([
   "below_evidence_floor",
   "unsupported_escalation",
   "provider_response_invalid",
+  "provider-timeout",
+  "provider-rate-limited",
+  "provider-server-error",
+  "provider-authentication-failed",
+  "provider-request-failed",
+  "provider-network-error",
+  "provider-model-mismatch",
+  "synthesis-clock-invalid",
+  "synthesis-boundary-failed",
 ]);
 const digestPattern = /^[0-9a-f]{64}$/u;
 const shaPattern = /^[0-9a-f]{40}$/u;

--- a/scripts/security/tavernkeeper-reports.d.mts
+++ b/scripts/security/tavernkeeper-reports.d.mts
@@ -149,18 +149,27 @@ export interface TavernarySynthesisProjection {
   assessment: TavernaryAssessmentV1;
 }
 
-export interface TavernaryAssessedReportV5 extends TavernKeeperReportIndexEntryV5 {
+export type TavernKeeperDangerBasis =
+  | "none"
+  | "malicious_or_compromised"
+  | "critical_exploitable_vulnerability"
+  | "mixed";
+export type TavernKeeperAssessmentSource = "model" | "deterministic_fallback";
+
+export interface TavernaryAssessedReportV6 extends TavernKeeperReportIndexEntryV5 {
   assessed_at: string;
   synthesis_policy_version: string;
   synthesis_model: string;
+  danger_basis: TavernKeeperDangerBasis;
+  assessment_source: TavernKeeperAssessmentSource;
   assessment: TavernaryAssessmentV1;
 }
 
-export interface TavernKeeperAssessmentSnapshotV5 {
-  schema_version: 5;
+export interface TavernKeeperAssessmentSnapshotV6 {
+  schema_version: 6;
   generated_at: string;
   preferred_report_ids: string[];
-  reports: TavernaryAssessedReportV5[];
+  reports: TavernaryAssessedReportV6[];
 }
 
 export interface TavernKeeperSourceRegistryEntry {
@@ -218,7 +227,7 @@ export function validateStoredReportIndex(
   registry:
     | TavernKeeperSourceRegistryEntry[]
     | { sources: TavernKeeperSourceRegistryEntry[] },
-): TavernKeeperAssessmentSnapshotV5;
+): TavernKeeperAssessmentSnapshotV6;
 export function fetchAndValidateTavernKeeperIndex(
   options?: TavernKeeperFetchOptions,
 ): Promise<TavernKeeperReportIndexV5>;
@@ -231,8 +240,8 @@ export function readStoredReportIndex(
   registry:
     | TavernKeeperSourceRegistryEntry[]
     | { sources: TavernKeeperSourceRegistryEntry[] },
-): Promise<TavernKeeperAssessmentSnapshotV5>;
+): Promise<TavernKeeperAssessmentSnapshotV6>;
 export function writeReportSummaries(
-  index: TavernKeeperAssessmentSnapshotV5,
+  index: TavernKeeperAssessmentSnapshotV6,
   outputPath: string,
 ): Promise<void>;

--- a/scripts/security/tavernkeeper-reports.mjs
+++ b/scripts/security/tavernkeeper-reports.mjs
@@ -526,12 +526,53 @@ const storedEntryExtraKeys = [
   "assessed_at",
   "synthesis_policy_version",
   "synthesis_model",
+  "danger_basis",
+  "assessment_source",
+  "assessment",
+];
+const priorStoredEntryExtraKeys = [
+  "assessed_at",
+  "synthesis_policy_version",
+  "synthesis_model",
   "assessment",
 ];
 const indexEntryKeys = reportIndexV5Schema.properties.reports.items.required;
 
-export function validateStoredReportIndex(snapshot, registry) {
-  assertV5(snapshot, "Tracked TavernKeeper assessment snapshot");
+function migrateStoredSnapshot(snapshot) {
+  if (snapshot?.schema_version !== 5) return snapshot;
+  assertExactKeys(
+    snapshot,
+    ["schema_version", "generated_at", "preferred_report_ids", "reports"],
+    "Tracked TavernKeeper assessment snapshot",
+  );
+  if (!Array.isArray(snapshot.reports)) {
+    throw new Error("Tracked TavernKeeper assessment snapshot is invalid");
+  }
+  return {
+    ...snapshot,
+    schema_version: 6,
+    reports: snapshot.reports.map((entry) => {
+      assertExactKeys(
+        entry,
+        [...indexEntryKeys, ...priorStoredEntryExtraKeys],
+        "Tracked TavernKeeper assessment",
+      );
+      return {
+        ...entry,
+        danger_basis: "none",
+        assessment_source: "model",
+      };
+    }),
+  };
+}
+
+export function validateStoredReportIndex(snapshotInput, registry) {
+  const snapshot = migrateStoredSnapshot(snapshotInput);
+  if (snapshot?.schema_version !== 6) {
+    throw new Error(
+      "Tracked TavernKeeper assessment snapshot schema validation failed: unsupported schema version",
+    );
+  }
   assertExactKeys(
     snapshot,
     ["schema_version", "generated_at", "preferred_report_ids", "reports"],
@@ -575,11 +616,24 @@ export function validateStoredReportIndex(snapshot, registry) {
       typeof entry.synthesis_model !== "string" ||
       entry.synthesis_model.trim() !== entry.synthesis_model ||
       entry.synthesis_model.length < 1 ||
-      entry.synthesis_model.length > 200
+      entry.synthesis_model.length > 200 ||
+      ![
+        "none",
+        "malicious_or_compromised",
+        "critical_exploitable_vulnerability",
+        "mixed",
+      ].includes(entry.danger_basis) ||
+      !["model", "deterministic_fallback"].includes(entry.assessment_source)
     ) {
       throw new Error("Tracked TavernKeeper synthesis identity is invalid");
     }
     validateStoredAssessmentShape(entry.assessment);
+    if (
+      (entry.assessment.risk_level === "high") !==
+      (entry.danger_basis !== "none")
+    ) {
+      throw new Error("Tracked TavernKeeper danger basis is invalid");
+    }
   }
   if (
     new Set(snapshot.preferred_report_ids).size !==

--- a/scripts/security/tavernkeeper-synthesis-provider.mjs
+++ b/scripts/security/tavernkeeper-synthesis-provider.mjs
@@ -1,5 +1,6 @@
 import { createStructuredProviderTransport } from "../catalog/enrichment-provider.mjs";
 import {
+  deriveProjectAdvisory,
   TAVERNKEEPER_ASSESSMENT_JSON_SCHEMA,
   tavernKeeperAssessmentRequirements,
 } from "./tavernkeeper-assessment-contract.mjs";
@@ -9,7 +10,7 @@ export function tavernKeeperSynthesisInstructions() {
 
 Most projects in this open-source, often vibe-coded community are made in good faith, but rare projects have attempted API-key phishing or theft, trojan delivery, harmful payloads, and bot infection. Judge the validated evidence in that context without treating ordinary SillyTavern extension behavior or scanner keywords as malicious by themselves.
 
-Produce a concise project-level assessment for nontechnical Tavernary visitors. Preserve material uncertainty and distinguish malicious evidence from ordinary security weaknesses. Put cited IDs only in cited_finding_ids and interaction_chains.finding_ids, using IDs listed in allowed_candidate_ids. Never put finding IDs or citation markers in visitor-facing prose. Observation IDs are never valid citations. Copy required_counts exactly. Set risk_level to evidence_floor unless two or more cited findings form a supported causal interaction expressed in interaction_chains. A nonzero high_danger count does not set the project risk level. You may not lower the deterministic evidence floor. Return only the required structured object.`;
+Produce a concise project-level assessment for nontechnical Tavernary visitors. Preserve material uncertainty and distinguish malicious evidence from ordinary security weaknesses. Put cited IDs only in cited_finding_ids and interaction_chains.finding_ids, using IDs listed in allowed_candidate_ids. Never put finding IDs or citation markers in visitor-facing prose. Observation IDs are never valid citations. Copy required_counts exactly. A nonzero high_danger count does not set the project risk level. risk_level must exactly equal required_project_advisory.risk_level; prose and interaction chains cannot select or change the project color. Return only the required structured object.`;
 }
 
 function synthesisInput(input) {
@@ -24,6 +25,10 @@ function synthesisInput(input) {
     ecosystem_context_version: report.ecosystem_context_version,
     counts: report.counts,
     ...tavernKeeperAssessmentRequirements(report),
+    required_project_advisory: deriveProjectAdvisory([
+      ...report.assessments,
+      ...report.observations,
+    ]),
     candidates: report.candidates.map((candidate) => ({
       candidate_id: candidate.candidate_id,
       origin: candidate.origin,

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -128,6 +128,16 @@ export default function AboutPage() {
             it. Never provide API keys, passwords, or other secrets to software
             unless you understand how they are used.
           </p>
+          <p>
+            Scan colors describe the evidence at one exact commit. Teal means
+            low concern, orange means a material concern, and red means
+            immediate danger at the exact scanned commit. A critical dependency
+            advisory alone does not make a project red. Red results identify
+            whether the danger is credible malicious or compromised behavior, a
+            critical readily exploitable vulnerability, or both. Red projects
+            remain listed so the community can see the warning; scan results do
+            not automatically hide or delist a project.
+          </p>
         </section>
 
         <section id="reporting-removal">

--- a/src/app/security/tavernkeeper/history/[sourceId]/page.tsx
+++ b/src/app/security/tavernkeeper/history/[sourceId]/page.tsx
@@ -9,7 +9,13 @@ const snapshot = snapshotData as unknown as {
 const riskLabels = {
   low: "Low concern",
   material: "Material concern",
-  high: "High concern",
+  high: "Immediate danger",
+};
+const dangerBasisLabels = {
+  malicious_or_compromised: "Credible malicious or compromised behavior",
+  critical_exploitable_vulnerability:
+    "Critical, readily exploitable vulnerability",
+  mixed: "Malicious or compromised behavior and an exploitable vulnerability",
 };
 
 function formatDate(timestamp: string) {
@@ -84,6 +90,13 @@ export function TavernKeeperAssessmentHistory({
                   <p>{report.assessment.summary}</p>
                   <p>{report.assessment.malicious_evidence}</p>
                   <dl>
+                    {report.assessment.risk_level === "high" &&
+                    report.danger_basis !== "none" ? (
+                      <div>
+                        <dt>Danger basis</dt>
+                        <dd>{dangerBasisLabels[report.danger_basis]}</dd>
+                      </div>
+                    ) : null}
                     <div>
                       <dt>Commit</dt>
                       <dd>

--- a/src/features/catalog/components/tavernkeeper-history-strip.tsx
+++ b/src/features/catalog/components/tavernkeeper-history-strip.tsx
@@ -3,7 +3,7 @@ import type { TavernKeeperReportSummary } from "@/features/catalog/tavernkeeper-
 const riskLabels = {
   low: "low concern",
   material: "material concern",
-  high: "high concern",
+  high: "immediate danger",
 };
 
 function formatHistoryDate(assessedAt: string) {

--- a/src/features/catalog/components/tavernkeeper-scan-indicator.tsx
+++ b/src/features/catalog/components/tavernkeeper-scan-indicator.tsx
@@ -88,7 +88,13 @@ const freshnessLabels = {
 const riskGradeLabels = {
   low: "Low concern",
   material: "Material concern",
-  high: "High concern",
+  high: "Immediate danger",
+};
+const dangerBasisLabels = {
+  malicious_or_compromised: "Credible malicious or compromised behavior",
+  critical_exploitable_vulnerability:
+    "Critical, readily exploitable vulnerability",
+  mixed: "Malicious or compromised behavior and an exploitable vulnerability",
 };
 
 function countLabel(count: number, singular: string, plural = `${singular}s`) {
@@ -402,6 +408,13 @@ export function TavernKeeperScanIndicator({
                     </span>
                   </p>
                   <dl className="tavernkeeper-scan-details">
+                    {report.riskLevel === "high" &&
+                    report.dangerBasis !== "none" ? (
+                      <div>
+                        <dt>Danger basis</dt>
+                        <dd>{dangerBasisLabels[report.dangerBasis]}</dd>
+                      </div>
+                    ) : null}
                     <div>
                       <dt>Scanned</dt>
                       <dd>

--- a/src/features/catalog/tavernkeeper-status.ts
+++ b/src/features/catalog/tavernkeeper-status.ts
@@ -1,6 +1,12 @@
 import { ACTIVE_TAVERNKEEPER_SCANNER_POLICY_VERSION } from "../../../scripts/security/tavernkeeper-reports.mjs";
 
 export type TavernKeeperRiskLevel = "low" | "material" | "high";
+export type TavernKeeperDangerBasis =
+  | "none"
+  | "malicious_or_compromised"
+  | "critical_exploitable_vulnerability"
+  | "mixed";
+export type TavernKeeperAssessmentSource = "model" | "deterministic_fallback";
 export type TavernKeeperVisualState =
   "teal" | "orange" | "red" | "gray" | "unsupported";
 export type TavernKeeperFreshness =
@@ -35,6 +41,8 @@ export interface TavernKeeperAssessedReport {
   assessed_at: string;
   synthesis_policy_version: string;
   synthesis_model: string;
+  danger_basis: TavernKeeperDangerBasis;
+  assessment_source: TavernKeeperAssessmentSource;
   report_url: string;
   history_url?: string;
   assessment: TavernKeeperFinalAssessment;
@@ -58,6 +66,8 @@ export interface TavernKeeperReportSummary {
   contextualReviewPolicyVersion: string;
   synthesisPolicyVersion: string;
   synthesisModel: string;
+  dangerBasis: TavernKeeperDangerBasis;
+  assessmentSource: TavernKeeperAssessmentSource;
   reportUrl: string;
   technicalHistoryUrl: string | null;
 }
@@ -181,6 +191,8 @@ function summarize(
     contextualReviewPolicyVersion: report.contextual_review_policy_version,
     synthesisPolicyVersion: report.synthesis_policy_version,
     synthesisModel: report.synthesis_model,
+    dangerBasis: report.danger_basis,
+    assessmentSource: report.assessment_source,
     reportUrl: report.report_url,
     technicalHistoryUrl: report.history_url ?? null,
   };

--- a/tests/e2e/catalog.spec.ts
+++ b/tests/e2e/catalog.spec.ts
@@ -1129,13 +1129,21 @@ test(
       "data-hydrated",
       "true",
     );
-    for (const [state, accessibleCopy, stateCopy, stale, historyBlocks] of [
+    for (const [
+      state,
+      accessibleCopy,
+      stateCopy,
+      stale,
+      historyBlocks,
+      dangerBasis,
+    ] of [
       [
         "teal",
         "Low concern; current.",
         "The reviewed behavior matches the extension's stated purpose, with no material concerns.",
         false,
         12,
+        null,
       ],
       [
         "teal",
@@ -1143,13 +1151,15 @@ test(
         "The reviewed behavior matches the extension's stated purpose, with no material concerns. This assessment covers an older commit. An updated scan is pending.",
         true,
         0,
+        null,
       ],
       [
         "red",
-        "High concern; current.",
+        "Immediate danger; current.",
         "The combined reviewed behavior could expose credentials to an untrusted endpoint.",
         false,
         0,
+        "Credible malicious or compromised behavior",
       ],
     ] as const) {
       const indicator = page
@@ -1182,8 +1192,13 @@ test(
         panel.locator(".tavernkeeper-assessment-counts span"),
       ).toHaveCount(3);
       await expect(panel.locator(".tavernkeeper-scan-details div")).toHaveCount(
-        2,
+        dangerBasis ? 3 : 2,
       );
+      if (dangerBasis) {
+        await expect(panel.locator(".tavernkeeper-scan-details")).toContainText(
+          `Danger basis${dangerBasis}`,
+        );
+      }
       await expect(
         panel.locator(".tavernkeeper-malicious-evidence"),
       ).toHaveCount(0);

--- a/tests/unit/about-page.test.tsx
+++ b/tests/unit/about-page.test.tsx
@@ -28,6 +28,14 @@ test("explains safety, reporting, and legal information on About", () => {
       /scan results are not a guarantee that a project is safe or free of harmful behavior/i,
     ),
   ).toBeInTheDocument();
+  expect(
+    screen.getByText(/red means immediate danger at the exact scanned commit/i),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByText(
+      /red projects remain listed so the community can see the warning/i,
+    ),
+  ).toBeInTheDocument();
   expect(screen.getByRole("link", { name: "Get help" })).toHaveAttribute(
     "href",
     "/help",

--- a/tests/unit/project-card.test.tsx
+++ b/tests/unit/project-card.test.tsx
@@ -143,6 +143,8 @@ describe("project card", () => {
             report: {
               reportId: "report-1",
               riskLevel: "low",
+              dangerBasis: "none",
+              assessmentSource: "model",
               headline: "Low concern",
               summary:
                 "The reviewed behavior matches the extension's stated purpose.",

--- a/tests/unit/tavernkeeper-history-page.test.tsx
+++ b/tests/unit/tavernkeeper-history-page.test.tsx
@@ -25,6 +25,8 @@ function report(
     assessed_at: "2026-08-02T12:05:00.000Z",
     synthesis_policy_version: "1",
     synthesis_model: "gpt-5.6-luna",
+    danger_basis: "none",
+    assessment_source: "model",
     report_url: "https://example.test/reports/one/",
     history_url: "https://example.test/reports/history/",
     assessment: {
@@ -112,6 +114,33 @@ describe("TavernKeeper final-assessment history", () => {
 
     expect(
       screen.getByText("No completed TavernKeeper assessments are available."),
+    ).toBeInTheDocument();
+  });
+
+  test("labels red history as immediate danger and states its basis", () => {
+    const dangerous = report({
+      danger_basis: "critical_exploitable_vulnerability",
+      assessment: {
+        ...report().assessment,
+        risk_level: "high",
+        headline: "Immediate danger identified",
+        high_danger: 1,
+      },
+    });
+
+    render(
+      <TavernKeeperAssessmentHistory
+        sourceId="github-42"
+        reports={[dangerous]}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { level: 2, name: "Immediate danger" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Danger basis")).toBeInTheDocument();
+    expect(
+      screen.getByText("Critical, readily exploitable vulnerability"),
     ).toBeInTheDocument();
   });
 });

--- a/tests/unit/tavernkeeper-reports.test.ts
+++ b/tests/unit/tavernkeeper-reports.test.ts
@@ -169,6 +169,43 @@ function addExpectedCandidate(reportInput: Record<string, any>) {
   return rebindReport(report);
 }
 
+function addImmediateDangerCandidate(reportInput: Record<string, any>) {
+  const report = addExpectedCandidate(reportInput);
+  report.assessments[0] = {
+    ...report.assessments[0],
+    disposition: "material_vulnerability",
+    impact: "critical",
+    exploitability: "readily_exploitable",
+    confidence: "high",
+    recommended_risk: "high",
+    technical_explanation:
+      "The shipped vulnerable path is reachable by untrusted input and can cause critical harm.",
+    layman_explanation:
+      "An attacker can readily exploit this flaw when the extension is used.",
+    developer_action: "Remove the vulnerable path before further use.",
+  };
+  report.counts.disposition = {
+    expected_behavior: 0,
+    minor_weakness: 0,
+    material_vulnerability: 1,
+    credible_malicious_behavior: 0,
+  };
+  report.counts.impact = {
+    none: 0,
+    low: 0,
+    medium: 0,
+    high: 0,
+    critical: 1,
+  };
+  report.counts.exploitability = {
+    unlikely: 0,
+    plausible: 0,
+    readily_exploitable: 1,
+  };
+  report.counts.recommended_risk = { low: 0, material: 0, high: 1 };
+  return rebindReport(report);
+}
+
 function publicDnsLookup() {
   return Promise.resolve([{ address: "8.8.8.8", family: 4 }]);
 }
@@ -250,6 +287,139 @@ describe("TavernKeeper V5 report import", () => {
 
     expect(validateScanReport(report, validatedIndex.reports[0])).toEqual(
       report,
+    );
+  });
+
+  test("publishes a deterministic immediate-danger fallback when synthesis is invalid", async () => {
+    const root = await mkdtemp(resolve(tmpdir(), "tavernkeeper-v6-red-"));
+    const outputPath = resolve(
+      root,
+      "data/security/tavernkeeper-report-summaries.json",
+    );
+    const importStatePath = resolve(
+      root,
+      "data/security/tavernkeeper-import-state.json",
+    );
+    await mkdir(resolve(root, "data/security"), { recursive: true });
+    await writeFile(
+      outputPath,
+      '{"schema_version":5,"generated_at":"1970-01-01T00:00:00.000Z","preferred_report_ids":[],"reports":[]}\n',
+    );
+    const [fixtureIndex, fixtureReport] = await fixtures();
+    const report = addImmediateDangerCandidate(fixtureReport);
+    const entry = projectIndexReport(report);
+    const index = { ...fixtureIndex, reports: [entry] };
+
+    const outcome = await reconcileTavernKeeperReports({
+      root,
+      outputPath,
+      importStatePath,
+      registry,
+      dnsLookup: publicDnsLookup,
+      requestImpl: async (url: string) =>
+        jsonResponse(url === TAVERNKEEPER_REPORT_INDEX_URL ? index : report),
+      synthesizeReport: async () => {
+        throw new TavernKeeperSynthesisError(
+          "invalid-output",
+          "unsupported_escalation",
+        );
+      },
+      now: () => new Date("2026-08-04T20:00:00.000Z"),
+    });
+
+    expect(outcome.snapshot).toMatchObject({
+      schema_version: 6,
+      preferred_report_ids: [entry.report_id],
+      reports: [
+        {
+          report_id: entry.report_id,
+          danger_basis: "critical_exploitable_vulnerability",
+          assessment_source: "deterministic_fallback",
+          synthesis_model: "deterministic-policy-v4",
+          assessment: {
+            risk_level: "high",
+            headline: "Immediate danger identified",
+          },
+        },
+      ],
+    });
+    expect(outcome).toMatchObject({ imported: 1, quarantined: 1 });
+    expect(outcome.import_state.quarantines).toEqual([
+      expect.objectContaining({
+        report_id: entry.report_id,
+        diagnostic: "unsupported_escalation",
+      }),
+    ]);
+  });
+
+  test("keeps prior summaries preferred while policy-4 enrichment advances in batches", async () => {
+    const root = await mkdtemp(resolve(tmpdir(), "tavernkeeper-v6-rollout-"));
+    const outputPath = resolve(
+      root,
+      "data/security/tavernkeeper-report-summaries.json",
+    );
+    const importStatePath = resolve(
+      root,
+      "data/security/tavernkeeper-import-state.json",
+    );
+    await mkdir(resolve(root, "data/security"), { recursive: true });
+    const [index, report] = await fixtures();
+    const secondReport = secondReportFrom(report);
+    const secondEntry = projectIndexReport(secondReport);
+    index.reports.push(secondEntry);
+    const priorReports = index.reports.map((entry: Record<string, any>) => ({
+      ...assessedEntry(entry, { synthesis_policy_version: "3" }),
+      danger_basis: "none",
+      assessment_source: "model",
+    }));
+    await writeFile(
+      outputPath,
+      `${JSON.stringify({
+        schema_version: 6,
+        generated_at: index.generated_at,
+        preferred_report_ids: priorReports.map(
+          (entry: Record<string, any>) => entry.report_id,
+        ),
+        reports: priorReports,
+      })}\n`,
+    );
+    const expandedRegistry = [
+      ...registry,
+      {
+        id: "github-43",
+        type: "github",
+        status: "active",
+        repository_id: 43,
+        repository: "owner/repo-two",
+      },
+    ];
+
+    const outcome = await reconcileTavernKeeperReports({
+      root,
+      outputPath,
+      importStatePath,
+      registry: expandedRegistry,
+      dnsLookup: publicDnsLookup,
+      requestImpl: async (url: string) =>
+        jsonResponse(
+          url === TAVERNKEEPER_REPORT_INDEX_URL
+            ? index
+            : url.includes(secondReport.report_id)
+              ? secondReport
+              : report,
+        ),
+      synthesizeReport: async (currentReport: Record<string, any>) =>
+        synthesisFor(
+          currentReport.repository_id === 43 ? secondEntry : index.reports[0],
+        ),
+      batchSize: 1,
+      now: () => new Date("2026-08-04T20:05:00.000Z"),
+    });
+
+    expect(outcome.imported).toBe(1);
+    expect(outcome.remaining).toBe(1);
+    expect(outcome.snapshot.preferred_report_ids).toEqual(
+      index.reports.map((entry: Record<string, any>) => entry.report_id),
     );
   });
 
@@ -398,7 +568,15 @@ describe("TavernKeeper V5 report import", () => {
       reports: [entry],
     };
 
-    expect(validateStoredReportIndex(stored, registry)).toEqual(stored);
+    expect(validateStoredReportIndex(stored, registry)).toMatchObject({
+      schema_version: 6,
+      reports: [
+        expect.objectContaining({
+          danger_basis: "none",
+          assessment_source: "model",
+        }),
+      ],
+    });
     expect(() =>
       validateStoredReportIndex(
         { ...stored, preferred_report_ids: ["f".repeat(64)] },
@@ -435,7 +613,15 @@ describe("TavernKeeper V5 report import", () => {
       reports: [historical],
     };
 
-    expect(validateStoredReportIndex(snapshot, registry)).toEqual(snapshot);
+    expect(validateStoredReportIndex(snapshot, registry)).toMatchObject({
+      schema_version: 6,
+      reports: [
+        expect.objectContaining({
+          danger_basis: "none",
+          assessment_source: "model",
+        }),
+      ],
+    });
     expect(() =>
       validateStoredReportIndex(
         { ...snapshot, preferred_report_ids: [historical.report_id] },
@@ -496,7 +682,7 @@ describe("TavernKeeper V5 report import", () => {
         },
       }),
     ).resolves.toEqual({
-      schema_version: 5,
+      schema_version: 6,
       generated_at: emptyIndex.generated_at,
       preferred_report_ids: [],
       reports: [],
@@ -504,7 +690,7 @@ describe("TavernKeeper V5 report import", () => {
     await expect(
       readFile(outputPath, "utf8").then((contents) => JSON.parse(contents)),
     ).resolves.toEqual({
-      schema_version: 5,
+      schema_version: 6,
       generated_at: emptyIndex.generated_at,
       preferred_report_ids: [],
       reports: [],
@@ -650,16 +836,24 @@ describe("TavernKeeper V5 report import", () => {
     });
 
     expect(outcome).toMatchObject({
-      imported: 1,
+      imported: 2,
       quarantined: 1,
       skipped_quarantines: 0,
       remaining: 0,
     });
     expect(outcome.snapshot.preferred_report_ids).toEqual([
+      index.reports[0].report_id,
       secondEntry.report_id,
     ]);
     expect(outcome.snapshot.reports).toEqual([
-      expect.objectContaining({ report_id: secondEntry.report_id }),
+      expect.objectContaining({
+        report_id: index.reports[0].report_id,
+        assessment_source: "deterministic_fallback",
+      }),
+      expect.objectContaining({
+        report_id: secondEntry.report_id,
+        assessment_source: "model",
+      }),
     ]);
     const stateText = await readFile(importStatePath, "utf8");
     expect(stateText).not.toContain("provider response");
@@ -684,7 +878,7 @@ describe("TavernKeeper V5 report import", () => {
     ]);
   });
 
-  test("retains an older assessment as history but not as preferred during quarantine", async () => {
+  test("retains an older assessment while preferring the current deterministic fallback", async () => {
     const root = await mkdtemp(resolve(tmpdir(), "tavernkeeper-v5-fallback-"));
     const outputPath = resolve(
       root,
@@ -739,8 +933,16 @@ describe("TavernKeeper V5 report import", () => {
       now: () => new Date("2026-08-02T13:05:00.000Z"),
     });
 
-    expect(outcome.snapshot.preferred_report_ids).toEqual([]);
-    expect(outcome.snapshot.reports).toEqual([prior]);
+    expect(outcome.snapshot.preferred_report_ids).toEqual([
+      replacementEntry.report_id,
+    ]);
+    expect(outcome.snapshot.reports).toEqual([
+      expect.objectContaining({ report_id: prior.report_id }),
+      expect.objectContaining({
+        report_id: replacementEntry.report_id,
+        assessment_source: "deterministic_fallback",
+      }),
+    ]);
     expect(outcome.import_state.quarantines).toEqual([
       expect.objectContaining({ report_id: replacementEntry.report_id }),
     ]);
@@ -824,6 +1026,7 @@ describe("TavernKeeper V5 report import", () => {
     ]);
     expect(outcome.skipped_quarantines).toBe(1);
     expect(outcome.snapshot.preferred_report_ids).toEqual([
+      index.reports[0].report_id,
       secondEntry.report_id,
     ]);
 
@@ -922,7 +1125,7 @@ describe("TavernKeeper V5 report import", () => {
     ]);
   });
 
-  test("removes a current assessment from preferred when its explicit retry quarantines", async () => {
+  test("keeps a current report preferred through deterministic fallback on explicit retry", async () => {
     const root = await mkdtemp(resolve(tmpdir(), "tavernkeeper-v5-retry-"));
     const outputPath = resolve(
       root,
@@ -963,8 +1166,13 @@ describe("TavernKeeper V5 report import", () => {
       now: () => new Date("2026-08-02T13:05:00.000Z"),
     });
 
-    expect(outcome.snapshot.reports).toEqual([prior]);
-    expect(outcome.snapshot.preferred_report_ids).toEqual([]);
+    expect(outcome.snapshot.reports).toEqual([
+      expect.objectContaining({
+        report_id: prior.report_id,
+        assessment_source: "deterministic_fallback",
+      }),
+    ]);
+    expect(outcome.snapshot.preferred_report_ids).toEqual([prior.report_id]);
     expect(outcome.import_state.quarantines).toEqual([
       expect.objectContaining({
         report_digest: index.reports[0].report_digest,
@@ -1050,7 +1258,7 @@ describe("TavernKeeper V5 report import", () => {
     ]);
   });
 
-  test("keeps provider failures batch-level and preserves both tracked files", async () => {
+  test("publishes a deterministic fallback for provider failures", async () => {
     const root = await mkdtemp(resolve(tmpdir(), "tavernkeeper-v5-provider-"));
     const outputPath = resolve(
       root,
@@ -1070,28 +1278,36 @@ describe("TavernKeeper V5 report import", () => {
     await writeFile(importStatePath, initialState);
     const [index, report] = await fixtures();
 
-    await expect(
-      reconcileTavernKeeperReports({
-        root,
-        outputPath,
-        importStatePath,
-        registry,
-        dnsLookup: publicDnsLookup,
-        requestImpl: async (url: string) =>
-          jsonResponse(url === TAVERNKEEPER_REPORT_INDEX_URL ? index : report),
-        synthesizeReport: async () => {
-          throw new TavernKeeperSynthesisError(
-            "provider-transient",
-            "provider-timeout",
-          );
-        },
-        now: () => new Date("2026-08-02T12:00:00.000Z"),
-      }),
-    ).rejects.toMatchObject({ kind: "provider-transient" });
+    const outcome = await reconcileTavernKeeperReports({
+      root,
+      outputPath,
+      importStatePath,
+      registry,
+      dnsLookup: publicDnsLookup,
+      requestImpl: async (url: string) =>
+        jsonResponse(url === TAVERNKEEPER_REPORT_INDEX_URL ? index : report),
+      synthesizeReport: async () => {
+        throw new TavernKeeperSynthesisError(
+          "provider-transient",
+          "provider-timeout",
+        );
+      },
+      now: () => new Date("2026-08-02T12:00:00.000Z"),
+    });
 
-    expect(await readFile(outputPath, "utf8")).toBe(
-      '{"schema_version":5,"generated_at":"1970-01-01T00:00:00.000Z","preferred_report_ids":[],"reports":[]}\n',
-    );
-    expect(await readFile(importStatePath, "utf8")).toBe(initialState);
+    expect(outcome.snapshot).toMatchObject({
+      schema_version: 6,
+      preferred_report_ids: [index.reports[0].report_id],
+      reports: [
+        {
+          report_id: index.reports[0].report_id,
+          assessment_source: "deterministic_fallback",
+          synthesis_model: "deterministic-policy-v4",
+        },
+      ],
+    });
+    expect(outcome.import_state.quarantines).toEqual([
+      expect.objectContaining({ diagnostic: "provider-timeout" }),
+    ]);
   });
 });

--- a/tests/unit/tavernkeeper-scan-indicator.test.tsx
+++ b/tests/unit/tavernkeeper-scan-indicator.test.tsx
@@ -24,7 +24,9 @@ function scanReport(
   return {
     reportId: "report-1",
     riskLevel: "high",
-    headline: "High concern",
+    headline: "Immediate danger",
+    dangerBasis: "malicious_or_compromised",
+    assessmentSource: "model",
     summary:
       "The combined reviewed behavior could expose credentials to an untrusted endpoint.",
     minorCautions: 1,
@@ -61,6 +63,7 @@ const redStatus: TavernKeeperCardStatus = {
 
 const tealReport = scanReport({
   riskLevel: "low",
+  dangerBasis: "none",
   headline: "Low concern",
   summary:
     "The reviewed behavior matches the extension's stated purpose, with no material concerns.",
@@ -126,14 +129,18 @@ describe("TavernKeeperScanIndicator", () => {
 
     fireEvent.click(
       screen.getByRole("button", {
-        name: /TavernKeeper scan: High concern; current/u,
+        name: /TavernKeeper scan: Immediate danger; current/u,
       }),
     );
 
     const panel = screen.getByRole("dialog", {
       name: "TavernKeeper Scan Results",
     });
-    expect(panel).toHaveTextContent("High concern");
+    expect(panel).toHaveTextContent("Immediate danger");
+    expect(panel).toHaveTextContent("Danger basis");
+    expect(panel).toHaveTextContent(
+      "Credible malicious or compromised behavior",
+    );
     expect(panel).toHaveTextContent("current");
     expect(panel).toHaveTextContent(redReport.summary);
     expect(panel).toHaveTextContent("1 minor caution");
@@ -170,6 +177,30 @@ describe("TavernKeeperScanIndicator", () => {
     expect(
       container.querySelector('svg[data-icon="scan-fill"]'),
     ).toBeInTheDocument();
+  });
+
+  test("distinguishes vulnerability danger from malicious behavior", () => {
+    const report = scanReport({
+      dangerBasis: "critical_exploitable_vulnerability",
+      maliciousEvidence:
+        "No credible malicious behavior was identified; the danger is an exploitable vulnerability.",
+    });
+    render(
+      <TavernKeeperScanIndicator
+        projectId="vulnerability-danger"
+        status={{ ...redStatus, report, history: [report] }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+
+    const panel = screen.getByRole("dialog");
+    expect(panel).toHaveTextContent(
+      "Critical, readily exploitable vulnerability",
+    );
+    expect(panel).not.toHaveTextContent(
+      "Credible malicious or compromised behavior",
+    );
   });
 
   test.each([
@@ -335,7 +366,7 @@ describe("TavernKeeperScanIndicator", () => {
     });
     expect(blocks).toHaveLength(12);
     expect(blocks[0]).toHaveAccessibleName(
-      "TavernKeeper scan history: high concern on July 2, 2026 at commit 0000000 under policy policy-1",
+      "TavernKeeper scan history: immediate danger on July 2, 2026 at commit 0000000 under policy policy-1",
     );
     expect(blocks.at(-1)).toHaveAccessibleName(
       "TavernKeeper scan history: low concern on July 13, 2026 at commit 0000000 under policy policy-1",
@@ -372,7 +403,7 @@ describe("TavernKeeperScanIndicator", () => {
     );
 
     const trigger = screen.getByRole("button", {
-      name: /TavernKeeper scan: High concern; current/u,
+      name: /TavernKeeper scan: Immediate danger; current/u,
     });
     fireEvent.pointerEnter(trigger);
     expect(screen.getByRole("dialog")).toBeInTheDocument();
@@ -390,7 +421,7 @@ describe("TavernKeeperScanIndicator", () => {
     );
 
     const trigger = screen.getByRole("button", {
-      name: /TavernKeeper scan: High concern; current/u,
+      name: /TavernKeeper scan: Immediate danger; current/u,
     });
     fireEvent.pointerEnter(trigger, { pointerType: "touch" });
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
@@ -406,7 +437,7 @@ describe("TavernKeeperScanIndicator", () => {
     );
 
     const trigger = screen.getByRole("button", {
-      name: /TavernKeeper scan: High concern; current/u,
+      name: /TavernKeeper scan: Immediate danger; current/u,
     });
     fireEvent.pointerEnter(trigger);
     fireEvent.pointerLeave(trigger);
@@ -435,7 +466,7 @@ describe("TavernKeeperScanIndicator", () => {
     );
     fireEvent.click(
       screen.getByRole("button", {
-        name: /TavernKeeper scan: High concern; current/u,
+        name: /TavernKeeper scan: Immediate danger; current/u,
       }),
     );
     const panel = screen.getByRole("dialog");
@@ -457,7 +488,7 @@ describe("TavernKeeperScanIndicator", () => {
     );
 
     const trigger = screen.getByRole("button", {
-      name: /TavernKeeper scan: High concern; current/u,
+      name: /TavernKeeper scan: Immediate danger; current/u,
     });
     fireEvent.focus(trigger);
     const panel = screen.getByRole("dialog");
@@ -482,7 +513,7 @@ describe("TavernKeeperScanIndicator", () => {
     );
 
     const trigger = screen.getByRole("button", {
-      name: /TavernKeeper scan: High concern; current/u,
+      name: /TavernKeeper scan: Immediate danger; current/u,
     });
     await user.tab();
     expect(trigger).toHaveFocus();
@@ -571,7 +602,7 @@ describe("TavernKeeperScanIndicator", () => {
     );
 
     const trigger = screen.getByRole("button", {
-      name: /TavernKeeper scan: High concern; current/u,
+      name: /TavernKeeper scan: Immediate danger; current/u,
     });
     fireEvent.click(trigger);
     fireEvent.keyDown(document, { key: "Escape" });
@@ -591,7 +622,7 @@ describe("TavernKeeperScanIndicator", () => {
     );
 
     const [firstTrigger, secondTrigger] = screen.getAllByRole("button", {
-      name: /TavernKeeper scan: High concern; current/u,
+      name: /TavernKeeper scan: Immediate danger; current/u,
     });
     fireEvent.pointerDown(firstTrigger, { pointerType: "touch" });
     fireEvent.focus(firstTrigger);

--- a/tests/unit/tavernkeeper-status.test.ts
+++ b/tests/unit/tavernkeeper-status.test.ts
@@ -37,6 +37,8 @@ function report(
     assessed_at: "2026-07-31T12:06:00.000Z",
     synthesis_policy_version: "1",
     synthesis_model: "gpt-5.6-luna",
+    danger_basis: "none",
+    assessment_source: "model",
     report_url:
       "https://mentallyquill.github.io/TavernKeeper/reports/github/42/" +
       `${currentSha}/3/${"c".repeat(64)}/`,
@@ -102,10 +104,11 @@ describe("deriveTavernKeeperCardStatus", () => {
       derive(
         report({
           target_sha: olderSha,
+          danger_basis: "malicious_or_compromised",
           assessment: {
             ...report().assessment,
             risk_level: "high",
-            headline: "High concern",
+            headline: "Immediate danger",
             minor_cautions: 0,
             high_danger: 1,
             malicious_evidence: "The review found credible malicious behavior.",
@@ -116,6 +119,7 @@ describe("deriveTavernKeeperCardStatus", () => {
       state: "red",
       riskLevel: "high",
       freshness: "stale",
+      report: { dangerBasis: "malicious_or_compromised" },
     });
   });
 
@@ -183,6 +187,7 @@ describe("deriveTavernKeeperCardStatus", () => {
       report_id: "d".repeat(64),
       target_sha: olderSha,
       assessed_at: "2026-07-31T12:06:00.000Z",
+      danger_basis: "critical_exploitable_vulnerability",
       assessment: { ...report().assessment, risk_level: "high" },
     });
     const correction = report({
@@ -235,6 +240,8 @@ describe("deriveTavernKeeperCardStatus", () => {
       minorCautions: 1,
       materialConcerns: 0,
       highDanger: 0,
+      dangerBasis: "none",
+      assessmentSource: "model",
       synthesisModel: "gpt-5.6-luna",
       treeUrl: `https://github.com/owner/repo/tree/${currentSha}`,
     });

--- a/tests/unit/tavernkeeper-synthesis.test.ts
+++ b/tests/unit/tavernkeeper-synthesis.test.ts
@@ -5,7 +5,9 @@ import { describe, expect, test, vi } from "vitest";
 
 import { EnrichmentProviderError } from "../../scripts/catalog/enrichment-provider.mjs";
 import {
+  buildDeterministicAssessment,
   deriveEvidenceFloor,
+  deriveProjectAdvisory,
   TavernaryAssessmentValidationError,
   tavernKeeperAssessmentRequirements,
   validateTavernaryAssessment,
@@ -163,7 +165,7 @@ describe("TavernKeeper evidence floors", () => {
     });
   });
 
-  test("keeps expected behavior, minor weaknesses, and low-confidence material evidence low", () => {
+  test("keeps expected behavior and minor weaknesses low", () => {
     expect(
       deriveEvidenceFloor([
         assessment(),
@@ -171,6 +173,13 @@ describe("TavernKeeper evidence floors", () => {
           candidate_id: "e".repeat(64),
           disposition: "minor_weakness",
         }),
+      ]),
+    ).toBe("low");
+  });
+
+  test("keeps low-confidence material evidence visible as material", () => {
+    expect(
+      deriveEvidenceFloor([
         assessment({
           candidate_id: "f".repeat(64),
           disposition: "material_vulnerability",
@@ -178,7 +187,105 @@ describe("TavernKeeper evidence floors", () => {
           recommended_risk: "material",
         }),
       ]),
-    ).toBe("low");
+    ).toBe("material");
+  });
+});
+
+describe("TavernKeeper deterministic project advisory", () => {
+  test("does not turn a critical but merely plausible dependency finding red", () => {
+    expect(
+      deriveProjectAdvisory([
+        assessment({
+          disposition: "material_vulnerability",
+          impact: "critical",
+          exploitability: "plausible",
+          confidence: "high",
+          recommended_risk: "material",
+        }),
+      ]),
+    ).toEqual({ risk_level: "material", danger_basis: "none" });
+  });
+
+  test("identifies high-confidence malicious behavior as immediate danger", () => {
+    expect(
+      deriveProjectAdvisory([
+        assessment({
+          disposition: "credible_malicious_behavior",
+          impact: "critical",
+          exploitability: "readily_exploitable",
+          confidence: "high",
+          recommended_risk: "high",
+        }),
+      ]),
+    ).toEqual({
+      risk_level: "high",
+      danger_basis: "malicious_or_compromised",
+    });
+  });
+
+  test("identifies a critical readily exploitable vulnerability as immediate danger", () => {
+    expect(
+      deriveProjectAdvisory([
+        assessment({
+          disposition: "material_vulnerability",
+          impact: "critical",
+          exploitability: "readily_exploitable",
+          confidence: "high",
+          recommended_risk: "high",
+        }),
+      ]),
+    ).toEqual({
+      risk_level: "high",
+      danger_basis: "critical_exploitable_vulnerability",
+    });
+  });
+
+  test("identifies mixed immediate-danger evidence", () => {
+    expect(
+      deriveProjectAdvisory([
+        assessment({
+          disposition: "credible_malicious_behavior",
+          impact: "critical",
+          exploitability: "readily_exploitable",
+          confidence: "high",
+          recommended_risk: "high",
+        }),
+        assessment({
+          candidate_id: "e".repeat(64),
+          disposition: "material_vulnerability",
+          impact: "critical",
+          exploitability: "readily_exploitable",
+          confidence: "high",
+          recommended_risk: "high",
+        }),
+      ]),
+    ).toEqual({ risk_level: "high", danger_basis: "mixed" });
+  });
+
+  test("builds policy-owned fallback copy and exact counts", () => {
+    const report = reportWith([
+      assessment({
+        disposition: "material_vulnerability",
+        impact: "critical",
+        exploitability: "readily_exploitable",
+        confidence: "high",
+        recommended_risk: "high",
+      }),
+    ]);
+
+    expect(buildDeterministicAssessment(report)).toEqual({
+      risk_level: "high",
+      headline: "Immediate danger identified",
+      summary:
+        "TavernKeeper identified immediate-danger evidence at the scanned commit. The detailed generated summary was unavailable; review the complete technical report before installing or using this project.",
+      minor_cautions: 0,
+      material_concerns: 0,
+      high_danger: 1,
+      malicious_evidence:
+        "No credible malicious behavior was identified; the immediate-danger result is based on a critical, readily exploitable vulnerability.",
+      cited_finding_ids: [candidateId],
+      interaction_chains: [],
+    });
   });
 });
 
@@ -407,7 +514,7 @@ describe("Tavernary final assessment contract", () => {
     });
   });
 
-  test("accepts a supported causal interaction that escalates risk", () => {
+  test("rejects a causal interaction that tries to select the project color", () => {
     const secondId = "e".repeat(64);
     const report = reportWith([
       assessment({ disposition: "minor_weakness" }),
@@ -430,7 +537,9 @@ describe("Tavernary final assessment contract", () => {
       ],
     });
 
-    expect(validateTavernaryAssessment(output, report)).toEqual(output);
+    expect(
+      validationFailure(() => validateTavernaryAssessment(output, report)),
+    ).toMatchObject({ diagnostic: "unsupported_escalation" });
   });
 });
 
@@ -505,10 +614,20 @@ describe("strict Luna synthesis", () => {
     expect(requestBody.messages[0].content).toContain(
       "A nonzero high_danger count does not set the project risk level",
     );
+    expect(requestBody.messages[0].content).toContain(
+      "risk_level must exactly equal required_project_advisory.risk_level",
+    );
+    expect(requestBody.messages[0].content).not.toContain(
+      "You may escalate beyond it",
+    );
     const projected = JSON.parse(requestBody.messages[1].content);
     expect(projected).toMatchObject({
       allowed_candidate_ids: [candidateId],
       evidence_floor: "low",
+      required_project_advisory: {
+        risk_level: "low",
+        danger_basis: "none",
+      },
       required_counts:
         tavernKeeperAssessmentRequirements(report).required_counts,
       repair,

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -666,6 +666,8 @@ test("reconciles reports independently and wakes TavernKeeper only after a chang
   expect(synthesisStep?.run).not.toContain('type == \\"number\\"');
   expect(incidentStep?.run).toContain("incident_key");
   expect(incidentStep?.run).toContain("Report incident key:");
+  expect(incidentStep?.run).toContain("narrative enrichment fallback");
+  expect(incidentStep?.run).not.toContain("report synthesis quarantined");
   expect(incidentStep?.run).not.toContain("diagnostic in:body");
   expect(incidentStep?.["continue-on-error"]).toBe(true);
   expect(


### PR DESCRIPTION
## Summary

- make Tavernary derive red only for immediate danger at the scanned commit, with an explicit malicious, exploitable-vulnerability, or mixed basis
- keep every valid TavernKeeper report publishable and preferred through deterministic fallback when optional narrative synthesis fails
- label red as Immediate danger across cards and history, document that red projects remain listed for community awareness, and migrate tracked summaries to schema 6

## Verification

- npm run check (211 files, 2320 tests; build and static export passed)
- npm run test:scan-e2e (Chromium, WebKit, and mobile smoke passed)
- npm run test:scan-visual (10 snapshots passed)