### PR TITLE
Bind required synthesis citations deterministically

### DIFF
--- a/scripts/security/tavernkeeper-synthesis.mjs
+++ b/scripts/security/tavernkeeper-synthesis.mjs
@@ -70,6 +70,24 @@ function providerFailure(error) {
   );
 }
 
+function bindRequiredCitations(output, report) {
+  if (
+    output === null ||
+    typeof output !== "object" ||
+    Array.isArray(output) ||
+    !Array.isArray(output.cited_finding_ids) ||
+    !output.cited_finding_ids.every((id) => typeof id === "string")
+  ) {
+    return output;
+  }
+  const citedFindingIds = [...output.cited_finding_ids];
+  for (const id of tavernKeeperAssessmentRequirements(report)
+    .required_candidate_ids) {
+    if (!citedFindingIds.includes(id)) citedFindingIds.push(id);
+  }
+  return { ...output, cited_finding_ids: citedFindingIds };
+}
+
 export async function synthesizeTavernKeeperReport(report, options) {
   const provider = options?.provider;
   if (!provider || typeof provider.generate !== "function") {
@@ -85,7 +103,10 @@ export async function synthesizeTavernKeeperReport(report, options) {
   for (let attempt = 1; attempt <= maximumAttempts; attempt += 1) {
     try {
       const generated = await provider.generate({ report, repair });
-      const assessment = validateTavernaryAssessment(generated.output, report);
+      const assessment = validateTavernaryAssessment(
+        bindRequiredCitations(generated.output, report),
+        report,
+      );
       const now = options.now?.() ?? new Date();
       if (!(now instanceof Date) || !Number.isFinite(now.getTime())) {
         throw new TavernKeeperSynthesisError(

--- a/tests/unit/tavernkeeper-synthesis.test.ts
+++ b/tests/unit/tavernkeeper-synthesis.test.ts
@@ -550,6 +550,25 @@ describe("strict Luna synthesis", () => {
     });
   });
 
+  test("binds policy-required citations before validating model output", async () => {
+    const report = {
+      ...(await fixture()),
+      ...reportWith([assessment({ disposition: "minor_weakness" })]),
+    };
+    const generate = vi.fn().mockResolvedValue({
+      output: lowOutput({ minor_cautions: 1 }),
+      metadata: { requestedModel: "gpt-5.6-luna" },
+    });
+
+    const result = await synthesizeTavernKeeperReport(report, {
+      provider: { generate },
+      now: () => new Date("2026-08-02T12:06:00.000Z"),
+    });
+
+    expect(generate).toHaveBeenCalledTimes(1);
+    expect(result.assessment.cited_finding_ids).toEqual([candidateId]);
+  });
+
   test("repairs public prose that leaks structured finding IDs", async () => {
     const report = await fixture();
     const leakedSummary = "The extension is low risk [" + "f".repeat(64) + "].";


### PR DESCRIPTION
## Summary

- append contract-required candidate IDs to structurally valid model output before assessment validation
- retain validation of unknown IDs, schema, prose, counts, interactions, and risk
- prove required citation omission no longer consumes repair attempts

## Production evidence

- issue #265 attempts 2 and 3 both failed with missing_candidate_ids despite explicit repair metadata

## Verification

- npm run check
- 211 test files and 2311 tests passed
- production static build and export verification passed