### PR TITLE
Repair schema-v6 TavernKeeper summary entry

### DIFF
--- a/data/security/tavernkeeper-report-summaries.json
+++ b/data/security/tavernkeeper-report-summaries.json
@@ -4466,6 +4466,8 @@
       "assessed_at": "2026-08-05T04:59:33.434Z",
       "synthesis_policy_version": "3",
       "synthesis_model": "gpt-5.6-luna",
+      "danger_basis": "none",
+      "assessment_source": "model",
       "assessment": {
         "cited_finding_ids": [
           "14a66334365238113c6ae7edc276bf763ada97c62141b3ea60a7125543bbff4c",


### PR DESCRIPTION
## Summary

- restore danger_basis and assessment_source on the Flowchart summary imported during the v5-to-v6 migration race
- keep the v6 reader strict

## Verification

- npm run security:validate-reports
- npm run check
- 210 tracked summaries and 1 quarantine validated
- 211 test files and 2321 tests passed
- production static build and export verification passed