### PR TITLE
Fix deployment after source delisting

### DIFF
--- a/scripts/security/tavernkeeper-reports.mjs
+++ b/scripts/security/tavernkeeper-reports.mjs
@@ -161,12 +161,16 @@ function registrySources(registry) {
   throw new Error("TavernKeeper report registry is invalid");
 }
 
-function activeGithubSourcesByRepositoryId(registry) {
+function activeGithubSourcesByRepositoryId(
+  registry,
+  { includeDelisted = false } = {},
+) {
   const sources = new Map();
   for (const source of registrySources(registry)) {
     if (
       source?.type === "github" &&
-      source.status === "active" &&
+      (source.status === "active" ||
+        (includeDelisted && source.status === "delisted")) &&
       Number.isSafeInteger(source.repository_id) &&
       source.repository_id > 0 &&
       typeof source.id === "string" &&
@@ -585,7 +589,9 @@ export function validateStoredReportIndex(snapshotInput, registry) {
   ) {
     throw new Error("Tracked TavernKeeper assessment snapshot is invalid");
   }
-  const sources = activeGithubSourcesByRepositoryId(registry);
+  const sources = activeGithubSourcesByRepositoryId(registry, {
+    includeDelisted: true,
+  });
   const reportIds = new Set();
   for (const entry of snapshot.reports) {
     assertExactKeys(

--- a/tests/unit/tavernkeeper-reports.test.ts
+++ b/tests/unit/tavernkeeper-reports.test.ts
@@ -585,6 +585,29 @@ describe("TavernKeeper V5 report import", () => {
     ).toThrow(/preferred/u);
   });
 
+  test("keeps stored history valid during a source delist transition", async () => {
+    const [index] = await fixtures();
+    const entry = assessedEntry(index.reports[0]);
+    const stored = {
+      schema_version: 5,
+      generated_at: index.generated_at,
+      preferred_report_ids: [entry.report_id],
+      reports: [entry],
+    };
+    const delistedRegistry = registry.map((source) => ({
+      ...source,
+      status: "delisted",
+    }));
+
+    expect(validateStoredReportIndex(stored, delistedRegistry)).toMatchObject({
+      schema_version: 6,
+      reports: [expect.objectContaining({ source_id: "github-42" })],
+    });
+    expect(() => validateReportIndex(index, delistedRegistry)).toThrow(
+      /active Tavernary source/u,
+    );
+  });
+
   test("retains an inactive-policy assessment only as non-preferred history", async () => {
     const [index] = await fixtures();
     const historical = {


### PR DESCRIPTION
## What changed

- allow tracked TavernKeeper history to remain valid while a source transitions from active to delisted
- keep the live TavernKeeper report index restricted to active sources
- add a regression proving the stored-history allowance does not make a delisted source an active scan target

## Root cause

Issue #290 successfully merged the delisted source record, but the exact Pages deployment failed because its cached TavernKeeper assessment still referenced Tavernary. Post-deploy reconciliation is responsible for removing that cache, creating a circular dependency when pre-deploy validation rejects it first.

## Verification

- focused regression failed with `TavernKeeper report does not identify an active Tavernary source` before the repair
- `npm.cmd test -- tests/unit/tavernkeeper-reports.test.ts` (33 passed)
- `npm.cmd run check` (211 files, 2,323 tests; production build and static export passed)

Refs #290
