### PR TITLE
Add manual issue admission recovery

### DIFF
--- a/.github/workflows/admit-issue.yml
+++ b/.github/workflows/admit-issue.yml
@@ -1,5 +1,5 @@
 name: "Submission intake: Check issue eligibility"
-run-name: "Issue #${{ github.event.issue.number }}: Check submission eligibility"
+run-name: "Issue #${{ inputs.issue_number || github.event.issue.number }}: Check submission eligibility"
 
 on:
   issues:
@@ -7,6 +7,12 @@ on:
       - opened
       - reopened
       - edited
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue number to re-run admission for"
+        required: true
+        type: number
 
 permissions:
   contents: read
@@ -14,7 +20,7 @@ permissions:
   actions: write
 
 concurrency:
-  group: issue-admission-${{ github.event.issue.number }}
+  group: issue-admission-${{ inputs.issue_number || github.event.issue.number }}
   cancel-in-progress: false
 
 jobs:
@@ -32,6 +38,7 @@ jobs:
         run: node scripts/submissions/admit-issue.mjs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ inputs.issue_number || github.event.issue.number }}
       - name: Reject conflicting submission labels
         if: >-
           steps.admission.outputs.admitted == 'true' &&

--- a/docs/maintenance/github-actions-user-guides.md
+++ b/docs/maintenance/github-actions-user-guides.md
@@ -224,7 +224,10 @@ skipped jobs and do not perform checkout, setup, or lifecycle work.
 ### 9.1 Route newly opened submission issues to the right validation path
 
 - Workflow: `admit-issue.yml`
-- What it does: checks if a new issue is eligible and dispatches to either project or Kit triage.
+- What it does: checks if an issue is eligible and dispatches it to the
+  appropriate Project, Kit, owner-request, withdrawal, or help triage path.
+- Manual recovery: choose **Run workflow**, enter the issue number, and let
+  admission dispatch the downstream workflow. Do not dispatch triage first.
 
 ### 9.2 Build and maintain the generated project transaction PR
 

--- a/docs/maintenance/operations-runbook.md
+++ b/docs/maintenance/operations-runbook.md
@@ -25,11 +25,13 @@ Do not edit generated artifacts manually.
 
 ### Issue admission
 
-`.github/workflows/admit-issue.yml` runs on `opened` and `reopened` issue
-events. External accounts may keep their oldest 10 issues open across every
-public issue type. Ordering uses creation time and then issue number; pull
-requests do not count. Repository owners, members, and collaborators bypass
-this public-intake cap.
+`.github/workflows/admit-issue.yml` runs on `opened`, `reopened`, and `edited`
+issue events. Maintainers can also run it manually with an issue number to
+recover a missed webhook; the manual path fetches the live open issue and
+applies the same admission policy before routing it. External accounts may keep
+their oldest 10 issues open across every public issue type. Ordering uses
+creation time and then issue number; pull requests do not count. Repository
+owners, members, and collaborators bypass this public-intake cap.
 
 Admission labels are workflow state:
 
@@ -42,8 +44,9 @@ reset. Reopening a limited issue reruns admission. If the open-issue lookup
 fails, admission fails open so a legitimate report is not discarded or
 stranded.
 
-After a GitHub API outage, rerun failed admission workflows. Do not manually
-publish a submission that has not passed its normal Project or Kit validation.
+After a GitHub API outage, run **Submission intake: Check issue eligibility**
+with the affected issue number. Do not dispatch triage first or manually publish
+a submission that has not passed its normal Project or Kit validation.
 
 ### Submission triage
 

--- a/docs/superpowers/plans/2026-08-06-manual-issue-admission.md
+++ b/docs/superpowers/plans/2026-08-06-manual-issue-admission.md
@@ -1,0 +1,39 @@
+# Manual Issue Admission Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development while executing this plan.
+
+**Goal:** Add a safe manual recovery dispatch to issue admission.
+
+**Architecture:** The workflow supplies an issue number. The admission script resolves a complete live issue payload through its existing GitHub API boundary, then feeds the unchanged admission and routing policy.
+
+**Tech Stack:** GitHub Actions YAML, Node.js 24, Vitest, TypeScript tests.
+
+## Global Constraints
+
+- Do not bypass admission policy or manually grant `issue-admitted`.
+- Preserve issue-event behavior.
+- Run only focused tests plus formatting for changed files.
+
+---
+
+### Task 1: Manual event resolution
+
+**Files:**
+- Modify: `tests/unit/admit-issue.test.ts`
+- Modify: `scripts/submissions/admit-issue.mjs`
+
+- [ ] Add failing tests for resolving a dispatch input into a live issue event and rejecting invalid numbers/PRs.
+- [ ] Run the focused admission test and confirm the expected failures.
+- [ ] Implement the minimal resolver and route CLI execution through it.
+- [ ] Re-run the focused admission test.
+
+### Task 2: Workflow contract
+
+**Files:**
+- Modify: `tests/unit/workflows.test.ts`
+- Modify: `.github/workflows/admit-issue.yml`
+
+- [ ] Add a failing workflow-contract test for the manual input and event/input fallback expressions.
+- [ ] Run the focused workflow test and confirm the expected failure.
+- [ ] Add `workflow_dispatch` and wire the issue number through run naming, concurrency, and the admission step.
+- [ ] Run both focused test files and formatting checks for changed files.

--- a/docs/superpowers/specs/2026-08-06-manual-issue-admission-design.md
+++ b/docs/superpowers/specs/2026-08-06-manual-issue-admission-design.md
@@ -1,0 +1,19 @@
+# Manual Issue Admission Dispatch Design
+
+## Goal
+
+Allow maintainers to recover missed issue webhooks by running **Submission intake: Check issue eligibility** with an issue number.
+
+## Design
+
+- Add a required numeric `issue_number` input to `workflow_dispatch`.
+- Use the input or the issue event number consistently in the run name, concurrency key, and admission step.
+- When the event has no issue payload, fetch the current issue through the existing authenticated GitHub request boundary, reject pull requests, and synthesize a `reopened` admission event.
+- Reuse the existing admission policy and downstream route dispatches without bypass labels or special recovery policy.
+
+## Safety and verification
+
+- Reject missing, non-positive, or non-integer issue numbers.
+- Reject API objects representing pull requests.
+- Preserve existing opened, reopened, and edited behavior.
+- Cover manual event resolution and workflow input/concurrency contracts with focused unit tests.

--- a/scripts/submissions/admit-issue.d.mts
+++ b/scripts/submissions/admit-issue.d.mts
@@ -58,3 +58,13 @@ export function issueAdmissionOutputs(
   issue_number: string;
   route: IssueRoute;
 };
+
+export function resolveIssueAdmissionEvent(input: {
+  event: {
+    action?: string;
+    repository?: { full_name: string };
+    issue?: AdmissionEvent["issue"];
+  };
+  issueNumber?: string | number;
+  request: GitHubRequest;
+}): Promise<AdmissionEvent>;

--- a/scripts/submissions/admit-issue.mjs
+++ b/scripts/submissions/admit-issue.mjs
@@ -262,11 +262,45 @@ export function issueAdmissionOutputs(decision, event) {
   };
 }
 
+export async function resolveIssueAdmissionEvent({
+  event,
+  issueNumber,
+  request,
+}) {
+  if (event.issue) return event;
+
+  const normalizedIssueNumber = String(issueNumber ?? "").trim();
+  if (!/^[1-9]\d*$/.test(normalizedIssueNumber)) {
+    throw new Error("Manual issue admission requires a positive issue number.");
+  }
+
+  const repository = event.repository?.full_name;
+  if (!repository) {
+    throw new Error("Manual issue admission requires a repository.");
+  }
+
+  const issue = await request(
+    `/repos/${repository}/issues/${normalizedIssueNumber}`,
+  );
+  if (issue?.pull_request) {
+    throw new Error("Manual issue admission does not accept pull requests.");
+  }
+  if (issue?.state !== "open") {
+    throw new Error("Manual issue admission requires an open issue.");
+  }
+
+  return { ...event, action: "reopened", issue };
+}
+
 async function main() {
-  const event = JSON.parse(
+  const rawEvent = JSON.parse(
     await readFile(process.env.GITHUB_EVENT_PATH, "utf8"),
   );
-  if (!event.issue) return;
+  const event = await resolveIssueAdmissionEvent({
+    event: rawEvent,
+    issueNumber: process.env.ISSUE_NUMBER,
+    request: github,
+  });
   const decision = await processIssueAdmission({ event, request: github });
   if (process.env.GITHUB_OUTPUT) {
     const outputs = issueAdmissionOutputs(decision, event);

--- a/tests/unit/admit-issue.test.ts
+++ b/tests/unit/admit-issue.test.ts
@@ -6,6 +6,7 @@ import {
   issueAdmissionOutputs,
   listOpenIssues,
   processIssueAdmission,
+  resolveIssueAdmissionEvent,
 } from "../../scripts/submissions/admit-issue.mjs";
 
 const kitBody = [
@@ -113,6 +114,66 @@ function openIssues(count: number) {
     user: { id: 42 },
   }));
 }
+
+test("resolves a manual admission dispatch from the live open issue", async () => {
+  const dispatchEvent = {
+    action: "workflow_dispatch",
+    repository: { full_name: "MentallyQuill/Tavernary" },
+  };
+  const liveIssue = {
+    number: 325,
+    state: "open",
+    author_association: "NONE",
+    user: { id: 42, login: "submitter" },
+    labels: [{ name: "project-submission" }],
+  };
+  const request = vi.fn(async () => liveIssue);
+
+  await expect(
+    resolveIssueAdmissionEvent({
+      event: dispatchEvent,
+      issueNumber: "325",
+      request,
+    }),
+  ).resolves.toEqual({
+    ...dispatchEvent,
+    action: "reopened",
+    issue: liveIssue,
+  });
+  expect(request).toHaveBeenCalledWith(
+    "/repos/MentallyQuill/Tavernary/issues/325",
+  );
+});
+
+test.each([
+  ["missing", "", undefined],
+  ["zero", "0", undefined],
+  ["non-integer", "3.25", undefined],
+  ["closed issue", "325", { number: 325, state: "closed" }],
+  [
+    "pull request",
+    "325",
+    {
+      number: 325,
+      state: "open",
+      pull_request: { url: "https://example.test" },
+    },
+  ],
+])(
+  "rejects a manual admission dispatch for a %s",
+  async (_, issueNumber, issue) => {
+    await expect(
+      resolveIssueAdmissionEvent({
+        event: {
+          action: "workflow_dispatch",
+          repository: { full_name: "MentallyQuill/Tavernary" },
+        },
+        issueNumber,
+        request: async () => issue,
+      }),
+    ).rejects.toThrow();
+  },
+);
 
 test("paginates open issues and preserves numeric identity data", async () => {
   const firstPage = Array.from({ length: 100 }, (_, index) => ({

--- a/tests/unit/issue-admission.test.ts
+++ b/tests/unit/issue-admission.test.ts
@@ -159,6 +159,9 @@ test("documents the shared public issue cap and maintainer recovery", async () =
   expect(kits).toContain("repository-wide open-issue limit");
   expect(operations).toContain("issue-admitted");
   expect(operations).toContain("issue-limit-reached");
-  expect(operations).toContain("opened` and `reopened");
+  expect(operations).toContain("`opened`, `reopened`, and `edited`");
+  expect(operations).toContain(
+    "run **Submission intake: Check issue eligibility**",
+  );
   expect(operations).toContain("fails open");
 });

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -1481,16 +1481,28 @@ test("continues admitted submissions in the admission run", async () => {
   );
 
   expect(admission.on.issues.types).toEqual(["opened", "reopened", "edited"]);
+  expect(admission.on.workflow_dispatch.inputs.issue_number).toMatchObject({
+    description: "Issue number to re-run admission for",
+    required: true,
+    type: "number",
+  });
   expect(admission.permissions).toEqual({
     contents: "read",
     issues: "write",
     actions: "write",
   });
   expect(admission.concurrency).toEqual({
-    group: "issue-admission-${{ github.event.issue.number }}",
+    group:
+      "issue-admission-${{ inputs.issue_number || github.event.issue.number }}",
     "cancel-in-progress": false,
   });
+  expect(admission["run-name"]).toBe(
+    "Issue #${{ inputs.issue_number || github.event.issue.number }}: Check submission eligibility",
+  );
   expect(source).toContain("node scripts/submissions/admit-issue.mjs");
+  expect(source).toContain(
+    "ISSUE_NUMBER: ${{ inputs.issue_number || github.event.issue.number }}",
+  );
   expect(source).toContain("steps.admission.outputs.admitted == 'true'");
   expect(source).toContain("gh workflow run triage-submission.yml");
   expect(source).toContain("gh workflow run triage-kit-submission.yml");


### PR DESCRIPTION
## Summary

- add a manual `issue_number` dispatch to the admission workflow
- fetch and validate the live open issue before applying normal admission policy
- route successful recovery through the existing downstream triage workflows
- document outage recovery and cover the workflow/script contracts

## Root cause

GitHub does not replay issue webhooks lost during an Actions incident. Maintainers had no safe way to rerun admission, so direct triage dispatches failed because `issue-admitted` was absent.

## Validation

- `npm run catalog:build`
- `npm test` (211 files, 2,329 tests)
- Prettier checks for changed files
- `git diff --check`