### PR TITLE
fix(about): polish page copy

### DIFF
--- a/docs/superpowers/plans/2026-08-06-about-page-copyedit.md
+++ b/docs/superpowers/plans/2026-08-06-about-page-copyedit.md
@@ -1,0 +1,108 @@
+# About Page Copyedit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Correct grammar and unclear prose across Tavernary's About page without changing its structure, policy meaning, or community-focused voice.
+
+**Architecture:** Keep the change entirely within the existing static About page component and its focused unit test. Add a regression assertion for the corrected lead, then make conservative sentence-level edits to the page while preserving headings, links, section order, and substantive claims.
+
+**Tech Stack:** Next.js 16, React 19, TypeScript, Vitest, Testing Library, Prettier, ESLint
+
+## Global Constraints
+
+- Preserve the existing headings, section order, navigation, actions, and links.
+- Preserve all substantive statements about project eligibility, independence, TavernKeeper scans, reporting, removal, safety, and legal responsibility.
+- Keep capitalization of catalog project types consistent with the product UI.
+- Do not introduce layout, styling, navigation, responsive, catalog-behavior, submission-rule, security-classification, or reporting-workflow changes.
+
+---
+
+### Task 1: Copyedit and verify the About page
+
+**Files:**
+- Modify: `tests/unit/about-page.test.tsx`
+- Modify: `src/app/about/page.tsx`
+
+**Interfaces:**
+- Consumes: the existing `AboutPage` React component and Testing Library render helpers.
+- Produces: corrected reader-facing About-page prose with an automated regression check for the lead paragraph.
+
+- [ ] **Step 1: Add the failing lead-copy regression test**
+
+Add this assertion immediately after `render(<AboutPage />);` in the existing About-page test:
+
+```tsx
+expect(
+  screen.getByText(
+    "Tavernary is a search and discovery catalog for AI roleplay tools in and around the SillyTavern community. It indexes public project information and directs visitors to each project's creator-owned repository or source page.",
+  ),
+).toBeInTheDocument();
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```powershell
+npm.cmd test -- tests/unit/about-page.test.tsx
+```
+
+Expected: FAIL because the current lead contains `surrounding the SillyTavern community` and the duplicated phrase `repositories repository` rather than the approved copy.
+
+- [ ] **Step 3: Apply the conservative full-page copyedit**
+
+Replace the lead with:
+
+```tsx
+<p className="about-lead">
+  Tavernary is a search and discovery catalog for AI roleplay tools in and
+  around the SillyTavern community. It indexes public project information
+  and directs visitors to each project&apos;s creator-owned repository or
+  source page.
+</p>
+```
+
+Then review every remaining paragraph in `src/app/about/page.tsx` and make only sentence-level edits that fix grammar, agreement, duplication, awkward constructions, or ambiguous antecedents. Do not change headings, IDs, links, actions, product rules, security color meanings, eligibility requirements, reporting authority, or legal qualifications.
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run:
+
+```powershell
+npm.cmd test -- tests/unit/about-page.test.tsx
+```
+
+Expected: PASS with no warnings or errors.
+
+- [ ] **Step 5: Format and inspect the scoped diff**
+
+Run:
+
+```powershell
+npm.cmd exec prettier -- --write src/app/about/page.tsx tests/unit/about-page.test.tsx
+git diff --check -- src/app/about/page.tsx tests/unit/about-page.test.tsx
+git diff -- src/app/about/page.tsx tests/unit/about-page.test.tsx
+```
+
+Expected: no whitespace errors; the diff contains only copy edits and the focused regression assertion.
+
+- [ ] **Step 6: Run the full repository gate**
+
+Run:
+
+```powershell
+npm.cmd run check
+```
+
+Expected: all formatting, lint, palette, catalog, security-report, type, unit, build, and static-export checks pass.
+
+- [ ] **Step 7: Commit only the feature files and plan**
+
+Run:
+
+```powershell
+git add -- src/app/about/page.tsx tests/unit/about-page.test.tsx docs/superpowers/plans/2026-08-06-about-page-copyedit.md
+git commit -m "fix(about): polish page copy"
+```
+
+Do not stage or modify the unrelated TavernKeeper report files already present in the worktree.

--- a/docs/superpowers/specs/2026-08-06-about-page-copyedit-design.md
+++ b/docs/superpowers/specs/2026-08-06-about-page-copyedit-design.md
@@ -1,0 +1,32 @@
+# About Page Copyedit Design
+
+## Goal
+
+Correct grammatical errors and unclear prose across Tavernary's About page while preserving its established meaning, structure, and community-focused voice.
+
+## Scope
+
+- Copyedit all reader-facing text in `src/app/about/page.tsx`.
+- Fix grammar, duplicated words, awkward phrasing, agreement, and ambiguous references.
+- Preserve the existing headings, section order, navigation, actions, and links.
+- Preserve all substantive statements about project eligibility, independence, TavernKeeper scans, reporting, removal, safety, and legal responsibility.
+- Keep capitalization of catalog project types consistent with the product UI.
+
+## Editorial Approach
+
+Use a conservative sentence-level edit. Prefer direct, natural phrasing without turning the page into marketing copy or introducing new claims. The opening paragraph should read:
+
+> Tavernary is a search and discovery catalog for AI roleplay tools in and around the SillyTavern community. It indexes public project information and directs visitors to each project's creator-owned repository or source page.
+
+## Verification
+
+- Add or update a focused unit assertion for the corrected opening copy.
+- Run the About-page unit test.
+- Run formatting and the repository's full `npm.cmd run check` gate.
+- Review the final diff to confirm that changes are editorial and preserve the protected policy meaning.
+
+## Out of Scope
+
+- Layout, styling, navigation, or responsive changes.
+- New About-page sections or claims.
+- Changes to catalog behavior, submission rules, security classifications, or reporting workflows.

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -19,41 +19,42 @@ export default function AboutPage() {
         <p className="about-kicker">About</p>
         <h1>About Tavernary</h1>
         <p className="about-lead">
-          Tavernary is a search and discovery catalog for AI roleplay tools,
-          surrounding the SillyTavern community. It indexes public project
-          information and sends visitors to creator-owned repositories
+          Tavernary is a search and discovery catalog for AI roleplay tools in
+          and around the SillyTavern community. It indexes public project
+          information and directs visitors to each project&apos;s creator-owned
           repository or source page.
         </p>
 
         <section>
           <h2>Why Tavernary exists</h2>
           <p>
-            The tools people use to shape their roleplay experience are spread
+            The tools people use to shape their roleplay experiences are spread
             across Reddit posts, Discord channels, creator repositories, and
             word of mouth. The best discoveries can be difficult to find again,
             and a great project can be invisible outside the small corner where
             someone happened to share it.
           </p>
           <p>
-            Tavernary is meant to give that scattered community a shared place
-            to gather: somewhere to explore what exists, understand what each
-            project does, and follow the path back to the people who made it.
+            Tavernary gives that scattered community a shared place to gather:
+            somewhere to explore what exists, understand what each project does,
+            and follow the path back to the people who made it.
           </p>
         </section>
 
         <section>
           <h2>Built for exploration</h2>
           <p>
-            Search projects and creators, browse Frontends, Extensions, and
+            Search for projects and creators, browse Frontends, Extensions, and
             System Presets, and use the catalog filters to narrow the field.
             Whether you are looking for a new interface, a small quality-of-life
             extension, or a preset to try, Tavernary is a place to start
             exploring.
           </p>
           <p>
-            The idea takes inspiration from PCPartPicker.com and its Reddit
-            roots: bring a fragmented community&apos;s knowledge into one place,
-            then give people the tools to make something that fits them.
+            Tavernary takes inspiration from PCPartPicker.com and from community
+            knowledge shared on Reddit. Its goal is to bring fragmented
+            knowledge into one place, then give people the tools to make
+            something that fits them.
           </p>
         </section>
 
@@ -66,9 +67,9 @@ export default function AboutPage() {
           </p>
           <p>
             Reorder the stack, save a draft in your browser, share your Kit with
-            others, and submit it for review. Kits are a way for the community
-            to show how its tools fit together—and for every visitor to find a
-            setup that feels like their own.
+            others, and submit it for review. Kits let the community show how
+            its tools fit together and help every visitor find a setup that
+            feels like their own.
           </p>
         </section>
 
@@ -102,8 +103,8 @@ export default function AboutPage() {
             documentation to understand what it is and how to run it.
           </p>
           <p>
-            Both providers receive the same repository activity, community, and
-            attribution treatment in the catalog.
+            Repositories from both providers receive the same activity,
+            community, and attribution treatment in the catalog.
           </p>
         </section>
 
@@ -116,9 +117,9 @@ export default function AboutPage() {
             <a href="https://mentallyquill.github.io/TavernKeeper/">
               TavernKeeper
             </a>
-            {", "}an advisory security-scanning system, but scan results are not
-            a guarantee that a project is safe or free of harmful behavior.
-            Tavernary does not host, install, or execute listed projects, and
+            {", "}an advisory security-scanning system, but scan results do not
+            guarantee that a project is safe or free of harmful behavior.
+            Tavernary does not host, install, or execute listed projects and
             cannot guarantee their code, dependencies, releases, installers, or
             behavior.
           </p>
@@ -133,10 +134,10 @@ export default function AboutPage() {
             low concern, orange means a material concern, and red means
             immediate danger at the exact scanned commit. A critical dependency
             advisory alone does not make a project red. Red results identify
-            whether the danger is credible malicious or compromised behavior, a
-            critical readily exploitable vulnerability, or both. Red projects
-            remain listed so the community can see the warning; scan results do
-            not automatically hide or delist a project.
+            credible malicious or compromised behavior, a critical and readily
+            exploitable vulnerability, or both. Red projects remain listed so
+            the community can see the warning; scan results do not automatically
+            hide or delist a project.
           </p>
         </section>
 

--- a/tests/e2e/contribution-links.spec.ts
+++ b/tests/e2e/contribution-links.spec.ts
@@ -21,7 +21,7 @@ test("explains Tavernary and links to contribution flows", async ({ page }) => {
   ).toBeVisible();
   await expect(
     page.getByText(
-      /Both providers receive the same repository activity, community, and attribution treatment/i,
+      /Repositories from both providers receive the same activity, community, and attribution treatment/i,
     ),
   ).toBeVisible();
   await expect(

--- a/tests/unit/about-page.test.tsx
+++ b/tests/unit/about-page.test.tsx
@@ -11,6 +11,11 @@ test("explains safety, reporting, and legal information on About", () => {
   render(<AboutPage />);
 
   expect(
+    screen.getByText(
+      "Tavernary is a search and discovery catalog for AI roleplay tools in and around the SillyTavern community. It indexes public project information and directs visitors to each project's creator-owned repository or source page.",
+    ),
+  ).toBeInTheDocument();
+  expect(
     screen.getByRole("heading", { name: "Safety and security" }),
   ).toBeInTheDocument();
   expect(
@@ -25,7 +30,7 @@ test("explains safety, reporting, and legal information on About", () => {
   );
   expect(
     screen.getByText(
-      /scan results are not a guarantee that a project is safe or free of harmful behavior/i,
+      /scan results do not guarantee that a project is safe or free of harmful behavior/i,
     ),
   ).toBeInTheDocument();
   expect(


### PR DESCRIPTION
## Summary

- correct the malformed About-page introduction
- polish grammar and clarity across the page without changing policy meaning
- add a focused regression assertion for the corrected lead

## Root cause

The introduction contained an awkward modifier and an accidental duplicated noun: `creator-owned repositories repository`.

## Impact

Visitors get clearer, grammatically correct About-page copy while all eligibility, safety, reporting, and legal statements retain their existing meaning.

## Verification

- `npm.cmd run check`
- 211 test files passed
- 2,329 tests passed
- production build passed
- static export verified
