### PR TITLE
Fix policy-4 JavaScript report import

### DIFF
--- a/scripts/security/tavernkeeper-reports.mjs
+++ b/scripts/security/tavernkeeper-reports.mjs
@@ -376,6 +376,7 @@ const originTools = {
   "osv-scanner": "osv-scanner",
   zizmor: "zizmor",
   malcontent: "malcontent",
+  "javascript-analysis": "javascript-analysis",
 };
 
 function assertReportCoverage(report) {

--- a/tests/unit/tavernkeeper-reports.test.ts
+++ b/tests/unit/tavernkeeper-reports.test.ts
@@ -310,6 +310,30 @@ describe("TavernKeeper V5 report import", () => {
     );
   });
 
+  test("accepts policy-4 candidates from completed JavaScript analysis", async () => {
+    const [fixtureIndex, baseReport] = await fixtures();
+    const report = addExpectedCandidate(policy4Report(baseReport));
+    report.candidates[0].origin = "javascript-analysis";
+    report.candidates[0].scanner_version =
+      "webcrack-2.16.0_js-x-ray-16.0.0_signatures-1_literals-1";
+    report.candidates[0].rule_id = "javascript.xray.unsafe-command";
+    report.coverage.tools.push({
+      name: "javascript-analysis",
+      version: report.candidates[0].scanner_version,
+      status: "completed",
+    });
+    const rebound = rebindReport(report);
+    const entry = projectIndexReport(rebound);
+    const validatedIndex = validateReportIndex(
+      { ...fixtureIndex, reports: [entry] },
+      registry,
+    );
+
+    expect(validateScanReport(rebound, validatedIndex.reports[0])).toEqual(
+      rebound,
+    );
+  });
+
   test("normalizes fetched policy-3 indexes that predate JavaScript coverage", async () => {
     const [index] = await fixtures();
     delete index.reports[0].coverage.javascript_analysis_status;


### PR DESCRIPTION
## Summary
- map the policy-4 javascript-analysis candidate origin to its completed scanner tool
- add a regression matching the first live Wandlight policy-4 candidate report

## Verification
- npm test: 212 files, 2,344 tests passed
- npm run build
- npm run verify:export
- formatting, lint, palette, catalog, report validation, and typecheck passed