### PR TITLE
Add plus OR catalog searches

### DIFF
--- a/docs/guides/using-the-catalog.md
+++ b/docs/guides/using-the-catalog.md
@@ -9,6 +9,10 @@ projects shown on the page.
 - Search requires all meaningful words, but the words may appear in any order.
   For example, `preset freaky` and `freaky preset` both find **Freaky
   Frankenstein 5.0**.
+- Join ordinary searches with `+` to show results matching any clause. For
+  example, `vectfox+summaryception` shows matches for either search, while
+  `Stab's Directives+Directive` keeps normal all-word matching inside each
+  clause. Copied catalog URLs preserve the complete expression.
 - Project and Kit titles, aliases, source identities, descriptions, kinds,
   primary functions, tags, frontends, compatibility, maintainers, and
   relationships are searchable.

--- a/docs/superpowers/plans/2026-08-09-search-plus-or.md
+++ b/docs/superpowers/plans/2026-08-09-search-plus-or.md
@@ -1,0 +1,344 @@
+# Search Plus OR Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a literal `+` OR operator that unions ordinary Tavernary searches and round-trips through a shareable URL.
+
+**Architecture:** Parse the raw field into independently normalized clauses, run each clause through the existing AND-based MiniSearch path, and merge duplicate cards at their best score. Keep the existing single `q` parameter and raw draft; standard URL encoding serializes the operator as `%2B`.
+
+**Tech Stack:** TypeScript, MiniSearch, React 19, Vitest, Testing Library, Playwright, Next.js 16
+
+## Global Constraints
+
+- Preserve exactly what the user types in the visible search field while editing.
+- Every nonempty `+` clause uses existing ordinary search behavior.
+- Empty clauses are ignored and duplicate cards appear once at their best score.
+- Add no exclusion, quoting, field-filter, precedence, or escape syntax.
+- Preserve ordinary `?q=preset+freaky` form-URL semantics as a space-separated query.
+- Keep Project and Kit search, filters, relevance transitions, corrections, and degraded fallback behavior.
+
+---
+
+### Task 1: Parse and execute OR expressions
+
+**Files:**
+- Modify: `src/features/search/search-normalization.ts:26-45`
+- Modify: `src/features/search/catalog-search.ts:60-420`
+- Test: `tests/unit/catalog-search.test.ts`
+
+**Interfaces:**
+- Produces: `searchClauses(value: string): string[]`
+- Preserves: `searchMeaning(value: string): string`, now returning canonical clauses joined by `+`
+- Preserves: `CatalogSearchIndex.search(query: string): CatalogSearchResults`
+- Preserves: `exactAllTermSearch(documents, query): CatalogSearchResults`
+
+- [ ] **Step 1: Write failing normalization and search tests**
+
+Add assertions that name the breaks: losing the OR boundary, treating a
+multi-word clause as OR, duplicating a card, retaining empty clauses, or
+reverting degraded search to global AND.
+
+```ts
+expect(searchClauses("  preset freaky + memory ++ ")).toEqual([
+  "preset freaky",
+  "memory",
+]);
+expect(searchMeaning("preset freaky+memory")).toBe("preset freaky+memory");
+
+const result = createCatalogSearchIndex(documents).search(
+  "preset freaky+memory books",
+);
+expect(result.matches.map(({ id }) => id).sort()).toEqual([
+  "freaky",
+  "memory",
+]);
+expect(
+  createCatalogSearchIndex(documents).search("preset missing+memory books")
+    .matches.map(({ id }) => id),
+).toEqual(["memory"]);
+expect(
+  createCatalogSearchIndex(documents).search("memory+memory books").matches,
+).toHaveLength(1);
+expect(
+  exactAllTermSearch(documents, "preset freaky+memory books").matches
+    .map(({ id }) => id)
+    .sort(),
+).toEqual(["freaky", "memory"]);
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```powershell
+npm.cmd test -- tests/unit/catalog-search.test.ts
+```
+
+Expected: FAIL because `searchClauses` is not exported and the current engine
+normalizes `+` into a space before requiring every term globally.
+
+- [ ] **Step 3: Add clause-aware normalization**
+
+Implement the expression boundary without changing `searchTerms`:
+
+```ts
+export function searchClauses(value: string) {
+  return value
+    .split("+")
+    .map((clause) => searchTerms(clause).join(" "))
+    .filter(Boolean);
+}
+
+export function searchMeaning(value: string) {
+  return searchClauses(value).join("+");
+}
+```
+
+- [ ] **Step 4: Merge independently searched clause results**
+
+Refactor the current single-query body into a clause operation. Merge matches
+by ID, replacing an existing match only when the new score is greater, and
+sort once after the union:
+
+```ts
+function mergeMatches(matches: CatalogSearchMatch[]) {
+  const bestById = new Map<string, CatalogSearchMatch>();
+  for (const match of matches) {
+    const current = bestById.get(match.id);
+    if (!current || match.score > current.score) bestById.set(match.id, match);
+  }
+  return [...bestById.values()].sort(
+    (left, right) => right.score - left.score || left.id.localeCompare(right.id),
+  );
+}
+```
+
+Use `searchClauses(query)` in both MiniSearch and exact-token paths. Search
+each clause with the existing `combineWith: "AND"`, term eligibility,
+`matchScore`, and evidence logic. If any query execution throws, call the
+clause-aware `degradedFallback(documents, query)` for the complete expression.
+
+- [ ] **Step 5: Compose clause-local corrections**
+
+Preserve uncorrected clauses and replace only clauses for which the existing
+correction function returns a candidate:
+
+```ts
+const corrected = clauses.map(
+  (clause) => correctionForQuery(miniSearch, clause) ?? clause,
+);
+const correction = corrected.some((clause, index) => clause !== clauses[index])
+  ? corrected.join("+")
+  : null;
+```
+
+Add a literal assertion such as:
+
+```ts
+expect(index.search("frankenstien+memory books").correction).toBe(
+  "frankenstein+memory books",
+);
+```
+
+- [ ] **Step 6: Run focused tests and verify GREEN**
+
+Run:
+
+```powershell
+npm.cmd test -- tests/unit/catalog-search.test.ts tests/unit/catalog-search-relevance.test.ts tests/unit/catalog-selectors.test.ts tests/unit/search-sort-transition.test.ts
+```
+
+Expected: all selected test files pass with no failures.
+
+- [ ] **Step 7: Commit the search engine behavior**
+
+```powershell
+git add src/features/search/search-normalization.ts src/features/search/catalog-search.ts tests/unit/catalog-search.test.ts
+git commit -m "feat(search): add plus OR expressions"
+```
+
+---
+
+### Task 2: Prove URL sharing and live catalog behavior
+
+**Files:**
+- Modify: `tests/unit/use-catalog-query.test.tsx`
+- Modify: `tests/e2e/catalog.spec.ts`
+- Modify: `docs/guides/using-the-catalog.md`
+
+**Interfaces:**
+- Consumes: `searchMeaning(value)` and `CatalogSearchIndex.search(query)` from Task 1
+- Verifies: existing `parseCatalogQuery`, `serializeCatalogQuery`, and raw search draft behavior
+- Produces: documented user syntax and browser regression coverage
+
+- [ ] **Step 1: Add the URL round-trip regression test**
+
+Exercise the real hook and browser history rather than duplicating
+`URLSearchParams` logic:
+
+```ts
+test("round-trips a literal plus operator through the shared URL", () => {
+  window.history.replaceState(null, "", "/?q=vectfox%2Bsummaryception");
+  const replaceState = vi.spyOn(window.history, "replaceState");
+  const { result } = renderHook(() => useCatalogQuery());
+
+  expect(result.current.query.search).toBe("vectfox+summaryception");
+
+  act(() => {
+    result.current.setQuery({
+      ...result.current.query,
+      search: "Stab's Directives+Directive",
+    });
+  });
+
+  expect(replaceState).toHaveBeenLastCalledWith(
+    null,
+    "",
+    "/?q=Stab%27s+Directives%2BDirective",
+  );
+});
+```
+
+Also retain the existing `/?q=preset+freaky` expectation to prove form-URL
+spaces remain backward compatible.
+
+- [ ] **Step 2: Run the query-state test**
+
+Run:
+
+```powershell
+npm.cmd test -- tests/unit/use-catalog-query.test.tsx tests/unit/search-sort-transition.test.ts
+```
+
+Expected: both files pass. The URL encoding behavior already belongs to the
+existing serializer; this is a characterization and regression gate.
+
+- [ ] **Step 3: Add the focused browser scenario**
+
+Add a test to `tests/e2e/catalog.spec.ts` that fills the real search field,
+asserts both result families, inspects the encoded URL, reloads it, and proves
+the multi-word clause:
+
+```ts
+test("shares plus OR searches with normal clause behavior", async ({ page }) => {
+  const search = page.getByRole("searchbox", { name: "Search projects" });
+  await search.fill("vectfox+summaryception");
+  await expect(page.getByRole("heading", { name: "VectFox", exact: true }))
+    .toBeVisible();
+  await expect(page.getByRole("heading", {
+    name: "Extension-Summaryception",
+    exact: true,
+  })).toBeVisible();
+  await expect(page).toHaveURL(/q=vectfox%2Bsummaryception/iu);
+
+  await page.reload();
+  await expect(search).toHaveValue("vectfox+summaryception");
+
+  await search.fill("Stab's Directives+Directive");
+  await expect(page.getByRole("heading", {
+    name: "Stab's Directives",
+    exact: true,
+  })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Directive", exact: true }))
+    .toBeVisible();
+});
+```
+
+- [ ] **Step 4: Document only the approved operator**
+
+Add this bullet under **Search and filters** in
+`docs/guides/using-the-catalog.md`:
+
+```markdown
+- Join ordinary searches with `+` to show results matching any clause. For
+  example, `vectfox+summaryception` shows matches for either search, while
+  `Stab's Directives+Directive` keeps normal all-word matching inside each
+  clause. Copied catalog URLs preserve the complete expression.
+```
+
+- [ ] **Step 5: Run focused unit and browser verification**
+
+Run:
+
+```powershell
+npm.cmd test -- tests/unit/catalog-search.test.ts tests/unit/use-catalog-query.test.tsx tests/unit/search-sort-transition.test.ts
+npm.cmd run test:e2e -- --grep "shares plus OR searches"
+```
+
+Expected: focused unit files and the new Chromium browser scenario pass.
+
+- [ ] **Step 6: Commit URL, browser, and documentation coverage**
+
+```powershell
+git add tests/unit/use-catalog-query.test.tsx tests/e2e/catalog.spec.ts docs/guides/using-the-catalog.md
+git commit -m "test(search): cover shared OR queries"
+```
+
+---
+
+### Task 3: Verify, publish, and merge
+
+**Files:**
+- Verify all files changed by Tasks 1 and 2
+
+**Interfaces:**
+- Consumes: the complete feature branch
+- Produces: a reviewed GitHub PR merged into `main`
+
+- [ ] **Step 1: Run the complete local verification gate**
+
+```powershell
+npm.cmd run format:check
+npm.cmd run lint
+npm.cmd run typecheck
+npm.cmd test
+npm.cmd run build
+npm.cmd run verify:export
+npm.cmd run test:e2e -- --grep "shares plus OR searches"
+```
+
+Expected: every command exits zero; the unit suite reports no failures and the
+focused browser scenario passes.
+
+- [ ] **Step 2: Inspect scope and commit history**
+
+```powershell
+git status -sb
+git diff --check origin/main...HEAD
+git diff --stat origin/main...HEAD
+git log --oneline origin/main..HEAD
+```
+
+Expected: only the approved design, plan, search behavior, tests, and user guide
+are present; the worktree is clean.
+
+- [ ] **Step 3: Push and open a ready PR**
+
+```powershell
+git push -u origin codex/search-plus-or
+gh pr create --base main --head codex/search-plus-or --title "Add plus OR catalog searches" --body "Adds + as an OR operator between normal Tavernary searches. Preserves all-term matching inside each clause and percent-encodes the operator in shareable URLs. Verified with focused search browser coverage and the full local validation gate."
+```
+
+The PR body summarizes syntax, URL behavior, user impact, and exact verification
+commands. The user explicitly requested merge, so create a ready PR rather than
+the publishing workflow's default draft.
+
+- [ ] **Step 4: Confirm checks and merge the PR**
+
+```powershell
+$prNumber = gh pr view --json number --jq '.number'
+gh pr checks $prNumber --watch
+gh pr merge $prNumber --merge --delete-branch
+```
+
+Expected: all required checks pass and GitHub reports the PR merged.
+
+- [ ] **Step 5: Verify merged source and remote state**
+
+```powershell
+gh pr view $prNumber --json state,mergedAt,mergeCommit,url,headRefName,baseRefName
+gh api repos/MentallyQuill/Tavernary/commits/main --jq '{sha:.sha,message:.commit.message,date:.commit.author.date}'
+```
+
+Expected: PR state is `MERGED`, the merge commit exists on `main`, and its SHA
+matches the current remote-main head returned by the API.

--- a/docs/superpowers/specs/2026-08-09-search-plus-or-design.md
+++ b/docs/superpowers/specs/2026-08-09-search-plus-or-design.md
@@ -1,0 +1,105 @@
+# Search Plus OR Design
+
+## Goal
+
+Allow one Tavernary search to combine multiple ordinary searches with `+`, so
+the complete result set and its copied URL can be shared. Each clause keeps the
+existing all-meaningful-terms, relevance, prefix, fuzzy, alias, metadata,
+Project, Kit, filter, and sort behavior.
+
+## Syntax
+
+- `vectfox+summaryception` means `(vectfox) OR (summaryception)`.
+- `Stab's Directives+Directive` means
+  `(Stab's AND Directives) OR (Directive)`.
+- Any number of nonempty clauses is accepted, so `a+b+c` is valid.
+- Whitespace around a clause is normalized by the existing search rules.
+- Empty clauses are ignored. `a++b` and `a+b+` behave like `a+b`.
+- A result matching more than one clause appears once.
+- This release adds no exclusion, quoting, field-filter, or precedence syntax.
+
+The visible field continues to preserve exactly what the user types while
+editing. The URL continues to use one `q` parameter. `URLSearchParams` encodes
+a literal operator as `%2B`, so a copied OR search restores `+`; an ordinary
+URL such as `?q=preset+freaky` retains standard form semantics and restores the
+space-separated search `preset freaky`.
+
+## Search architecture
+
+Add a focused expression parser to search normalization. It splits the raw
+value on literal `+`, applies the current clause normalization independently,
+drops empty clauses, and exposes a canonical expression meaning joined by `+`.
+This keeps `a b` distinct from `a+b` for result-cache validation and search-sort
+transitions without changing ordinary query meaning.
+
+The existing MiniSearch index remains Tavernary's only search engine. Its
+public `search()` operation runs each normalized clause through the current
+single-clause AND search, unions the matches, and sorts the union with the
+existing relevance scores and deterministic ID fallback. When one project
+matches multiple clauses, retain the match with the highest score and its
+evidence; equal scores retain the earlier clause's match.
+
+The exact-token degraded fallback uses the same clause parser and union rules,
+so a MiniSearch initialization or execution failure does not silently revert
+OR to AND. The result is marked degraded under the existing contract.
+
+Correction candidates remain clause-local. The returned correction replaces
+correctable clauses and preserves the other normalized clauses, but the
+existing UI continues to surface a correction only through its current
+no-result behavior.
+
+## URL and UI behavior
+
+No new URL parameter or filter control is introduced. The existing catalog
+query parser, serializer, raw search draft, browser history, active query chip,
+clear action, Project/Kit mode, and copied browser URL remain authoritative.
+The serializer's standard percent encoding is sufficient; it must be covered by
+a regression test proving `%2B` round-trips to a visible literal `+`.
+
+Search remains ANDed with every selected catalog filter. Filters operate on the
+union exactly as they operate on ordinary search results. Relevance remains the
+default search sort, and changing between `a b` and `a+b` is a meaningful query
+change that restores Relevance after a manual sort override.
+
+## Failure handling and edge cases
+
+- No meaningful clauses produces the existing empty-search behavior.
+- One meaningful clause uses ordinary search behavior without a special path
+  visible to callers.
+- Duplicate clauses do not duplicate cards.
+- A query-time MiniSearch exception degrades the complete expression to the
+  exact-token OR fallback.
+- Existing literal-plus URL compatibility is preserved through `%2B`; no escape
+  grammar is added in this release.
+
+## Verification
+
+Unit coverage must prove clause normalization, multi-clause union, multi-word
+AND semantics inside a clause, duplicate suppression, empty-clause handling,
+best-score retention, correction composition, and degraded exact-token OR
+behavior. Query-state coverage must prove literal `+` serializes as `%2B`,
+round-trips through parsing, and remains distinct from a space-separated query.
+
+Browser coverage must type `vectfox+summaryception`, show the normal matches for
+both clauses, confirm the URL contains `%2B`, reload the copied URL, and confirm
+the exact visible expression and results return. It must also cover
+`Stab's Directives+Directive` to prove spaces inside a clause retain ordinary
+all-term behavior.
+
+Before merge, run focused search/query tests, the full unit suite, lint,
+typecheck, production build, static-export verification, and the focused
+browser scenario.
+
+## Acceptance criteria
+
+- `vectfox+summaryception` returns the union of both ordinary searches.
+- `Stab's Directives+Directive` returns the union of its multi-word and
+  single-word clauses.
+- Every clause preserves normal Tavernary search behavior.
+- Duplicate cards appear once at their best relevance score.
+- Copied URLs restore the literal `+`, visible query, filters, sort, and result
+  set.
+- Ordinary space-separated searches and `?q=preset+freaky` URLs retain their
+  existing meaning.
+- Project and Kit search, exact-token degradation, corrections, and filters do
+  not regress.

--- a/src/features/search/catalog-search.ts
+++ b/src/features/search/catalog-search.ts
@@ -3,6 +3,7 @@ import MiniSearch, { type SearchResult } from "minisearch";
 import {
   allowedEditDistance,
   normalizeSearchText,
+  searchClauses,
   searchDocumentTerms,
   searchMeaning,
   searchTerms,
@@ -236,6 +237,20 @@ function degradedFallback(
   return { ...exactAllTermSearch(documents, query), degraded: true };
 }
 
+function mergeMatches(matches: CatalogSearchMatch[]) {
+  const bestById = new Map<string, CatalogSearchMatch>();
+  for (const match of matches) {
+    const current = bestById.get(match.id);
+    if (!current || match.score > current.score) {
+      bestById.set(match.id, match);
+    }
+  }
+  return [...bestById.values()].sort(
+    (left, right) =>
+      right.score - left.score || left.id.localeCompare(right.id),
+  );
+}
+
 function conservativeCorrection(original: string, candidate: string) {
   const originalTerms = uniqueTerms(original);
   const candidateTerms = uniqueTerms(candidate);
@@ -281,8 +296,8 @@ export function exactAllTermSearch(
   documents: CatalogSearchDocument[],
   query: string,
 ): CatalogSearchResults {
-  const normalizedQuery = searchMeaning(query);
-  const fullQuery = normalizeSearchText(query);
+  const clauses = searchClauses(query);
+  const normalizedQuery = clauses.join("+");
   if (!normalizedQuery) {
     return {
       normalizedQuery,
@@ -292,21 +307,22 @@ export function exactAllTermSearch(
     };
   }
 
-  const terms = uniqueTerms(normalizedQuery);
-  const matches = documents
-    .filter((document) => {
-      const tokens = tokenSet(documentText(document));
-      return terms.every((term) => tokens.has(term));
-    })
-    .map((document): CatalogSearchMatch => ({
-      id: document.id,
-      score: matchScore(document, fullQuery, 3, 0),
-      evidence: exactEvidence(document, normalizedQuery),
-    }))
-    .sort(
-      (left, right) =>
-        right.score - left.score || left.id.localeCompare(right.id),
-    );
+  const matches = mergeMatches(
+    clauses.flatMap((clause) => {
+      const terms = uniqueTerms(clause);
+      const fullQuery = normalizeSearchText(clause);
+      return documents
+        .filter((document) => {
+          const tokens = tokenSet(documentText(document));
+          return terms.every((term) => tokens.has(term));
+        })
+        .map((document): CatalogSearchMatch => ({
+          id: document.id,
+          score: matchScore(document, fullQuery, 3, 0),
+          evidence: exactEvidence(document, clause),
+        }));
+    }),
+  );
 
   return {
     normalizedQuery,
@@ -355,8 +371,8 @@ export function createCatalogSearchIndex(
 
   return {
     search(query) {
-      const normalizedQuery = searchMeaning(query);
-      const fullQuery = normalizeSearchText(query);
+      const clauses = searchClauses(query);
+      const normalizedQuery = clauses.join("+");
       if (!normalizedQuery) {
         return {
           normalizedQuery,
@@ -367,46 +383,56 @@ export function createCatalogSearchIndex(
       }
 
       try {
-        const results = miniSearch.search(normalizedQuery);
-        const matches = results
-          .flatMap((result): CatalogSearchMatch[] => {
-            const document = documentsById.get(String(result.id));
-            if (!document) return [];
-            const termMatches = uniqueTerms(normalizedQuery)
-              .map((term) => bestTermMatch(result, term))
-              .filter((match): match is TermMatch => match !== null);
-            if (termMatches.length !== uniqueTerms(normalizedQuery).length) {
-              return [];
-            }
-            const exactnessTier = termMatches.some(
-              ({ kind }) => kind === "fuzzy",
-            )
-              ? 1
-              : termMatches.some(({ kind }) => kind === "prefix")
-                ? 2
-                : 3;
-            return [
-              {
-                id: document.id,
-                score: matchScore(
-                  document,
-                  fullQuery,
-                  exactnessTier,
-                  result.score,
-                ),
-                evidence: evidenceForResult(document, result, normalizedQuery),
-              },
-            ];
-          })
-          .sort(
-            (left, right) =>
-              right.score - left.score || left.id.localeCompare(right.id),
-          );
+        const matches = mergeMatches(
+          clauses.flatMap((clause) => {
+            const fullQuery = normalizeSearchText(clause);
+            const terms = uniqueTerms(clause);
+            return miniSearch
+              .search(clause)
+              .flatMap((result): CatalogSearchMatch[] => {
+                const document = documentsById.get(String(result.id));
+                if (!document) return [];
+                const termMatches = terms
+                  .map((term) => bestTermMatch(result, term))
+                  .filter((match): match is TermMatch => match !== null);
+                if (termMatches.length !== terms.length) {
+                  return [];
+                }
+                const exactnessTier = termMatches.some(
+                  ({ kind }) => kind === "fuzzy",
+                )
+                  ? 1
+                  : termMatches.some(({ kind }) => kind === "prefix")
+                    ? 2
+                    : 3;
+                return [
+                  {
+                    id: document.id,
+                    score: matchScore(
+                      document,
+                      fullQuery,
+                      exactnessTier,
+                      result.score,
+                    ),
+                    evidence: evidenceForResult(document, result, clause),
+                  },
+                ];
+              });
+          }),
+        );
+        const correctedClauses = clauses.map(
+          (clause) => correctionForQuery(miniSearch, clause) ?? clause,
+        );
+        const correction = correctedClauses.some(
+          (clause, index) => clause !== clauses[index],
+        )
+          ? correctedClauses.join("+")
+          : null;
 
         return {
           normalizedQuery,
           matches,
-          correction: correctionForQuery(miniSearch, normalizedQuery),
+          correction,
           degraded: false,
         };
       } catch (error) {

--- a/src/features/search/components/search-empty-state.tsx
+++ b/src/features/search/components/search-empty-state.tsx
@@ -1,4 +1,4 @@
-import { searchMeaning } from "../search-normalization";
+import { searchClauses } from "../search-normalization";
 
 export interface SearchFeedback {
   query: string;
@@ -38,7 +38,8 @@ export function SearchEmptyState({
   onUseCorrection,
   onClearFilters,
 }: SearchFeedback & { mode: "projects" | "kits" }) {
-  if (!searchMeaning(query)) {
+  const clauseCount = searchClauses(query).length;
+  if (clauseCount === 0) {
     return (
       <div className="catalog-empty">
         <strong>
@@ -72,15 +73,22 @@ export function SearchEmptyState({
     );
   }
 
+  const hasAlternatives = clauseCount > 1;
+
   return (
     <div className="catalog-empty search-empty-state">
       <strong>
-        No {mode === "kits" ? "Kit" : "project"} matches all search terms
+        No {mode === "kits" ? "Kit" : "project"} matches{" "}
+        {hasAlternatives ? "any search clause" : "all search terms"}
       </strong>
       <span>
         {correction
-          ? "All terms are required. Check the suggested spelling."
-          : "Try removing a term."}
+          ? hasAlternatives
+            ? "All words within each clause are required. Check the suggested spelling."
+            : "All terms are required. Check the suggested spelling."
+          : hasAlternatives
+            ? "Try removing a word from a clause."
+            : "Try removing a term."}
       </span>
       {correction ? (
         <SearchCorrection

--- a/src/features/search/search-normalization.ts
+++ b/src/features/search/search-normalization.ts
@@ -40,8 +40,15 @@ export function searchDocumentTerms(value: string) {
   return [...new Set([...normalizedTerms, ...compactTerms])];
 }
 
+export function searchClauses(value: string) {
+  return value
+    .split("+")
+    .map((clause) => searchTerms(clause).join(" "))
+    .filter(Boolean);
+}
+
 export function searchMeaning(value: string) {
-  return searchTerms(value).join(" ");
+  return searchClauses(value).join("+");
 }
 
 export function allowedEditDistance(term: string): 0 | 1 | 2 {

--- a/tests/e2e/catalog.spec.ts
+++ b/tests/e2e/catalog.spec.ts
@@ -718,6 +718,21 @@ test("shares plus OR searches with normal clause behavior", async ({
   await expect(
     page.getByRole("heading", { name: "Directive", exact: true }),
   ).toBeVisible();
+
+  await search.fill("Stab's Directives+vectfox");
+
+  await expect(
+    page.getByRole("heading", {
+      name: "Stab's Directives",
+      exact: true,
+    }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "VectFox", exact: true }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Directive", exact: true }),
+  ).toHaveCount(0);
 });
 
 test("searches Kits by noncontiguous structured fields", async ({ page }) => {

--- a/tests/e2e/catalog.spec.ts
+++ b/tests/e2e/catalog.spec.ts
@@ -676,6 +676,50 @@ test("searches, changes density, and accepts legacy view URLs", async ({
   ).toHaveValue("");
 });
 
+test("shares plus OR searches with normal clause behavior", async ({
+  page,
+}) => {
+  const search = page.getByRole("searchbox", { name: "Search projects" });
+
+  await search.fill("vectfox+summaryception");
+
+  await expect(
+    page.getByRole("heading", { name: "VectFox", exact: true }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("heading", {
+      name: "Extension-Summaryception",
+      exact: true,
+    }),
+  ).toBeVisible();
+  await expect(page).toHaveURL(/q=vectfox%2Bsummaryception/iu);
+
+  await page.reload();
+
+  await expect(search).toHaveValue("vectfox+summaryception");
+  await expect(
+    page.getByRole("heading", { name: "VectFox", exact: true }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("heading", {
+      name: "Extension-Summaryception",
+      exact: true,
+    }),
+  ).toBeVisible();
+
+  await search.fill("Stab's Directives+Directive");
+
+  await expect(
+    page.getByRole("heading", {
+      name: "Stab's Directives",
+      exact: true,
+    }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Directive", exact: true }),
+  ).toBeVisible();
+});
+
 test("searches Kits by noncontiguous structured fields", async ({ page }) => {
   await page.getByRole("button", { name: "Kits", exact: true }).click();
   await expect(

--- a/tests/unit/catalog-search.test.ts
+++ b/tests/unit/catalog-search.test.ts
@@ -8,6 +8,7 @@ import {
 import {
   allowedEditDistance,
   normalizeSearchText,
+  searchClauses,
   searchDocumentTerms,
   searchMeaning,
   searchTerms,
@@ -62,6 +63,14 @@ describe("search normalization", () => {
     expect(searchMeaning("PRESET FREAKY")).toBe("preset freaky");
   });
 
+  test("preserves nonempty plus-separated clauses in query meaning", () => {
+    expect(searchClauses("  preset freaky + memory ++ ")).toEqual([
+      "preset freaky",
+      "memory",
+    ]);
+    expect(searchMeaning("preset freaky+memory")).toBe("preset freaky+memory");
+  });
+
   test("preserves compact identity tokens alongside camel-case words", () => {
     expect(searchDocumentTerms("MentallyQuill/SillyTavern")).toEqual([
       "mentally",
@@ -92,6 +101,32 @@ describe("catalog search", () => {
     expect(index.search("freaky preset").matches.map(({ id }) => id)).toEqual([
       "freaky",
     ]);
+  });
+
+  test("unions ordinary searches while requiring every term in each clause", () => {
+    const index = createCatalogSearchIndex(documents);
+
+    expect(
+      index
+        .search("preset freaky+memory books")
+        .matches.map(({ id }) => id)
+        .sort(),
+    ).toEqual(["freaky", "memory"]);
+    expect(
+      index.search("preset missing+memory books").matches.map(({ id }) => id),
+    ).toEqual(["memory"]);
+  });
+
+  test("ignores empty clauses and keeps a duplicate at its best match", () => {
+    const result = createCatalogSearchIndex(documents).search(
+      "++memory+memory books+",
+    );
+
+    expect(result.normalizedQuery).toBe("memory+memory books");
+    expect(result.matches).toHaveLength(1);
+    expect(
+      result.matches[0]?.evidence.map(({ queryTerm }) => queryTerm),
+    ).toEqual(["memory", "books"]);
   });
 
   test("ranks exact title terms above supporting-field matches", () => {
@@ -143,6 +178,14 @@ describe("catalog search", () => {
     expect(index.search("gln").matches).toEqual([]);
   });
 
+  test("composes corrections without replacing unchanged clauses", () => {
+    const index = createCatalogSearchIndex(documents);
+
+    expect(index.search("frankenstien+memory books").correction).toBe(
+      "frankenstein+memory books",
+    );
+  });
+
   test("returns field evidence for exact visible and hidden matches", () => {
     const index = createCatalogSearchIndex(documents);
 
@@ -166,6 +209,11 @@ describe("catalog search", () => {
     ).toEqual(["freaky"]);
     expect(exactAllTermSearch(documents, "frankenstien").matches).toEqual([]);
     expect(exactAllTermSearch(documents, "set freaky").matches).toEqual([]);
+    expect(
+      exactAllTermSearch(documents, "preset freaky+memory books")
+        .matches.map(({ id }) => id)
+        .sort(),
+    ).toEqual(["freaky", "memory"]);
   });
 
   test("degrades to exact tokens when MiniSearch initialization fails", () => {
@@ -179,11 +227,15 @@ describe("catalog search", () => {
       });
 
     try {
-      const result =
-        createCatalogSearchIndex(documents).search("preset freaky");
+      const result = createCatalogSearchIndex(documents).search(
+        "preset freaky+memory books",
+      );
 
       expect(result.degraded).toBe(true);
-      expect(result.matches.map(({ id }) => id)).toEqual(["freaky"]);
+      expect(result.matches.map(({ id }) => id).sort()).toEqual([
+        "freaky",
+        "memory",
+      ]);
     } finally {
       addAll.mockRestore();
       consoleError.mockRestore();
@@ -202,10 +254,13 @@ describe("catalog search", () => {
       });
 
     try {
-      const result = index.search("preset freaky");
+      const result = index.search("preset freaky+memory books");
 
       expect(result.degraded).toBe(true);
-      expect(result.matches.map(({ id }) => id)).toEqual(["freaky"]);
+      expect(result.matches.map(({ id }) => id).sort()).toEqual([
+        "freaky",
+        "memory",
+      ]);
     } finally {
       search.mockRestore();
       consoleError.mockRestore();

--- a/tests/unit/search-evidence.test.tsx
+++ b/tests/unit/search-evidence.test.tsx
@@ -109,6 +109,23 @@ test("distinguishes all-term misses from ordinary empty catalog states", () => {
   rerender(
     <SearchEmptyState
       mode="kits"
+      query="missing clause+other missing"
+      textMatchCount={0}
+      activeFilterCount={0}
+      correction="missing clauses+other missing"
+      onUseCorrection={vi.fn()}
+    />,
+  );
+  expect(screen.getByText("No Kit matches any search clause")).toBeVisible();
+  expect(
+    screen.getByText(
+      "All words within each clause are required. Check the suggested spelling.",
+    ),
+  ).toBeVisible();
+
+  rerender(
+    <SearchEmptyState
+      mode="kits"
       query=""
       textMatchCount={0}
       activeFilterCount={0}

--- a/tests/unit/search-sort-transition.test.ts
+++ b/tests/unit/search-sort-transition.test.ts
@@ -39,6 +39,17 @@ test("resets a manual override after a meaningful edit", () => {
   ).toBe("relevance");
 });
 
+test("treats changing AND terms into OR clauses as a meaningful edit", () => {
+  expect(
+    nextSearchSort({
+      previousSearch: "preset freaky",
+      nextSearch: "preset+freaky",
+      currentSort: "alphabetical",
+      browseSort: "alphabetical",
+    }),
+  ).toBe("relevance");
+});
+
 test("restores the remembered browse sort when cleared", () => {
   expect(
     nextSearchSort({

--- a/tests/unit/use-catalog-query.test.tsx
+++ b/tests/unit/use-catalog-query.test.tsx
@@ -24,6 +24,28 @@ describe("catalog query history", () => {
     expect(result.current.query.sort).toBe(sort);
   });
 
+  test("round-trips a literal plus operator through the shared URL", () => {
+    window.history.replaceState(null, "", "/?q=vectfox%2Bsummaryception");
+    const replaceState = vi.spyOn(window.history, "replaceState");
+    const { result } = renderHook(() => useCatalogQuery());
+
+    expect(result.current.query.search).toBe("vectfox+summaryception");
+
+    act(() => {
+      result.current.setQuery({
+        ...result.current.query,
+        search: "Stab's Directives+Directive",
+      });
+    });
+
+    expect(replaceState).toHaveBeenLastCalledWith(
+      null,
+      "",
+      "/?q=Stab%27s+Directives%2BDirective",
+    );
+    expect(result.current.query.search).toBe("Stab's Directives+Directive");
+  });
+
   test("treats a stale Uncategorized URL as the default category", () => {
     window.history.replaceState(null, "", "/?category=uncategorized");
 


### PR DESCRIPTION
## Summary
- add `+` as OR between normal Tavernary search clauses
- preserve all-word matching, relevance, corrections, degraded fallback, filters, and Project/Kit behavior inside each clause
- round-trip literal `+` as `%2B` in shareable URLs while preserving legacy form-URL spaces
- make OR no-result copy clause-aware and document the syntax

## Verification
- `npm.cmd run check` (212 test files, 2,354 tests; formatting, lint, validation, typecheck, production build, static export)
- `npm.cmd run test:e2e -- --grep "shares plus OR searches"` (Chromium, 1 passed)
- independent final code review completed; blocking copy finding fixed and browser proof strengthened
