### PR TITLE
Accept TavernKeeper review fallback coverage

### DIFF
--- a/data/schemas/tavernkeeper-scan-report.v5.schema.json
+++ b/data/schemas/tavernkeeper-scan-report.v5.schema.json
@@ -542,6 +542,16 @@
           "type": "integer",
           "minimum": 0,
           "maximum": 9007199254740991
+        },
+        "model_completed": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        "deterministic_fallback": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
         }
       },
       "required": ["required", "completed"],

--- a/scripts/security/tavernkeeper-reports.mjs
+++ b/scripts/security/tavernkeeper-reports.mjs
@@ -23,6 +23,8 @@ const incompleteJavascriptLimitation =
   "JavaScript analysis was incomplete, so this first-filter scan supports no clean conclusion about unobserved behavior.";
 const metadataOnlyEvidenceLimitation =
   "One or more scanner candidates refer to non-text artifacts. Their size, digest, and scanner metadata were verified, but raw contents were not provided to the contextual model.";
+const deterministicReviewFallbackLimitation =
+  "One or more scanner candidates did not receive contextual model assessment within the bounded review window. They remain conservatively classified as material concerns and require manual inspection.";
 const rfc3339DateTime =
   /^(?<year>\d{4})-(?<month>0[1-9]|1[0-2])-(?<day>0[1-9]|[12]\d|3[01])T(?<hour>[01]\d|2[0-3]):(?<minute>[0-5]\d):(?<second>[0-5]\d)(?:\.\d+)?Z$/u;
 
@@ -398,6 +400,33 @@ function assertReportCoverage(report) {
           evidenceValidation.validated_candidates))
   ) {
     throw new Error("TavernKeeper report review coverage is incomplete");
+  }
+  const modelCompleted = report.review_coverage.model_completed;
+  const deterministicFallback = report.review_coverage.deterministic_fallback;
+  if (
+    (modelCompleted === undefined) !== (deterministicFallback === undefined) ||
+    (modelCompleted !== undefined &&
+      modelCompleted + deterministicFallback !==
+        report.review_coverage.completed)
+  ) {
+    throw new Error(
+      "TavernKeeper report model and fallback coverage is incomplete",
+    );
+  }
+  const conservativeFallbackAssessments = report.assessments.filter(
+    (assessment) =>
+      assessment.disposition === "material_vulnerability" &&
+      assessment.impact === "medium" &&
+      assessment.exploitability === "plausible" &&
+      assessment.confidence === "low" &&
+      assessment.recommended_risk === "material",
+  ).length;
+  if (
+    (deterministicFallback ?? 0) > conservativeFallbackAssessments ||
+    (deterministicFallback ?? 0) > 0 !==
+      report.limitations.includes(deterministicReviewFallbackLimitation)
+  ) {
+    throw new Error("TavernKeeper deterministic fallback coverage is invalid");
   }
   if (
     metadataOnlyEvidence !==

--- a/tests/unit/tavernkeeper-reports.test.ts
+++ b/tests/unit/tavernkeeper-reports.test.ts
@@ -461,6 +461,81 @@ describe("TavernKeeper V5 report import", () => {
     ).toThrow(/metadata-only evidence limitation/iu);
   });
 
+  test("accepts disclosed conservative model fallback coverage", async () => {
+    const [fixtureIndex, baseReport] = await fixtures();
+    const report = addExpectedCandidate(policy4Report(baseReport));
+    report.review_coverage = {
+      required: 1,
+      completed: 1,
+      model_completed: 0,
+      deterministic_fallback: 1,
+    };
+    report.assessments[0] = {
+      ...report.assessments[0],
+      disposition: "material_vulnerability",
+      impact: "medium",
+      exploitability: "plausible",
+      confidence: "low",
+      recommended_risk: "material",
+      technical_explanation:
+        "Contextual model assessment was unavailable within the bounded review window.",
+      layman_explanation:
+        "Automated contextual review could not resolve this scanner warning.",
+      developer_action: "Manually inspect the cited evidence before release.",
+    };
+    report.counts = {
+      ...report.counts,
+      disposition: {
+        expected_behavior: 0,
+        minor_weakness: 0,
+        material_vulnerability: 1,
+        credible_malicious_behavior: 0,
+      },
+      impact: { none: 0, low: 0, medium: 1, high: 0, critical: 0 },
+      exploitability: {
+        unlikely: 0,
+        plausible: 1,
+        readily_exploitable: 0,
+      },
+      confidence: { low: 1, medium: 0, high: 0 },
+      recommended_risk: { low: 0, material: 1, high: 0 },
+    };
+    report.limitations.push(
+      "One or more scanner candidates did not receive contextual model assessment within the bounded review window. They remain conservatively classified as material concerns and require manual inspection.",
+    );
+    const rebound = rebindReport(report);
+    const entry = projectIndexReport(rebound);
+    const validatedIndex = validateReportIndex(
+      { ...fixtureIndex, reports: [entry] },
+      registry,
+    );
+
+    expect(() =>
+      validateScanReport(rebound, validatedIndex.reports[0]),
+    ).not.toThrow();
+  });
+
+  test("rejects fallback coverage that is missing or presented as clean", async () => {
+    const [fixtureIndex, baseReport] = await fixtures();
+    const report = addExpectedCandidate(policy4Report(baseReport));
+    report.review_coverage = {
+      required: 1,
+      completed: 1,
+      model_completed: 0,
+      deterministic_fallback: 1,
+    };
+    const rebound = rebindReport(report);
+    const entry = projectIndexReport(rebound);
+    const validatedIndex = validateReportIndex(
+      { ...fixtureIndex, reports: [entry] },
+      registry,
+    );
+
+    expect(() =>
+      validateScanReport(rebound, validatedIndex.reports[0]),
+    ).toThrow(/fallback/iu);
+  });
+
   test("rejects incomplete JavaScript coverage when every stage recovered", async () => {
     const [fixtureIndex, baseReport] = await fixtures();
     const report = policy4Report(baseReport);


### PR DESCRIPTION
## Summary
- sync the exact TavernKeeper V5 report schema extension
- accept model/fallback coverage counts only when they cover every assessment
- reject fallback candidates that lack the fixed warning or appear clean

## Verification
- npm run check
- producer and consumer V5 schemas are byte-identical