### PR TITLE
Clarify the Support page funding commitment

### DIFF
--- a/src/app/support/page.tsx
+++ b/src/app/support/page.tsx
@@ -77,10 +77,9 @@ export default function SupportPage() {
               carries forward to help cover future Tavernary operating costs.
             </p>
             <p>
-              The $12 target is a simple community-funding goal.
-              Tavernary&apos;s owner intends to cover costs above it for now.
-              The $13.50 model figure below is an uncached estimate; measured
-              costs may be lower with cached input and will vary with usage.
+              The $12 target is a simple community-funding goal. I&apos;ll cover
+              anything beyond that for now as I explore community interest in
+              supporting Tavernary and making it sustainable.
             </p>
           </div>
         </section>

--- a/tests/unit/support-page.test.tsx
+++ b/tests/unit/support-page.test.tsx
@@ -14,9 +14,14 @@ test("explains Tavernary's operating target, costs, and rollover policy", () => 
   expect(screen.getByText("$12/month", { exact: true })).toBeInTheDocument();
   expect(
     screen.getByText(
-      /\$12 target is a simple community-funding goal.*owner intends to cover costs above it for now.*\$13\.50 model figure.*uncached estimate/i,
+      "The $12 target is a simple community-funding goal. I'll cover anything beyond that for now as I explore community interest in supporting Tavernary and making it sustainable.",
     ),
   ).toBeInTheDocument();
+  expect(
+    screen.queryByText(
+      /The \$13\.50 model figure below is an uncached estimate/i,
+    ),
+  ).not.toBeInTheDocument();
   expect(
     screen.getByText(/anything above the current month.*carries forward/i),
   ).toBeInTheDocument();


### PR DESCRIPTION
Updates the monthly-target copy to speak directly in the owner's first person and removes the uncached-estimate caveat from that appeal. Adds a regression assertion for the exact published wording and confirms the removed sentence stays absent. Validation: npm run check (2,369 tests, production build, and static export).