### PR TITLE
fix(security): prioritize new scan reports

### DIFF
--- a/scripts/security/import-tavernkeeper-reports.mjs
+++ b/scripts/security/import-tavernkeeper-reports.mjs
@@ -285,6 +285,22 @@ export async function reconcileTavernKeeperReports(options = {}) {
     }
     return !matchingTrackedEntry(existing.get(entry.report_id), entry);
   });
+  const prioritizedEligible = [...eligible].sort((left, right) => {
+    const priority = ({ entry, prior, mode }) =>
+      retryReportDigest === entry.report_digest
+        ? 0
+        : prior === undefined
+          ? 1
+          : mode === "model"
+            ? 2
+            : 3;
+    return (
+      priority(left) - priority(right) ||
+      Date.parse(right.entry.completed_at) -
+        Date.parse(left.entry.completed_at) ||
+      left.entry.report_id.localeCompare(right.entry.report_id)
+    );
+  });
   const skippedQuarantines = work.filter(
     ({ entry, mode }) =>
       mode === "model" &&
@@ -295,7 +311,10 @@ export async function reconcileTavernKeeperReports(options = {}) {
   let imported = 0;
   let quarantined = 0;
 
-  for (const { entry, prior, mode } of eligible.slice(0, batchSize)) {
+  for (const { entry, prior, mode } of prioritizedEligible.slice(
+    0,
+    batchSize,
+  )) {
     if (
       prior !== undefined &&
       !isDeepStrictEqual(indexProjection(prior), entry)

--- a/tests/unit/tavernkeeper-reports.test.ts
+++ b/tests/unit/tavernkeeper-reports.test.ts
@@ -963,6 +963,96 @@ describe("TavernKeeper V5 report import", () => {
     ]);
   });
 
+  test("prioritizes a new contextual report ahead of offline legacy regrading", async () => {
+    const root = await mkdtemp(
+      resolve(tmpdir(), "tavernkeeper-v6-new-before-legacy-"),
+    );
+    const outputPath = resolve(
+      root,
+      "data/security/tavernkeeper-report-summaries.json",
+    );
+    const importStatePath = resolve(
+      root,
+      "data/security/tavernkeeper-import-state.json",
+    );
+    await mkdir(resolve(root, "data/security"), { recursive: true });
+    const [fixtureIndex, baseReport] = await fixtures();
+    const legacyReport = policy4Report(baseReport);
+    const legacyEntry = projectIndexReport(legacyReport);
+    const newReport = secondReportFrom(
+      rebindReport(policy3ExposureReport(baseReport)),
+    );
+    const newEntry = projectIndexReport(newReport);
+    const index = { ...fixtureIndex, reports: [legacyEntry, newEntry] };
+    const prior = assessedEntry(legacyEntry, {
+      synthesis_policy_version: "4",
+      danger_basis: "none",
+      assessment_source: "model",
+    });
+    await writeFile(
+      outputPath,
+      `${JSON.stringify({
+        schema_version: 6,
+        generated_at: index.generated_at,
+        preferred_report_ids: [legacyEntry.report_id],
+        reports: [prior],
+      })}\n`,
+    );
+    const expandedRegistry = [
+      ...registry,
+      {
+        id: "github-43",
+        type: "github",
+        status: "active",
+        repository_id: 43,
+        repository: "owner/repo-two",
+      },
+    ];
+    const requests: string[] = [];
+    let synthesisCalls = 0;
+
+    const outcome = await reconcileTavernKeeperReports({
+      root,
+      outputPath,
+      importStatePath,
+      registry: expandedRegistry,
+      dnsLookup: publicDnsLookup,
+      requestImpl: async (url: string) => {
+        requests.push(url);
+        if (url === TAVERNKEEPER_REPORT_INDEX_URL) return jsonResponse(index);
+        if (url === `${newEntry.report_url}report.json`)
+          return jsonResponse(newReport);
+        throw new Error("legacy regrade must remain behind the new report");
+      },
+      synthesizeReport: async () => {
+        synthesisCalls += 1;
+        return synthesisFor(newEntry);
+      },
+      batchSize: 1,
+      now: () => new Date("2026-08-09T10:02:30.000Z"),
+    });
+
+    expect(requests).toEqual([
+      TAVERNKEEPER_REPORT_INDEX_URL,
+      `${newEntry.report_url}report.json`,
+    ]);
+    expect(synthesisCalls).toBe(1);
+    expect(outcome).toMatchObject({ imported: 1, remaining: 1 });
+    expect(outcome.snapshot.reports).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          report_id: legacyEntry.report_id,
+          synthesis_policy_version: "4",
+        }),
+        expect.objectContaining({
+          report_id: newEntry.report_id,
+          synthesis_policy_version: TAVERNKEEPER_SYNTHESIS_POLICY_VERSION,
+          assessment_source: "model",
+        }),
+      ]),
+    );
+  });
+
   test("deterministically regrades a new legacy-policy report without synthesis", async () => {
     const root = await mkdtemp(
       resolve(tmpdir(), "tavernkeeper-v6-legacy-new-"),


### PR DESCRIPTION
## What changed
- process explicit retry digests first
- process genuinely new/untracked TavernKeeper reports before stored offline regrades
- prefer newer reports within each priority lane
- keep legacy policy-1/2 regrading bounded and model-free

## Why
Three new policy-3 scan reports were valid and deployed by TavernKeeper but remained behind hundreds of deterministic legacy migrations in Tavernary's five-item batches.

## Verification
- strict TDD regression failed before ordering was added
- npm.cmd run check
- 216 test files / 2400 tests
- validated 420 summaries / 0 quarantines
- 408 projects / 9 Kits validated
- 374 static pages built and export verified
- git diff --check