### PR TITLE
Accept large TavernKeeper scan reports

### DIFF
--- a/scripts/security/tavernkeeper-assessment-contract.mjs
+++ b/scripts/security/tavernkeeper-assessment-contract.mjs
@@ -107,6 +107,14 @@ function validateIds(value, { minimum = 0, maximum = 256 } = {}) {
   );
 }
 
+function validateCandidateUniverse(value) {
+  return (
+    Array.isArray(value) &&
+    new Set(value).size === value.length &&
+    value.every((id) => typeof id === "string" && digestPattern.test(id))
+  );
+}
+
 const assessmentKeys = [
   "risk_level",
   "headline",
@@ -383,7 +391,7 @@ function requiredCitations(report) {
 
 export function tavernKeeperAssessmentRequirements(report) {
   const allowedCandidateIds = [...knownCandidateIds(report)].sort();
-  if (!validateIds(allowedCandidateIds)) {
+  if (!validateCandidateUniverse(allowedCandidateIds)) {
     throw new Error("TavernKeeper candidate identities are invalid");
   }
   const requiredCandidateIds = [...requiredCitations(report)].sort();

--- a/tests/unit/tavernkeeper-synthesis.test.ts
+++ b/tests/unit/tavernkeeper-synthesis.test.ts
@@ -118,6 +118,21 @@ function validationFailure(run: () => unknown) {
 }
 
 describe("TavernKeeper evidence floors", () => {
+  test("accepts a large candidate universe with bounded required citations", () => {
+    const items = Array.from({ length: 566 }, (_, index) =>
+      assessment({
+        candidate_id: index.toString(16).padStart(64, "0"),
+        disposition: index < 11 ? "minor_weakness" : "expected_behavior",
+      }),
+    );
+    const report = reportWith(items);
+
+    const requirements = tavernKeeperAssessmentRequirements(report);
+
+    expect(requirements.allowed_candidate_ids).toHaveLength(566);
+    expect(requirements.required_candidate_ids).toHaveLength(11);
+  });
+
   test("raises high-confidence credible malicious behavior to high", () => {
     expect(
       deriveEvidenceFloor([


### PR DESCRIPTION
## Summary
- accept validated TavernKeeper candidate universes larger than 256 entries
- keep generated summary citation arrays bounded to 256 entries
- cover the production Directive shape: 566 candidates and 11 required citations

## Verification
- strict red/green regression reproduced the production failure
- npm.cmd run check (216 files, 2401 tests, 374 static pages)