### PR TITLE
Align Ko-fi actions across desktop and mobile

### DIFF
--- a/src/app/support/page.tsx
+++ b/src/app/support/page.tsx
@@ -49,28 +49,28 @@ export default function SupportPage() {
             <div className="support-target-heading">
               <h2 id="monthly-target">Monthly operating target</h2>
               <strong className="support-target-value">$12/month</strong>
-            </div>
-            <a
-              className="support-kofi-link"
-              href={kofiProfileUrl}
-              target="_blank"
-              rel="noreferrer noopener"
-            >
-              <svg
-                className="support-kofi-icon"
-                aria-hidden="true"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.9"
-                strokeLinecap="round"
-                strokeLinejoin="round"
+              <a
+                className="support-kofi-link"
+                href={kofiProfileUrl}
+                target="_blank"
+                rel="noreferrer noopener"
               >
-                <path d="M4 8h13v6.5A4.5 4.5 0 0 1 12.5 19h-4A4.5 4.5 0 0 1 4 14.5V8Z" />
-                <path d="M17 10h1.5a2.5 2.5 0 0 1 0 5H17M8 5.5c0-1 1-1 1-2M12 5.5c0-1 1-1 1-2" />
-              </svg>
-              <span>Support on Ko-fi</span>
-            </a>
+                <svg
+                  className="support-kofi-icon"
+                  aria-hidden="true"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.9"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="M4 8h13v6.5A4.5 4.5 0 0 1 12.5 19h-4A4.5 4.5 0 0 1 4 14.5V8Z" />
+                  <path d="M17 10h1.5a2.5 2.5 0 0 1 0 5H17M8 5.5c0-1 1-1 1-2M12 5.5c0-1 1-1 1-2" />
+                </svg>
+                <span>Support on Ko-fi</span>
+              </a>
+            </div>
             <p>
               Donations first cover Tavernary&apos;s operating costs for the
               current month. Anything above the current month&apos;s costs

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -49,6 +49,7 @@
 
   .header-actions {
     grid-area: actions;
+    gap: 4px;
   }
 
   .header-actions .about-link {

--- a/src/styles/support.css
+++ b/src/styles/support.css
@@ -9,12 +9,13 @@
 .support-target-heading {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: 16px;
   margin: 7px 0 8px;
 }
 
 .support-content .support-target h2 {
+  min-width: 0;
+  flex: 1 1 auto;
   margin: 0;
   color: var(--color-heading);
   font-size: 1.3rem;
@@ -47,7 +48,7 @@
   align-items: center;
   justify-content: center;
   gap: 8px;
-  margin: 4px 0 8px;
+  margin: 0;
   border: 1px solid var(--color-action-primary-bg);
   border-radius: 6px;
   padding: 0 14px;

--- a/tests/e2e/contribution-links.spec.ts
+++ b/tests/e2e/contribution-links.spec.ts
@@ -107,6 +107,34 @@ test("links to the transparent support page beside Submit Project", async ({
     "https://ko-fi.com/mentallyquill",
   );
   await expect(supportOnKofi).toHaveCSS("color", "rgb(22, 16, 8)");
+  const targetHeading = upkeep.getByRole("heading", {
+    name: "Monthly operating target",
+  });
+  const targetValue = upkeep.getByText("$12/month", { exact: true });
+  const [targetHeadingBox, targetValueBox, supportOnKofiBox] =
+    await Promise.all([
+      targetHeading.boundingBox(),
+      targetValue.boundingBox(),
+      supportOnKofi.boundingBox(),
+    ]);
+  expect(targetHeadingBox).not.toBeNull();
+  expect(targetValueBox).not.toBeNull();
+  expect(supportOnKofiBox).not.toBeNull();
+  expect(targetValueBox!.x).toBeGreaterThanOrEqual(
+    targetHeadingBox!.x + targetHeadingBox!.width,
+  );
+  expect(supportOnKofiBox!.x).toBeGreaterThanOrEqual(
+    targetValueBox!.x + targetValueBox!.width,
+  );
+  const targetCenterY = targetHeadingBox!.y + targetHeadingBox!.height / 2;
+  expect(
+    Math.abs(targetValueBox!.y + targetValueBox!.height / 2 - targetCenterY),
+  ).toBeLessThanOrEqual(2);
+  expect(
+    Math.abs(
+      supportOnKofiBox!.y + supportOnKofiBox!.height / 2 - targetCenterY,
+    ),
+  ).toBeLessThanOrEqual(2);
   await expect(upkeep).toHaveCSS("padding-left", "24px");
   await expect(upkeep).toHaveCSS("padding-right", "24px");
   await expect(upkeep).toHaveCSS("border-top-color", "rgb(43, 58, 64)");

--- a/tests/e2e/mobile.spec.ts
+++ b/tests/e2e/mobile.spec.ts
@@ -76,9 +76,28 @@ test("matches the approved mobile header hierarchy", async ({ page }) => {
   expect(supportBox!.width).toBe(34);
   expect(supportBox!.height).toBe(34);
   expect(supportBox!.x).toBeGreaterThanOrEqual(submitBox!.x + submitBox!.width);
+  expect
+    .soft(supportBox!.x - (submitBox!.x + submitBox!.width))
+    .toBeLessThanOrEqual(4);
   expect(
     await submit.evaluate((element) => element.getBoundingClientRect().height),
   ).toBeLessThan(40);
+});
+
+test("keeps the mobile support action inside a 412px viewport", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 412, height: 915 });
+  await page.goto(sitePath());
+
+  const support = page.getByRole("link", {
+    name: "Support Tavernary on Ko-fi",
+  });
+  const supportBox = await support.boundingBox();
+  expect(supportBox).not.toBeNull();
+  expect(supportBox!.width).toBe(34);
+  expect(supportBox!.height).toBe(34);
+  expect(supportBox!.x + supportBox!.width).toBeLessThanOrEqual(412);
 });
 
 test("opens the Tavernary support page from a 320px viewport", async ({


### PR DESCRIPTION
Moves the Support-page Ko-fi action into the monthly operating target row so the title, $12/month value, and action align horizontally on desktop. Tightens only the mobile header action gap from 8px to 4px, preserving the existing 34x34px coffee button while keeping it inside a 412px viewport. Root cause: the original browser coverage checked size and ordering but not screenshot-width containment. Adds desktop alignment and mobile containment regressions. Validation: npm run check (216 files, 2,400 tests, production build, static export), focused Chromium regressions, and local responsive inspection.