### PR TITLE
Add search basics help popover

### DIFF
--- a/docs/superpowers/plans/2026-08-10-search-help-popover.md
+++ b/docs/superpowers/plans/2026-08-10-search-help-popover.md
@@ -1,0 +1,387 @@
+# Search Help Popover Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an accessible, compact search-syntax help popover beside the main catalog search field on desktop and mobile.
+
+**Architecture:** A focused client component owns the help trigger, local open state, and document-level dismissal listeners. `SiteHeader` integrates that component while converting the search wrapper to valid label/input markup, and existing catalog styles provide a viewport-safe anchored panel without changing any search state or parsing code.
+
+**Tech Stack:** React 19, TypeScript, Next.js, CSS, Vitest, Testing Library, Playwright
+
+## Global Constraints
+
+- Preserve the existing `+` OR semantics, space-separated AND semantics, URL serialization, filters, ranking, and `/` shortcut behavior.
+- Use the supplied circular question-mark SVG paths with `currentColor`.
+- Keep the help trigger visible on desktop and mobile; keep the existing `/` badge hidden at widths of 760px and below.
+- Use the exact heading `Search basics`, accessible trigger name `Search help`, and the five approved instructions from the design.
+- Dismiss on a second trigger activation, outside pointer activation, or Escape; Escape restores trigger focus.
+- Keep the popover within an 8px viewport margin.
+- Do not modify or stage unrelated worktree files.
+
+---
+
+### Task 1: Build the accessible search-help component
+
+**Files:**
+- Create: `src/components/icons/search-help-icon.tsx`
+- Create: `src/features/search/components/search-help.tsx`
+- Create: `tests/unit/search-help.test.tsx`
+
+**Interfaces:**
+- Consumes: React `useEffect`, `useId`, `useRef`, and `useState`.
+- Produces: `SearchHelpIcon(): JSX.Element` and `SearchHelp(): JSX.Element`.
+
+- [ ] **Step 1: Write failing interaction tests**
+
+Create `tests/unit/search-help.test.tsx` with real DOM interactions:
+
+```tsx
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, expect, test } from "vitest";
+
+import { SearchHelp } from "@/features/search/components/search-help";
+
+afterEach(cleanup);
+
+test("opens the approved search instructions and toggles closed", async () => {
+  const user = userEvent.setup();
+  render(<SearchHelp />);
+  const trigger = screen.getByRole("button", { name: "Search help" });
+
+  expect(trigger).toHaveAttribute("aria-expanded", "false");
+  await user.click(trigger);
+  expect(trigger).toHaveAttribute("aria-expanded", "true");
+  const dialog = screen.getByRole("dialog", { name: "Search basics" });
+  expect(dialog).toHaveTextContent("A B");
+  expect(dialog).toHaveTextContent("matches results containing A and B");
+  expect(dialog).toHaveTextContent("A+B");
+  expect(dialog).toHaveTextContent("matches results containing A or B");
+  expect(dialog).toHaveTextContent("A+B C");
+  expect(dialog).toHaveTextContent("matches A, or both B and C");
+  expect(dialog).toHaveTextContent("Search-result URLs can be copied and shared");
+  expect(dialog).toHaveTextContent("Press / anywhere on the page to jump to search");
+
+  await user.click(trigger);
+  expect(screen.queryByRole("dialog")).toBeNull();
+});
+
+test("dismisses outside and restores trigger focus after Escape", async () => {
+  const user = userEvent.setup();
+  render(<><SearchHelp /><button type="button">Outside</button></>);
+  const trigger = screen.getByRole("button", { name: "Search help" });
+
+  await user.click(trigger);
+  await user.click(screen.getByRole("button", { name: "Outside" }));
+  expect(screen.queryByRole("dialog")).toBeNull();
+
+  await user.click(trigger);
+  await user.keyboard("{Escape}");
+  expect(screen.queryByRole("dialog")).toBeNull();
+  expect(trigger).toHaveFocus();
+});
+```
+
+- [ ] **Step 2: Run the unit test and verify RED**
+
+Run:
+
+```powershell
+npm.cmd test -- tests/unit/search-help.test.tsx
+```
+
+Expected: FAIL because `@/features/search/components/search-help` does not exist.
+
+- [ ] **Step 3: Add the icon from the supplied SVG**
+
+Create `src/components/icons/search-help-icon.tsx`:
+
+```tsx
+export function SearchHelpIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      data-icon="search-help"
+      fill="currentColor"
+      focusable="false"
+      viewBox="0 0 24 24"
+    >
+      <path d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2zm0 18a8 8 0 1 1 8-8 8 8 0 0 1-8 8z" />
+      <path d="M12 6a3.5 3.5 0 0 0-3.5 3.5 1 1 0 0 0 2 0A1.5 1.5 0 1 1 12 11a1 1 0 0 0-1 1v2a1 1 0 0 0 2 0v-1.16A3.49 3.49 0 0 0 12 6z" />
+      <circle cx="12" cy="17" r="1" />
+    </svg>
+  );
+}
+```
+
+- [ ] **Step 4: Implement the minimal interactive component**
+
+Create `src/features/search/components/search-help.tsx` as a client component. Use `useId()` for the panel and heading IDs, a button ref for focus restoration, and a root ref for outside detection. While open, register `pointerdown` and `keydown` listeners on `document`, remove them during cleanup, and render this semantic content:
+
+```tsx
+<span className="search-help" ref={rootRef}>
+  <button
+    aria-controls={panelId}
+    aria-expanded={open}
+    aria-label="Search help"
+    className="search-help-trigger"
+    onClick={() => setOpen((current) => !current)}
+    ref={triggerRef}
+    type="button"
+  >
+    <SearchHelpIcon />
+  </button>
+  {open ? (
+    <section
+      aria-labelledby={headingId}
+      className="search-help-popover"
+      id={panelId}
+      role="dialog"
+    >
+      <h2 id={headingId}>Search basics</h2>
+      <ul>
+        <li><code>A B</code><span>matches results containing A and B.</span></li>
+        <li><code>A+B</code><span>matches results containing A or B.</span></li>
+        <li><code>A+B C</code><span>matches A, or both B and C.</span></li>
+      </ul>
+      <p>Search-result URLs can be copied and shared.</p>
+      <p>Press <kbd>/</kbd> anywhere on the page to jump to search.</p>
+    </section>
+  ) : null}
+</span>
+```
+
+The Escape handler must call `setOpen(false)` and `triggerRef.current?.focus()`. The outside handler must close only when `rootRef.current?.contains(event.target as Node)` is false.
+
+- [ ] **Step 5: Run the focused unit test and verify GREEN**
+
+Run:
+
+```powershell
+npm.cmd test -- tests/unit/search-help.test.tsx
+```
+
+Expected: 2 tests PASS with no warnings.
+
+- [ ] **Step 6: Commit the component**
+
+```powershell
+git add src/components/icons/search-help-icon.tsx src/features/search/components/search-help.tsx tests/unit/search-help.test.tsx
+git commit -m "feat(search): add help popover"
+```
+
+### Task 2: Integrate and style the control across breakpoints
+
+**Files:**
+- Modify: `src/features/catalog/components/site-header.tsx`
+- Modify: `src/styles/catalog.css`
+- Modify: `src/styles/responsive.css`
+- Modify: `tests/e2e/catalog.spec.ts`
+- Modify: `tests/e2e/mobile.spec.ts`
+
+**Interfaces:**
+- Consumes: `SearchHelp()` from Task 1 and the existing `searchRef`, `search`, and `onSearch` header props.
+- Produces: Valid search-region markup containing the existing input, `/` badge, and help trigger.
+
+- [ ] **Step 1: Add failing desktop and mobile browser assertions**
+
+In `tests/e2e/catalog.spec.ts`, extend the main-search focus test to assert the ordering and interaction:
+
+```ts
+const shortcut = page.locator(".site-search > kbd");
+const help = page.getByRole("button", { name: "Search help" });
+await expect(shortcut).toBeVisible();
+await expect(help).toBeVisible();
+const shortcutBox = await shortcut.boundingBox();
+const helpBox = await help.boundingBox();
+expect(shortcutBox).not.toBeNull();
+expect(helpBox).not.toBeNull();
+expect(helpBox!.x).toBeGreaterThan(shortcutBox!.x);
+await help.click();
+await expect(page.getByRole("dialog", { name: "Search basics" })).toBeVisible();
+await page.keyboard.press("Escape");
+await expect(help).toBeFocused();
+await page.keyboard.press("/");
+await expect(search).toBeFocused();
+```
+
+In `tests/e2e/mobile.spec.ts`, add a test that asserts the slash badge is hidden, the help trigger is visible, and the open panel stays within the 390px viewport:
+
+```ts
+test("keeps search help available within the mobile viewport", async ({ page }) => {
+  await page.goto(sitePath());
+  await expect(page.locator(".site-search > kbd")).toBeHidden();
+  const help = page.getByRole("button", { name: "Search help" });
+  await expect(help).toBeVisible();
+  await help.click();
+  const dialog = page.getByRole("dialog", { name: "Search basics" });
+  await expect(dialog).toBeVisible();
+  const box = await dialog.boundingBox();
+  expect(box).not.toBeNull();
+  expect(box!.x).toBeGreaterThanOrEqual(8);
+  expect(box!.x + box!.width).toBeLessThanOrEqual(382);
+});
+```
+
+- [ ] **Step 2: Build the static site and verify browser RED**
+
+Run:
+
+```powershell
+npm.cmd run build
+npm.cmd run test:e2e -- tests/e2e/catalog.spec.ts tests/e2e/mobile.spec.ts --grep "main search|search help"
+```
+
+Expected: FAIL because no `Search help` button exists in the header.
+
+- [ ] **Step 3: Integrate valid search markup**
+
+In `site-header.tsx`, import `SearchHelp`, change the wrapping `<label className="site-search">` to `<div className="site-search" role="search">`, add `<label className="visually-hidden" htmlFor="catalog-search">Search projects</label>`, set `id="catalog-search"` on the input, retain its existing `aria-label`, and render `<SearchHelp />` after the existing `<kbd>/</kbd>`.
+
+- [ ] **Step 4: Add compact themed styling**
+
+In `catalog.css`, add rules with these contracts:
+
+```css
+.search-help {
+  position: relative;
+  display: grid;
+  flex: none;
+  place-items: center;
+}
+
+.search-help-trigger {
+  display: grid;
+  width: 28px;
+  height: 28px;
+  border: 0;
+  border-radius: 50%;
+  padding: 5px;
+  color: var(--color-text-muted);
+  background: transparent;
+  cursor: pointer;
+  place-items: center;
+}
+
+.search-help-trigger:hover,
+.search-help-trigger[aria-expanded="true"] {
+  color: var(--color-text-primary);
+  background: var(--color-bg-surface-active);
+}
+
+.search-help-trigger:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.search-help-trigger svg {
+  width: 18px;
+  height: 18px;
+}
+
+.search-help-popover {
+  position: absolute;
+  z-index: 30;
+  top: calc(100% + 10px);
+  right: 0;
+  width: min(320px, calc(100vw - 16px));
+  border: 1px solid var(--color-border-strong);
+  border-radius: 8px;
+  padding: 14px;
+  color: var(--color-text-secondary);
+  background: var(--color-bg-surface);
+  box-shadow: var(--shadow-overlay);
+  overflow-wrap: anywhere;
+}
+```
+
+Add focused heading, list, paragraph, `<code>`, and `<kbd>` spacing using existing theme tokens. Do not let the broad `.site-search svg` rule override the 18px icon dimensions. Under `@media (pointer: coarse)`, add a 44px pseudo-element hit target around `.search-help-trigger`. Under `@media (prefers-reduced-motion: reduce)`, disable the popover transition if one is present.
+
+Keep the existing mobile `.site-search kbd { display: none; }` rule scoped so it does not hide the `<kbd>` inside `.search-help-popover`; change the selector to `.site-search > kbd` in both base and responsive styles where necessary.
+
+- [ ] **Step 5: Rebuild and verify browser GREEN**
+
+Run:
+
+```powershell
+npm.cmd run build
+npm.cmd run test:e2e -- tests/e2e/catalog.spec.ts tests/e2e/mobile.spec.ts --grep "main search|search help"
+```
+
+Expected: desktop and mobile search-help tests PASS, including panel bounds and `/` focus behavior.
+
+- [ ] **Step 6: Run focused unit and visual-contract tests**
+
+Run:
+
+```powershell
+npm.cmd test -- tests/unit/search-help.test.tsx tests/unit/visual-alignment-contract.test.ts
+```
+
+Expected: all focused tests PASS.
+
+- [ ] **Step 7: Commit the integration**
+
+```powershell
+git add src/features/catalog/components/site-header.tsx src/styles/catalog.css src/styles/responsive.css tests/e2e/catalog.spec.ts tests/e2e/mobile.spec.ts
+git commit -m "feat(search): expose help on all screens"
+```
+
+### Task 3: Run release gates and prepare the PR
+
+**Files:**
+- Modify only files required to repair a demonstrated failure from the gates below.
+
+**Interfaces:**
+- Consumes: the complete feature from Tasks 1 and 2.
+- Produces: a verified branch ready for GitHub review and merge.
+
+- [ ] **Step 1: Run formatting and static analysis**
+
+```powershell
+npm.cmd run format:check
+npm.cmd run lint
+npm.cmd run palette:audit
+npm.cmd run typecheck
+```
+
+Expected: every command exits 0 with no errors.
+
+- [ ] **Step 2: Run the complete automated suite**
+
+```powershell
+npm.cmd test
+```
+
+Expected: all test files and tests PASS.
+
+- [ ] **Step 3: Run the production and static-export gates**
+
+```powershell
+npm.cmd run build
+npm.cmd run verify:export
+```
+
+Expected: production build and static-export verification exit 0.
+
+- [ ] **Step 4: Run the complete relevant browser suites**
+
+```powershell
+npm.cmd run test:e2e -- tests/e2e/catalog.spec.ts tests/e2e/mobile.spec.ts
+```
+
+Expected: the complete catalog and mobile browser suites PASS.
+
+- [ ] **Step 5: Review the final diff and branch state**
+
+```powershell
+git diff origin/main...HEAD --check
+git status --short
+git log --oneline origin/main..HEAD
+```
+
+Expected: no whitespace errors, no uncommitted files, and only the design, plan, component, integration, and test commits are present.
+
+- [ ] **Step 6: Publish and merge**
+
+Push `codex/search-help-popover`, open a ready PR summarizing behavior and verification, wait for required GitHub checks, address any actionable review feedback, and merge only after all required checks pass.

--- a/docs/superpowers/specs/2026-08-10-search-help-popover-design.md
+++ b/docs/superpowers/specs/2026-08-10-search-help-popover-design.md
@@ -1,0 +1,62 @@
+# Search Help Popover Design
+
+## Goal
+
+Add a compact question-mark control to the main catalog search bar that explains Tavernary's search syntax, shareable URLs, and `/` keyboard shortcut on desktop and mobile.
+
+## Interaction
+
+- Place the circular question-mark icon immediately to the right of the existing `/` shortcut badge.
+- Keep the help control visible at every supported viewport width. The existing `/` badge remains hidden at widths of 760px and below.
+- Clicking or tapping the control toggles a compact, non-modal popover titled `Search basics`.
+- Close the popover when the user clicks the trigger again, clicks or taps outside the control, or presses Escape.
+- Escape returns focus to the help trigger.
+- The panel stays within an 8px viewport margin on narrow screens.
+
+## Content
+
+The popover presents five short instructions:
+
+- `A B` — matches results containing A and B.
+- `A+B` — matches results containing A or B.
+- `A+B C` — matches A, or both B and C.
+- Search-result URLs can be copied and shared.
+- Press `/` anywhere on the page to jump to search.
+
+The examples describe the existing search contract only. This feature does not change parsing, ranking, filtering, URL serialization, or keyboard-shortcut behavior.
+
+## Components and markup
+
+- Add a focused `SearchHelp` client component responsible for the trigger, popover state, dismissal listeners, and instructional content.
+- Add a `SearchHelpIcon` component derived from the supplied circular question-mark SVG. Preserve its paths while converting the fill to `currentColor` so it follows Tavernary's theme.
+- Replace the current wrapping search `<label>` with a `<div role="search">`. Associate a visually hidden `<label>` with the input through a stable `id`; this keeps the input's accessible name while avoiding an interactive button nested inside a label.
+- The help button uses `type="button"`, the accessible name `Search help`, and synchronized `aria-expanded` and `aria-controls` attributes.
+- The popover uses `role="dialog"` and `aria-labelledby` pointing to its `Search basics` heading. It is non-modal and does not trap focus.
+
+## Layout and styling
+
+- The trigger has a 28px visible circular face with a larger 44px touch target on coarse pointers, without increasing the search bar's 42px desktop height.
+- The supplied icon renders at 18px and uses existing control, muted-text, focus-ring, surface, border, and shadow tokens.
+- The popover is positioned below and right-aligned to the trigger, with a maximum width of 320px and `width: min(320px, calc(100vw - 16px))`.
+- The panel sits above catalog content, wraps long text safely, and uses compact typographic spacing consistent with Tavernary's current header.
+- Code examples use `<code>` and the keyboard shortcut uses `<kbd>`.
+- Reduced-motion preferences disable any panel transition.
+
+## Failure handling
+
+The control is local UI state and has no network or persistence dependency. If JavaScript is unavailable, the normal search input and all existing search behavior remain present; the help control is visible but does not open.
+
+## Verification
+
+- Unit tests cover opening, exact instructional content, toggling, outside-pointer dismissal, Escape dismissal, focus restoration, and ARIA state.
+- Desktop browser coverage verifies the trigger appears to the right of the `/` badge and that existing `/` focus behavior still works.
+- Mobile browser coverage verifies the help trigger remains visible while the `/` badge is hidden, and the open panel stays within the viewport.
+- Focused tests, formatting, lint, typecheck, the production build, static-export verification, and relevant browser suites pass before publication.
+
+## Acceptance criteria
+
+- The attached circular question-mark icon appears to the right of the slash shortcut on desktop.
+- The same icon remains available in the mobile search bar.
+- Every approved search instruction is visible in the compact popover.
+- Mouse, touch, and keyboard users can open and dismiss the panel.
+- The interaction is accessible and does not alter existing search or URL behavior.

--- a/src/components/icons/search-help-icon.tsx
+++ b/src/components/icons/search-help-icon.tsx
@@ -1,0 +1,15 @@
+export function SearchHelpIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      data-icon="search-help"
+      fill="currentColor"
+      focusable="false"
+      viewBox="0 0 24 24"
+    >
+      <path d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2zm0 18a8 8 0 1 1 8-8 8 8 0 0 1-8 8z" />
+      <path d="M12 6a3.5 3.5 0 0 0-3.5 3.5 1 1 0 0 0 2 0A1.5 1.5 0 1 1 12 11a1 1 0 0 0-1 1v2a1 1 0 0 0 2 0v-1.16A3.49 3.49 0 0 0 12 6z" />
+      <circle cx="12" cy="17" r="1" />
+    </svg>
+  );
+}

--- a/src/features/catalog/components/site-header.tsx
+++ b/src/features/catalog/components/site-header.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import Link from "next/link";
 
 import { CategoryIcon } from "@/components/icons/category-icon";
+import { SearchHelp } from "@/features/search/components/search-help";
 import { KoFiSupport } from "@/features/catalog/components/kofi-support";
 
 export function SiteHeader({
@@ -36,10 +37,13 @@ export function SiteHeader({
           <span className="brand-tagline">Where AI roleplay tools gather</span>
         </span>
       </Link>
-      <label className="site-search">
+      <div className="site-search" role="search">
         <CategoryIcon name="search" />
-        <span className="visually-hidden">Search projects</span>
+        <label className="visually-hidden" htmlFor="catalog-search">
+          Search projects
+        </label>
         <input
+          id="catalog-search"
           ref={searchRef}
           type="search"
           value={search}
@@ -48,7 +52,8 @@ export function SiteHeader({
           aria-label="Search projects"
         />
         <kbd>/</kbd>
-      </label>
+        <SearchHelp />
+      </div>
       <nav className="header-actions" aria-label="Site actions">
         <a className="top-link about-link" href="./about/">
           About

--- a/src/features/search/components/search-help.tsx
+++ b/src/features/search/components/search-help.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useEffect, useId, useRef, useState } from "react";
+
+import { SearchHelpIcon } from "@/components/icons/search-help-icon";
+
+export function SearchHelp() {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLSpanElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const generatedId = useId();
+  const panelId = `${generatedId}-search-help`;
+  const headingId = `${panelId}-heading`;
+
+  useEffect(() => {
+    if (!open) return;
+
+    const dismissOutside = (event: PointerEvent) => {
+      if (
+        event.target instanceof Node &&
+        !rootRef.current?.contains(event.target)
+      ) {
+        setOpen(false);
+      }
+    };
+    const dismissOnEscape = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      setOpen(false);
+      triggerRef.current?.focus();
+    };
+
+    document.addEventListener("pointerdown", dismissOutside);
+    document.addEventListener("keydown", dismissOnEscape);
+    return () => {
+      document.removeEventListener("pointerdown", dismissOutside);
+      document.removeEventListener("keydown", dismissOnEscape);
+    };
+  }, [open]);
+
+  return (
+    <span className="search-help" ref={rootRef}>
+      <button
+        aria-controls={panelId}
+        aria-expanded={open}
+        aria-label="Search help"
+        className="search-help-trigger"
+        onClick={() => setOpen((current) => !current)}
+        ref={triggerRef}
+        type="button"
+      >
+        <SearchHelpIcon />
+      </button>
+      {open ? (
+        <section
+          aria-labelledby={headingId}
+          className="search-help-popover"
+          id={panelId}
+          role="dialog"
+        >
+          <h2 id={headingId}>Search basics</h2>
+          <ul>
+            <li>
+              <code>A B</code>
+              <span>— matches results containing A and B.</span>
+            </li>
+            <li>
+              <code>A+B</code>
+              <span>— matches results containing A or B.</span>
+            </li>
+            <li>
+              <code>A+B C</code>
+              <span>— matches A, or both B and C.</span>
+            </li>
+          </ul>
+          <p>Search-result URLs can be copied and shared.</p>
+          <p>
+            Press <kbd>/</kbd> anywhere on the page to jump to search.
+          </p>
+        </section>
+      ) : null}
+    </span>
+  );
+}

--- a/src/features/search/components/search-help.tsx
+++ b/src/features/search/components/search-help.tsx
@@ -1,16 +1,92 @@
 "use client";
 
-import { useEffect, useId, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+} from "react";
 
 import { SearchHelpIcon } from "@/components/icons/search-help-icon";
 
+const VIEWPORT_MARGIN = 8;
+const POPOVER_GAP = 8;
+
+function clamp(value: number, minimum: number, maximum: number) {
+  return Math.min(Math.max(value, minimum), Math.max(minimum, maximum));
+}
+
+function viewportBounds() {
+  const viewport = window.visualViewport;
+  return viewport
+    ? {
+        height: viewport.height,
+        left: viewport.offsetLeft,
+        top: viewport.offsetTop,
+        width: viewport.width,
+      }
+    : { height: window.innerHeight, left: 0, top: 0, width: window.innerWidth };
+}
+
+function popoverPosition(trigger: DOMRect, popover: DOMRect) {
+  const viewport = viewportBounds();
+  const left = clamp(
+    trigger.right - popover.width,
+    viewport.left + VIEWPORT_MARGIN,
+    viewport.left + viewport.width - popover.width - VIEWPORT_MARGIN,
+  );
+  const below = trigger.bottom + POPOVER_GAP;
+  const top = clamp(
+    below,
+    viewport.top + VIEWPORT_MARGIN,
+    viewport.top + viewport.height - popover.height - VIEWPORT_MARGIN,
+  );
+
+  return { left, top };
+}
+
 export function SearchHelp() {
   const [open, setOpen] = useState(false);
+  const [position, setPosition] = useState<CSSProperties | null>(null);
   const rootRef = useRef<HTMLSpanElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const popoverRef = useRef<HTMLElement>(null);
   const generatedId = useId();
   const panelId = `${generatedId}-search-help`;
   const headingId = `${panelId}-heading`;
+
+  const closePopover = useCallback(() => {
+    setOpen(false);
+    setPosition(null);
+  }, []);
+
+  const updatePosition = useCallback(() => {
+    if (!triggerRef.current || !popoverRef.current) return;
+    setPosition(
+      popoverPosition(
+        triggerRef.current.getBoundingClientRect(),
+        popoverRef.current.getBoundingClientRect(),
+      ),
+    );
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    updatePosition();
+    window.addEventListener("resize", updatePosition);
+    window.addEventListener("scroll", updatePosition, true);
+    window.visualViewport?.addEventListener("resize", updatePosition);
+    window.visualViewport?.addEventListener("scroll", updatePosition);
+    return () => {
+      window.removeEventListener("resize", updatePosition);
+      window.removeEventListener("scroll", updatePosition, true);
+      window.visualViewport?.removeEventListener("resize", updatePosition);
+      window.visualViewport?.removeEventListener("scroll", updatePosition);
+    };
+  }, [open, updatePosition]);
 
   useEffect(() => {
     if (!open) return;
@@ -20,13 +96,13 @@ export function SearchHelp() {
         event.target instanceof Node &&
         !rootRef.current?.contains(event.target)
       ) {
-        setOpen(false);
+        closePopover();
       }
     };
     const dismissOnEscape = (event: KeyboardEvent) => {
       if (event.key !== "Escape") return;
       event.preventDefault();
-      setOpen(false);
+      closePopover();
       triggerRef.current?.focus();
     };
 
@@ -36,7 +112,7 @@ export function SearchHelp() {
       document.removeEventListener("pointerdown", dismissOutside);
       document.removeEventListener("keydown", dismissOnEscape);
     };
-  }, [open]);
+  }, [closePopover, open]);
 
   return (
     <span className="search-help" ref={rootRef}>
@@ -45,7 +121,10 @@ export function SearchHelp() {
         aria-expanded={open}
         aria-label="Search help"
         className="search-help-trigger"
-        onClick={() => setOpen((current) => !current)}
+        onClick={() => {
+          if (open) closePopover();
+          else setOpen(true);
+        }}
         ref={triggerRef}
         type="button"
       >
@@ -56,7 +135,12 @@ export function SearchHelp() {
           aria-labelledby={headingId}
           className="search-help-popover"
           id={panelId}
+          ref={popoverRef}
           role="dialog"
+          style={{
+            ...position,
+            visibility: position ? "visible" : "hidden",
+          }}
         >
           <h2 id={headingId}>Search basics</h2>
           <ul>

--- a/src/styles/catalog.css
+++ b/src/styles/catalog.css
@@ -347,20 +347,6 @@
   margin-top: 10px;
 }
 
-@media (pointer: coarse) {
-  .search-help-trigger::before {
-    position: absolute;
-    inset: -8px;
-    content: "";
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .search-help-popover {
-    transition: none;
-  }
-}
-
 .header-actions {
   display: flex;
   align-items: center;
@@ -1909,11 +1895,18 @@ body.sheet-open {
     inset: -14px;
     content: "";
   }
+
+  .search-help-trigger::before {
+    position: absolute;
+    inset: -8px;
+    content: "";
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .tavernkeeper-scan-indicator-trigger,
-  .tavernkeeper-popover {
+  .tavernkeeper-popover,
+  .search-help-popover {
     transition: none;
   }
 }

--- a/src/styles/catalog.css
+++ b/src/styles/catalog.css
@@ -241,7 +241,7 @@
   color: var(--color-control-placeholder);
 }
 
-.site-search kbd {
+.site-search > kbd {
   border: 1px solid var(--color-border-default);
   border-radius: 4px;
   padding: 3px 6px;
@@ -250,6 +250,115 @@
   font-family: inherit;
   font-size: 10px;
   line-height: 1.3;
+}
+
+.search-help {
+  position: relative;
+  display: grid;
+  flex: none;
+  place-items: center;
+}
+
+.search-help-trigger {
+  position: relative;
+  display: grid;
+  width: 28px;
+  height: 28px;
+  border: 0;
+  border-radius: 50%;
+  padding: 5px;
+  color: var(--color-text-muted);
+  background: transparent;
+  cursor: pointer;
+  place-items: center;
+}
+
+.search-help-trigger:hover,
+.search-help-trigger[aria-expanded="true"] {
+  color: var(--color-text-primary);
+  background: var(--color-bg-surface-active);
+}
+
+.search-help-trigger:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.search-help-trigger svg {
+  width: 18px;
+  height: 18px;
+}
+
+.search-help-popover {
+  position: fixed;
+  z-index: 30;
+  width: min(320px, calc(100vw - 16px));
+  box-sizing: border-box;
+  border: 1px solid var(--color-border-strong);
+  border-radius: 8px;
+  padding: 14px;
+  color: var(--color-text-secondary);
+  background: var(--color-bg-surface);
+  box-shadow: var(--shadow-overlay);
+  font-size: 12px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.search-help-popover h2,
+.search-help-popover p,
+.search-help-popover ul {
+  margin: 0;
+}
+
+.search-help-popover h2 {
+  color: var(--color-text-primary);
+  font-size: 14px;
+  line-height: 1.25;
+}
+
+.search-help-popover ul {
+  display: grid;
+  gap: 7px;
+  margin-top: 11px;
+  padding: 0;
+  list-style: none;
+}
+
+.search-help-popover li {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  align-items: baseline;
+  gap: 7px;
+}
+
+.search-help-popover code,
+.search-help-popover kbd {
+  border: 1px solid var(--color-border-default);
+  border-radius: 4px;
+  padding: 1px 4px;
+  color: var(--color-text-primary);
+  background: var(--color-bg-canvas);
+  font: inherit;
+  font-weight: 700;
+}
+
+.search-help-popover p {
+  margin-top: 10px;
+}
+
+@media (pointer: coarse) {
+  .search-help-trigger::before {
+    position: absolute;
+    inset: -8px;
+    content: "";
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .search-help-popover {
+    transition: none;
+  }
 }
 
 .header-actions {

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -81,10 +81,10 @@
   .site-search {
     grid-area: search;
     grid-column: 1 / -1;
-    width: 100%;
+    width: calc(100vw - 26px);
   }
 
-  .site-search kbd {
+  .site-search > kbd {
     display: none;
   }
 

--- a/tests/e2e/catalog.spec.ts
+++ b/tests/e2e/catalog.spec.ts
@@ -330,6 +330,25 @@ test("uses one focus boundary for the main search", async ({ page }) => {
     "border-top-color",
     "rgb(45, 212, 191)",
   );
+
+  const shortcut = page.locator(".site-search > kbd");
+  const help = page.getByRole("button", { name: "Search help" });
+  await expect(shortcut).toBeVisible();
+  await expect(help).toBeVisible();
+  const shortcutBox = await shortcut.boundingBox();
+  const helpBox = await help.boundingBox();
+  expect(shortcutBox).not.toBeNull();
+  expect(helpBox).not.toBeNull();
+  expect(helpBox!.x).toBeGreaterThan(shortcutBox!.x);
+
+  await help.click();
+  await expect(
+    page.getByRole("dialog", { name: "Search basics" }),
+  ).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(help).toBeFocused();
+  await page.keyboard.press("/");
+  await expect(search).toBeFocused();
 });
 
 test("uses the approved desktop filter controls", async ({ page }) => {

--- a/tests/e2e/mobile.spec.ts
+++ b/tests/e2e/mobile.spec.ts
@@ -84,6 +84,27 @@ test("matches the approved mobile header hierarchy", async ({ page }) => {
   ).toBeLessThan(40);
 });
 
+test("keeps search help available within the mobile viewport", async ({
+  page,
+}) => {
+  await page.goto(sitePath());
+
+  await expect(page.locator(".site-search > kbd")).toBeHidden();
+  const help = page.getByRole("button", { name: "Search help" });
+  await expect(help).toBeVisible();
+  const helpBox = await help.boundingBox();
+  expect(helpBox).not.toBeNull();
+  expect(helpBox!.x + helpBox!.width).toBeLessThanOrEqual(382);
+  await help.click();
+
+  const dialog = page.getByRole("dialog", { name: "Search basics" });
+  await expect(dialog).toBeVisible();
+  const box = await dialog.boundingBox();
+  expect(box).not.toBeNull();
+  expect(box!.x).toBeGreaterThanOrEqual(8);
+  expect(box!.x + box!.width).toBeLessThanOrEqual(382);
+});
+
 test("keeps the mobile support action inside a 412px viewport", async ({
   page,
 }) => {

--- a/tests/unit/search-help.test.tsx
+++ b/tests/unit/search-help.test.tsx
@@ -1,0 +1,54 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, expect, test } from "vitest";
+
+import { SearchHelp } from "@/features/search/components/search-help";
+
+afterEach(cleanup);
+
+test("opens the approved search instructions and toggles closed", async () => {
+  const user = userEvent.setup();
+  render(<SearchHelp />);
+  const trigger = screen.getByRole("button", { name: "Search help" });
+
+  expect(trigger).toHaveAttribute("aria-expanded", "false");
+  await user.click(trigger);
+  expect(trigger).toHaveAttribute("aria-expanded", "true");
+
+  const dialog = screen.getByRole("dialog", { name: "Search basics" });
+  expect(dialog).toHaveTextContent("A B");
+  expect(dialog).toHaveTextContent("matches results containing A and B");
+  expect(dialog).toHaveTextContent("A+B");
+  expect(dialog).toHaveTextContent("matches results containing A or B");
+  expect(dialog).toHaveTextContent("A+B C");
+  expect(dialog).toHaveTextContent("matches A, or both B and C");
+  expect(dialog).toHaveTextContent(
+    "Search-result URLs can be copied and shared",
+  );
+  expect(dialog).toHaveTextContent(
+    "Press / anywhere on the page to jump to search",
+  );
+
+  await user.click(trigger);
+  expect(screen.queryByRole("dialog")).toBeNull();
+});
+
+test("dismisses outside and restores trigger focus after Escape", async () => {
+  const user = userEvent.setup();
+  render(
+    <>
+      <SearchHelp />
+      <button type="button">Outside</button>
+    </>,
+  );
+  const trigger = screen.getByRole("button", { name: "Search help" });
+
+  await user.click(trigger);
+  await user.click(screen.getByRole("button", { name: "Outside" }));
+  expect(screen.queryByRole("dialog")).toBeNull();
+
+  await user.click(trigger);
+  await user.keyboard("{Escape}");
+  expect(screen.queryByRole("dialog")).toBeNull();
+  expect(trigger).toHaveFocus();
+});

--- a/tests/visual/catalog.visual.spec.ts
+++ b/tests/visual/catalog.visual.spec.ts
@@ -61,6 +61,32 @@ async function stabilizeRelationshipActivityAge(page: Page) {
   await repositorySizes.nth(1).evaluate((label) => {
     label.textContent = "9.1 MB repo";
   });
+
+  const activityCounts = page.locator(".relationship-pair .activity-score > b");
+  await expect(activityCounts).toHaveCount(2);
+  await activityCounts.nth(0).evaluate((label) => {
+    label.textContent = "1/12";
+  });
+  await activityCounts.nth(1).evaluate((label) => {
+    label.textContent = "12/12";
+  });
+
+  const activityWeeks = page.locator(".relationship-pair .activity-weeks");
+  await expect(activityWeeks).toHaveCount(2);
+  await activityWeeks
+    .nth(0)
+    .locator("i")
+    .evaluateAll((weeks) => {
+      weeks.forEach((week, index) => {
+        week.classList.toggle("active", index === 10);
+      });
+    });
+  await activityWeeks
+    .nth(1)
+    .locator("i")
+    .evaluateAll((weeks) => {
+      weeks.forEach((week) => week.classList.add("active"));
+    });
 }
 
 async function expectNoHorizontalOverflow(page: Page) {


### PR DESCRIPTION
## Summary

- add the supplied circular question-mark control beside the main search shortcut
- explain AND, plus-OR, grouped-clause, shareable URL, and slash-focus behavior
- keep the control and viewport-clamped popover accessible on desktop and mobile
- preserve existing search parsing, ranking, filtering, and URL behavior

## Verification

- `npm.cmd run check`
  - 217 test files passed
  - 2,402 tests passed
  - production build and static export verified
- `npm.cmd run test:e2e -- tests/e2e/catalog.spec.ts tests/e2e/mobile.spec.ts`
  - 96 passed
  - 13 fixture-gated tests skipped
- rendered visual inspection at desktop and mobile breakpoints
