### PR TITLE
Accept TavernKeeper contextual-review policy v4

### DIFF
--- a/docs/superpowers/plans/2026-08-10-resolve-outstanding-github.md
+++ b/docs/superpowers/plans/2026-08-10-resolve-outstanding-github.md
@@ -1,0 +1,176 @@
+# Resolve Outstanding GitHub Work Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore TavernKeeper reconciliation, release the approved utility-first repair path, and close the remaining actionable GitHub queue through validated automation.
+
+**Architecture:** Extend the existing TavernKeeper immutable-report validator with a version-bound policy-4 branch, publish it independently, then synchronize and release the already-reviewed utility-provider PR. Repository workflows remain the sole owners of generated submission branches, issue transitions, and deployed catalog transactions.
+
+**Tech Stack:** Node.js 24, JavaScript ES modules, TypeScript tests with Vitest, GitHub Actions, GitHub CLI.
+
+## Global Constraints
+
+- Preserve the dirty and divergent primary checkout; use only isolated worktrees.
+- Contextual policy 4 requires `contextual-review-v7` and `contextual-assessment-v2`.
+- Contextual policies 3 and 4 require the existing demonstrated-risk validation; policies 1 and 2 remain legacy.
+- Never merge through a red required check or manually close an active synthesis fallback.
+- Use repository workflows for generated project branches and issue state transitions.
+
+---
+
+### Task 1: Accept contextual-review policy 4
+
+**Files:**
+- Modify: `tests/unit/tavernkeeper-reports.test.ts`
+- Modify: `scripts/security/tavernkeeper-reports.mjs`
+
+**Interfaces:**
+- Consumes: TavernKeeper report/index fields `contextual_review_policy_version`, `prompt_version`, `assessment_schema_version`, and `risk_exposure`.
+- Produces: `validateReportIndex()` and `validateScanReport()` acceptance of valid policy-4 artifacts without weakening legacy validation.
+
+- [ ] **Step 1: Add a valid policy-4 fixture helper and failing acceptance test**
+
+Add a `policy4ExposureReport()` helper that derives from `policy3ExposureReport()`, sets policy `4`, prompt `contextual-review-v7`, schema `contextual-assessment-v2`, and rebinds the immutable digest. Assert that both index and report validation return the policy-4 artifact.
+
+- [ ] **Step 2: Run the focused test and verify red**
+
+Run:
+
+```powershell
+npm.cmd test -- tests/unit/tavernkeeper-reports.test.ts -t "accepts policy-4 demonstrated-risk reports"
+```
+
+Expected: failure with `TavernKeeper has an unsupported contextual review policy version`.
+
+- [ ] **Step 3: Implement the minimal version-bound validator**
+
+In `scripts/security/tavernkeeper-reports.mjs`:
+
+```js
+const supportedContextualReviewPolicyVersions = new Set(["1", "2", "3", "4"]);
+
+function contextualReviewPromptVersion(policyVersion) {
+  return policyVersion === "4" ? "contextual-review-v7" : "contextual-review-v6";
+}
+```
+
+Treat policies 3 and 4 as demonstrated-risk policies, require the version-specific prompt plus schema v2, reuse the existing risk computation, and retain the legacy branch for policies 1 and 2.
+
+- [ ] **Step 4: Run the focused test and verify green**
+
+Run the command from Step 2. Expected: pass.
+
+- [ ] **Step 5: Add one stale-contract regression**
+
+Clone a valid policy-4 report, replace its prompt with `contextual-review-v6`, rebind its digest, and assert `validateScanReport()` throws a policy-4 contract-version error.
+
+- [ ] **Step 6: Verify the full reader suite**
+
+```powershell
+npm.cmd test -- tests/unit/tavernkeeper-reports.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Run repository verification**
+
+```powershell
+npm.cmd run check
+```
+
+Expected: formatting, lint, generated catalog/report validation, typecheck, tests, static build, and export verification all pass.
+
+- [ ] **Step 8: Commit**
+
+```powershell
+git add scripts/security/tavernkeeper-reports.mjs tests/unit/tavernkeeper-reports.test.ts
+git commit -m "fix(security): accept contextual policy v4"
+```
+
+### Task 2: Publish and merge the policy-4 reader
+
+**Files:**
+- Existing committed design and implementation changes on `codex/resolve-outstanding-github-20260810`.
+
+**Interfaces:**
+- Produces: a focused GitHub PR whose merge restores the reconciliation reader.
+
+- [ ] **Step 1: Push the isolated branch**
+
+```powershell
+git push origin codex/resolve-outstanding-github-20260810
+```
+
+- [ ] **Step 2: Open a ready PR**
+
+Create a PR titled `Accept TavernKeeper contextual-review policy v4` with the root cause and verification evidence.
+
+- [ ] **Step 3: Wait for required checks and merge**
+
+Use `gh pr checks --watch`; merge only when verify and visual checks are green.
+
+### Task 3: Restore reconciliation and resolve #460
+
+**Files:** None; workflow-owned state only.
+
+**Interfaces:**
+- Consumes: merged reader, report digest `11f7bea761dfa400588c9c2d89ce40e6ae8949111f86f510056b54dccf5afdc5`.
+- Produces: successful reconciliation and automated incident closure when narrative synthesis succeeds.
+
+- [ ] **Step 1: Dispatch an ordinary reconciliation**
+
+```powershell
+gh workflow run import-tavernkeeper-reports.yml --ref main
+```
+
+Confirm the unsupported-policy error is absent.
+
+- [ ] **Step 2: Dispatch the exact fallback retry**
+
+```powershell
+gh workflow run import-tavernkeeper-reports.yml --ref main -f retry_report_digest=11f7bea761dfa400588c9c2d89ce40e6ae8949111f86f510056b54dccf5afdc5
+```
+
+Wait for completion and inspect issue #460. If the same provider fallback recurs, retain the issue with its automation-owned updated diagnostic.
+
+### Task 4: Release PR #459 and resolve #419
+
+**Files:** Existing PR #459 branch and workflow-owned generated submission branch.
+
+**Interfaces:**
+- Produces: utility-first structured output in `main`, one-shot Luna repair for invalid JSON, and a valid project submission for issue #419.
+
+- [ ] **Step 1: Synchronize PR #459 with current main**
+
+In its existing isolated worktree, fetch and merge `origin/main` into `codex/utility-json-repair`. Resolve only genuine source conflicts; retain current main's visual stabilization unchanged.
+
+- [ ] **Step 2: Run local verification and push**
+
+Run `npm.cmd run catalog:build` followed by `npm.cmd run check`, then push the branch.
+
+- [ ] **Step 3: Mark ready, wait for checks, and merge**
+
+Remove draft status only after the local suite passes. Merge only when required checks are green.
+
+- [ ] **Step 4: Retry issue #419**
+
+```powershell
+gh workflow run generate-project-submission.yml --ref main -f issue_number=419 -f force_regeneration=false
+```
+
+Wait for the generated review PR, inspect its catalog record and checks, then merge when green. Confirm the publication workflow closes #419.
+
+### Task 5: Final deployed-state audit
+
+**Files:** None; read-only verification.
+
+**Interfaces:**
+- Produces: exact final issue/PR/run inventory and deployed catalog evidence.
+
+- [ ] **Step 1: Verify GitHub inventory**
+
+List all open issues and PRs. Any remaining item must have a current, explicit blocker rather than stale state.
+
+- [ ] **Step 2: Verify exact deployment**
+
+Confirm the latest successful Pages deployment uses the final publication SHA and the hydrated catalog contains the `zeroxjason-sillytavern-chatrenamer` project exactly once.

--- a/docs/superpowers/specs/2026-08-10-resolve-outstanding-github-design.md
+++ b/docs/superpowers/specs/2026-08-10-resolve-outstanding-github-design.md
@@ -1,0 +1,58 @@
+# Resolve Outstanding GitHub Work Design
+
+## Goal
+
+Close Tavernary's actionable GitHub queue without bypassing validation, preserving the intentionally dirty primary checkout and treating deployment as a separate proof step.
+
+## Current state
+
+- PR #457 is merged after both required checks passed.
+- Issue #465 is closed as an exact duplicate of published Kit #464.
+- Issue #419 reproducibly fails because the model returns summary JSON containing Markdown/list syntax.
+- Issue #460 represents an active deterministic TavernKeeper synthesis fallback.
+- Tavernary's report reader supports scanner policy 4 but rejects contextual-review policy 4, so reconciliation cannot currently retry #460.
+- Draft PR #459 provides utility-primary structured generation with one-shot Luna JSON repair. Its rollout hold is now releasable because TavernKeeper PR #135 is merged and all required repository secrets are configured.
+
+## Design
+
+### Contextual-review policy 4 compatibility
+
+Extend the existing immutable-report reader rather than weakening validation. Policy 4 uses the same demonstrated-risk item shape and risk mapping as policy 3, but binds `prompt_version` to `contextual-review-v7`; both use `contextual-assessment-v2`. Policies 1 and 2 remain legacy and must still reject `risk_exposure`.
+
+The reader will:
+
+- accept contextual-review versions 1 through 4;
+- require `risk_exposure` on every policy-3 and policy-4 assessment/observation;
+- require high-confidence demonstrated exposure for credible malicious behavior;
+- recompute and validate each recommended risk using the existing demonstrated-risk mapping;
+- require prompt v6 for policy 3 and prompt v7 for policy 4;
+- preserve all existing scanner-policy, digest, source-identity, coverage, and URL checks.
+
+Tests will prove a valid policy-4 index/report pair imports and that stale prompt versions or invalid risk tuples are rejected.
+
+### Release sequence
+
+1. Publish the policy-4 reader fix through a focused PR and merge only after required checks pass.
+2. Dispatch TavernKeeper reconciliation and confirm the unsupported-policy failure is gone.
+3. Update PR #459 from current `main`; do not accept visual baselines merely to turn CI green. Its model-routing diff contains no UI change, so current main's stabilized snapshots should pass after synchronization.
+4. Mark #459 ready and merge only after all required checks pass.
+5. Retry issue #419 through the repaired structured-output path, inspect and merge the generated catalog PR, then verify issue closure and deployment.
+6. Retry issue #460's exact immutable report digest. The existing incident reconciler will close it only if narrative synthesis succeeds; otherwise retain it with new diagnostic evidence.
+
+## Error handling and safety
+
+- Work only in isolated worktrees; do not modify or clean the primary checkout.
+- Do not force-update shared automation branches except through their repository-owned workflow.
+- Do not merge through a red required check.
+- Treat repeated external/provider fallback as an active incident rather than manually closing it.
+- If a workflow produces no catalog change, inspect its explicit diagnostic before deciding whether closure is valid.
+
+## Verification
+
+- Targeted policy-reader unit tests pass through an observed red-green cycle.
+- `npm.cmd run check` passes before publishing the reader fix.
+- Each PR reports green required checks before merge.
+- Reconciliation completes successfully on an exact `main` SHA.
+- Issue #419 is closed by the publication workflow and its project is present in the generated and deployed catalog.
+- Issue #460 is closed by incident reconciliation or remains open with current retry evidence.
+- Final GitHub inventory contains no unaccounted open issue or PR.

--- a/scripts/security/tavernkeeper-reports.mjs
+++ b/scripts/security/tavernkeeper-reports.mjs
@@ -19,7 +19,7 @@ const digestPattern = /^[0-9a-f]{64}$/u;
 const fullShaPattern = /^[0-9a-f]{40}$/u;
 const versionPattern = /^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$/u;
 const supportedScannerPolicyVersions = new Set(["3", "4"]);
-const supportedContextualReviewPolicyVersions = new Set(["1", "2", "3"]);
+const supportedContextualReviewPolicyVersions = new Set(["1", "2", "3", "4"]);
 const incompleteJavascriptLimitation =
   "JavaScript analysis was incomplete, so this first-filter scan supports no clean conclusion about unobserved behavior.";
 const metadataOnlyEvidenceLimitation =
@@ -135,7 +135,10 @@ function assertSupportedContextualReviewPolicy(entry) {
 function assertContextualReviewPolicy(report) {
   assertSupportedContextualReviewPolicy(report);
   const items = [...report.assessments, ...report.observations];
-  if (report.contextual_review_policy_version !== "3") {
+  const demonstratedRiskPolicy = ["3", "4"].includes(
+    report.contextual_review_policy_version,
+  );
+  if (!demonstratedRiskPolicy) {
     if (items.some((item) => Object.hasOwn(item, "risk_exposure"))) {
       throw new Error(
         "TavernKeeper legacy contextual-policy report contains risk exposure",
@@ -143,12 +146,16 @@ function assertContextualReviewPolicy(report) {
     }
     return;
   }
+  const expectedPromptVersion =
+    report.contextual_review_policy_version === "4"
+      ? "contextual-review-v7"
+      : "contextual-review-v6";
   if (
-    report.prompt_version !== "contextual-review-v6" ||
+    report.prompt_version !== expectedPromptVersion ||
     report.assessment_schema_version !== "contextual-assessment-v2"
   ) {
     throw new Error(
-      "TavernKeeper policy-3 report has invalid demonstrated-risk contract versions",
+      `TavernKeeper policy-${report.contextual_review_policy_version} report has invalid demonstrated-risk contract versions`,
     );
   }
   const invalid = items.some(
@@ -161,7 +168,7 @@ function assertContextualReviewPolicy(report) {
   );
   if (invalid) {
     throw new Error(
-      "TavernKeeper policy-3 report violates demonstrated-risk rules",
+      `TavernKeeper policy-${report.contextual_review_policy_version} report violates demonstrated-risk rules`,
     );
   }
 }

--- a/tests/unit/tavernkeeper-reports.test.ts
+++ b/tests/unit/tavernkeeper-reports.test.ts
@@ -287,6 +287,14 @@ function policy3ExposureReport(reportInput: Record<string, any>) {
   return report;
 }
 
+function policy4ExposureReport(reportInput: Record<string, any>) {
+  const report = policy3ExposureReport(reportInput);
+  report.contextual_review_policy_version = "4";
+  report.prompt_version = "contextual-review-v7";
+  report.assessment_schema_version = "contextual-assessment-v2";
+  return rebindReport(report);
+}
+
 function policy3ImmediateDangerReport(reportInput: Record<string, any>) {
   const report = addImmediateDangerCandidate(policy4Report(reportInput));
   report.contextual_review_policy_version = "3";
@@ -393,6 +401,31 @@ describe("TavernKeeper V5 report import", () => {
     );
   });
 
+  test("accepts policy-4 demonstrated-risk reports", async () => {
+    const [fixtureIndex, baseReport] = await fixtures();
+    const report = policy4ExposureReport(baseReport);
+    const entry = projectIndexReport(report);
+    const validatedIndex = validateReportIndex(
+      { ...fixtureIndex, reports: [entry] },
+      registry,
+    );
+
+    expect(validateScanReport(report, validatedIndex.reports[0])).toEqual(
+      report,
+    );
+  });
+
+  test("rejects policy-4 reports bound to the policy-3 prompt", async () => {
+    const [, baseReport] = await fixtures();
+    const report = policy4ExposureReport(baseReport);
+    report.prompt_version = "contextual-review-v6";
+    const rebound = rebindReport(report);
+
+    expect(() =>
+      validateScanReport(rebound, projectIndexReport(rebound)),
+    ).toThrow(/policy-4.*contract versions/iu);
+  });
+
   test.each([
     [
       "missing assessment exposure",
@@ -487,7 +520,7 @@ describe("TavernKeeper V5 report import", () => {
     ).toThrow(/legacy.*risk exposure/iu);
   });
 
-  test.each(["4", "999"])(
+  test.each(["5", "999"])(
     "rejects unsupported contextual policy %s on an immutable report",
     async (policy) => {
       const [index, baseReport] = await fixtures();
@@ -1097,7 +1130,7 @@ describe("TavernKeeper V5 report import", () => {
     expect(outcome.import_state.quarantines).toEqual([]);
   });
 
-  test.each(["4", "999"])(
+  test.each(["5", "999"])(
     "rejects unsupported contextual policy %s before reconciliation routes work",
     async (policy) => {
       const root = await mkdtemp(


### PR DESCRIPTION
## Summary

- accept TavernKeeper contextual-review policy 4 with its prompt-v7 contract
- preserve policy-1/2 legacy behavior and policy-3 demonstrated-risk validation
- reject stale policy-4 prompt versions and unsupported future policies before synthesis

## Root cause

TavernKeeper completed the policy-v4 catalog rescan, but Tavernary only allowed contextual-review policies 1-3. Every reconciliation therefore stopped at index validation.

## Verification

- observed red: policy-4 report rejected as unsupported
- reader suite: 70 tests passed
- `npm.cmd run check`: 217 files and 2,405 tests passed; 375 static pages built; export verified