### PR TITLE
Accept current TavernKeeper review telemetry

### DIFF
--- a/data/schemas/tavernkeeper-scan-report.v5.schema.json
+++ b/data/schemas/tavernkeeper-scan-report.v5.schema.json
@@ -354,6 +354,16 @@
               "minimum": 0,
               "maximum": 9007199254740991
             },
+            "warning_occurrences": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9007199254740991
+            },
+            "warning_families": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9007199254740991
+            },
             "representations": {
               "type": "object",
               "properties": {

--- a/data/schemas/tavernkeeper-scan-report.v5.schema.json
+++ b/data/schemas/tavernkeeper-scan-report.v5.schema.json
@@ -115,6 +115,74 @@
       ],
       "additionalProperties": false
     },
+    "review_batches": {
+      "maxItems": 10000,
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": ["contextual_review", "json_repair"]
+          },
+          "attempt": { "type": "integer", "minimum": 1, "maximum": 5 },
+          "group_count": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 5
+          },
+          "candidate_count": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 320
+          },
+          "estimated_input_tokens": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              { "type": "null" }
+            ]
+          },
+          "over_budget": { "type": "boolean" },
+          "input_tokens": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "output_tokens": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "cache_read_tokens": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "reasoning_tokens": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          }
+        },
+        "required": [
+          "kind",
+          "attempt",
+          "group_count",
+          "candidate_count",
+          "estimated_input_tokens",
+          "over_budget",
+          "input_tokens",
+          "output_tokens",
+          "cache_read_tokens",
+          "reasoning_tokens"
+        ],
+        "additionalProperties": false
+      }
+    },
     "history": {
       "type": "object",
       "properties": {
@@ -565,6 +633,52 @@
         }
       },
       "required": ["required", "completed"],
+      "additionalProperties": false
+    },
+    "review_reuse": {
+      "type": "object",
+      "properties": {
+        "groups": {
+          "type": "object",
+          "properties": {
+            "fresh": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9007199254740991
+            },
+            "reused": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9007199254740991
+            }
+          },
+          "required": ["fresh", "reused"],
+          "additionalProperties": false
+        },
+        "candidates": {
+          "type": "object",
+          "properties": {
+            "fresh": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9007199254740991
+            },
+            "reused": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9007199254740991
+            }
+          },
+          "required": ["fresh", "reused"],
+          "additionalProperties": false
+        },
+        "source_report_ids": {
+          "maxItems": 10000,
+          "type": "array",
+          "items": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+        }
+      },
+      "required": ["groups", "candidates", "source_report_ids"],
       "additionalProperties": false
     },
     "candidates": {

--- a/scripts/security/tavernkeeper-reports.mjs
+++ b/scripts/security/tavernkeeper-reports.mjs
@@ -527,6 +527,38 @@ function assertReportCoverage(report) {
       "TavernKeeper report candidate lacks completed tool coverage",
     );
   }
+  if (
+    report.review_batches &&
+    [
+      "input_tokens",
+      "output_tokens",
+      "cache_read_tokens",
+      "reasoning_tokens",
+    ].some(
+      (field) =>
+        report.review_batches.reduce((sum, batch) => sum + batch[field], 0) !==
+        report.review_usage[field],
+    )
+  ) {
+    throw new Error(
+      "TavernKeeper review batch usage does not reconcile with its totals",
+    );
+  }
+  if (report.review_reuse) {
+    const sourceIds = report.review_reuse.source_report_ids;
+    if (
+      report.review_reuse.candidates.fresh +
+        report.review_reuse.candidates.reused !==
+        report.candidates.length ||
+      (report.review_reuse.groups.reused === 0) !== (sourceIds.length === 0) ||
+      new Set(sourceIds).size !== sourceIds.length ||
+      sourceIds.some(
+        (sourceId, index) => index > 0 && sourceIds[index - 1] >= sourceId,
+      )
+    ) {
+      throw new Error("TavernKeeper review reuse provenance is inconsistent");
+    }
+  }
   const javascript = report.coverage.javascript_analysis;
   if (report.scanner_policy_version === "4" && javascript === undefined) {
     throw new Error(

--- a/scripts/security/tavernkeeper-reports.mjs
+++ b/scripts/security/tavernkeeper-reports.mjs
@@ -526,6 +526,23 @@ function assertReportCoverage(report) {
       "TavernKeeper policy-4 report lacks JavaScript analysis coverage",
     );
   }
+  if (
+    javascript &&
+    Object.hasOwn(javascript, "warning_occurrences") !==
+      Object.hasOwn(javascript, "warning_families")
+  ) {
+    throw new Error(
+      "TavernKeeper JavaScript warning occurrence and family counts must appear together",
+    );
+  }
+  if (
+    javascript?.warning_occurrences !== undefined &&
+    javascript.warning_families > javascript.warning_occurrences
+  ) {
+    throw new Error(
+      "TavernKeeper JavaScript warning families cannot exceed warning occurrences",
+    );
+  }
   const incomplete = javascript?.status === "incomplete";
   const hasUnrecoveredJavascript =
     javascript?.unresolved.some(({ recovered }) => !recovered) ?? false;

--- a/tests/unit/tavernkeeper-reports.test.ts
+++ b/tests/unit/tavernkeeper-reports.test.ts
@@ -664,6 +664,76 @@ describe("TavernKeeper V5 report import", () => {
     ).toThrow(/families.*exceed.*occurrences/iu);
   });
 
+  test("accepts review batch and reuse telemetry", async () => {
+    const [fixtureIndex, baseReport] = await fixtures();
+    const report = policy4Report(baseReport);
+    report.review_batches = [];
+    report.review_reuse = {
+      groups: { fresh: 0, reused: 0 },
+      candidates: { fresh: 0, reused: 0 },
+      source_report_ids: [],
+    };
+    const rebound = rebindReport(report);
+    const entry = projectIndexReport(rebound);
+    const validatedIndex = validateReportIndex(
+      { ...fixtureIndex, reports: [entry] },
+      registry,
+    );
+
+    expect(validateScanReport(rebound, validatedIndex.reports[0])).toEqual(
+      rebound,
+    );
+  });
+
+  test("rejects review batch usage that disagrees with totals", async () => {
+    const [fixtureIndex, baseReport] = await fixtures();
+    const report = policy4Report(baseReport);
+    report.review_batches = [
+      {
+        kind: "contextual_review",
+        attempt: 1,
+        group_count: 1,
+        candidate_count: 1,
+        estimated_input_tokens: 1,
+        over_budget: false,
+        input_tokens: 1,
+        output_tokens: 0,
+        cache_read_tokens: 0,
+        reasoning_tokens: 0,
+      },
+    ];
+    const rebound = rebindReport(report);
+    const entry = projectIndexReport(rebound);
+    const validatedIndex = validateReportIndex(
+      { ...fixtureIndex, reports: [entry] },
+      registry,
+    );
+
+    expect(() =>
+      validateScanReport(rebound, validatedIndex.reports[0]),
+    ).toThrow(/batch usage.*totals/iu);
+  });
+
+  test("rejects inconsistent review reuse provenance", async () => {
+    const [fixtureIndex, baseReport] = await fixtures();
+    const report = policy4Report(baseReport);
+    report.review_reuse = {
+      groups: { fresh: 1, reused: 0 },
+      candidates: { fresh: 1, reused: 0 },
+      source_report_ids: [],
+    };
+    const rebound = rebindReport(report);
+    const entry = projectIndexReport(rebound);
+    const validatedIndex = validateReportIndex(
+      { ...fixtureIndex, reports: [entry] },
+      registry,
+    );
+
+    expect(() =>
+      validateScanReport(rebound, validatedIndex.reports[0]),
+    ).toThrow(/reuse provenance/iu);
+  });
+
   test("rejects complete JavaScript coverage with an unrecovered stage", async () => {
     const [fixtureIndex, baseReport] = await fixtures();
     const report = policy4Report(baseReport);

--- a/tests/unit/tavernkeeper-reports.test.ts
+++ b/tests/unit/tavernkeeper-reports.test.ts
@@ -581,6 +581,56 @@ describe("TavernKeeper V5 report import", () => {
     ).toThrow(/JavaScript .*coverage/u);
   });
 
+  test("accepts X-Ray warning-family coverage", async () => {
+    const [fixtureIndex, baseReport] = await fixtures();
+    const report = policy4Report(baseReport);
+    report.coverage.javascript_analysis.warning_occurrences = 12;
+    report.coverage.javascript_analysis.warning_families = 3;
+    const rebound = rebindReport(report);
+    const entry = projectIndexReport(rebound);
+    const validatedIndex = validateReportIndex(
+      { ...fixtureIndex, reports: [entry] },
+      registry,
+    );
+
+    expect(validateScanReport(rebound, validatedIndex.reports[0])).toEqual(
+      rebound,
+    );
+  });
+
+  test("rejects incomplete X-Ray warning-family coverage", async () => {
+    const [fixtureIndex, baseReport] = await fixtures();
+    const report = policy4Report(baseReport);
+    report.coverage.javascript_analysis.warning_occurrences = 12;
+    const rebound = rebindReport(report);
+    const entry = projectIndexReport(rebound);
+    const validatedIndex = validateReportIndex(
+      { ...fixtureIndex, reports: [entry] },
+      registry,
+    );
+
+    expect(() =>
+      validateScanReport(rebound, validatedIndex.reports[0]),
+    ).toThrow(/warning.*counts.*together/iu);
+  });
+
+  test("rejects more X-Ray families than warning occurrences", async () => {
+    const [fixtureIndex, baseReport] = await fixtures();
+    const report = policy4Report(baseReport);
+    report.coverage.javascript_analysis.warning_occurrences = 2;
+    report.coverage.javascript_analysis.warning_families = 3;
+    const rebound = rebindReport(report);
+    const entry = projectIndexReport(rebound);
+    const validatedIndex = validateReportIndex(
+      { ...fixtureIndex, reports: [entry] },
+      registry,
+    );
+
+    expect(() =>
+      validateScanReport(rebound, validatedIndex.reports[0]),
+    ).toThrow(/families.*exceed.*occurrences/iu);
+  });
+
   test("rejects complete JavaScript coverage with an unrecovered stage", async () => {
     const [fixtureIndex, baseReport] = await fixtures();
     const report = policy4Report(baseReport);


### PR DESCRIPTION
## Summary
- accept current TavernKeeper review-batch, review-reuse, and X-Ray family telemetry
- independently reconcile batch token totals and validate reuse provenance
- require paired X-Ray occurrence/family counters and reject impossible counts
- preserve strict rejection of unknown report fields

## Root cause
After contextual-policy v4 support merged, live reconciliation correctly advanced to report validation and exposed the remaining top-level review_batches/review_reuse schema drift. The first new X-Ray-family report would also have introduced its two coverage counters.

## Verification
- observed red: X-Ray counters rejected as additional properties
- live importer evidence: review_batches/review_reuse rejected as top-level additional properties
- focused current-format tests: 6 passed
- report-reader suite after current-main merge: 76 passed
- all 360 active live TavernKeeper preferred reports validate with the updated strict reader, without synthesis/model calls
- full local gate before the telemetry follow-up: 217 files, 2,406 tests, 375 static pages, export verified
- formatting and diff checks pass