### PR TITLE
Accept TavernKeeper review reuse metadata

### DIFF
--- a/data/schemas/tavernkeeper-scan-report.v5.schema.json
+++ b/data/schemas/tavernkeeper-scan-report.v5.schema.json
@@ -115,6 +115,52 @@
       ],
       "additionalProperties": false
     },
+    "review_reuse": {
+      "type": "object",
+      "properties": {
+        "groups": {
+          "type": "object",
+          "properties": {
+            "fresh": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9007199254740991
+            },
+            "reused": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9007199254740991
+            }
+          },
+          "required": ["fresh", "reused"],
+          "additionalProperties": false
+        },
+        "candidates": {
+          "type": "object",
+          "properties": {
+            "fresh": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9007199254740991
+            },
+            "reused": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9007199254740991
+            }
+          },
+          "required": ["fresh", "reused"],
+          "additionalProperties": false
+        },
+        "source_report_ids": {
+          "maxItems": 10000,
+          "type": "array",
+          "items": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+        }
+      },
+      "required": ["groups", "candidates", "source_report_ids"],
+      "additionalProperties": false
+    },
     "history": {
       "type": "object",
       "properties": {

--- a/tests/unit/tavernkeeper-reports.test.ts
+++ b/tests/unit/tavernkeeper-reports.test.ts
@@ -415,6 +415,26 @@ describe("TavernKeeper V5 report import", () => {
     );
   });
 
+  test("accepts policy-4 review reuse metadata", async () => {
+    const [fixtureIndex, baseReport] = await fixtures();
+    const report = policy4ExposureReport(baseReport);
+    report.review_reuse = {
+      groups: { fresh: 1, reused: 0 },
+      candidates: { fresh: 1, reused: 0 },
+      source_report_ids: [],
+    };
+    const rebound = rebindReport(report);
+    const entry = projectIndexReport(rebound);
+    const validatedIndex = validateReportIndex(
+      { ...fixtureIndex, reports: [entry] },
+      registry,
+    );
+
+    expect(validateScanReport(rebound, validatedIndex.reports[0])).toEqual(
+      rebound,
+    );
+  });
+
   test("rejects policy-4 reports bound to the policy-3 prompt", async () => {
     const [, baseReport] = await fixtures();
     const report = policy4ExposureReport(baseReport);


### PR DESCRIPTION
## Summary

- accept TavernKeeper's optional policy-v4 `review_reuse` metadata
- bind fresh/reused group and candidate counts to safe integers
- bind source report IDs to bounded immutable SHA-256 digests

## Root cause

After contextual-review policy 4 support merged, reconciliation reached immutable report validation and rejected the upstream `review_reuse` object as an additional property. The schema here matches TavernKeeper's generated v5 report contract exactly.

## Verification

- observed red: policy-v4 report rejected as an additional property
- reader suite: 71 tests passed
- `npm.cmd run check`: 217 files and 2,406 tests passed; 409 projects and 375 static pages built; export verified