### PR TITLE
Publish SillyTavern-ChatRenamer

### DIFF
--- a/data/registry/projects/zeroxjason-sillytavern-chatrenamer.json
+++ b/data/registry/projects/zeroxjason-sillytavern-chatrenamer.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 6,
+  "id": "zeroxjason-sillytavern-chatrenamer",
+  "name": "SillyTavern-ChatRenamer",
+  "kind": "extension",
+  "summary": "SillyTavern-ChatRenamer automatically names each new chat with its character, active model, and timestamp, making model-testing conversations easy to identify at a glance.",
+  "metadata_status": "curated",
+  "source_id": "github-1312920117",
+  "frontends": ["sillytavern"],
+  "primary_function": "interface-workflow",
+  "tags": ["organize-chats-and-messages"],
+  "cataloged_at": "2026-08-10T18:09:06.411Z",
+  "catalog_cohort": "standard",
+  "listing_status": "active",
+  "listing_status_reason": null,
+  "metadata_policy": {
+    "summary": { "mode": "automatic" },
+    "tags": { "mode": "automatic" }
+  }
+}

--- a/data/registry/sources/github-1312920117.json
+++ b/data/registry/sources/github-1312920117.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 1,
+  "id": "github-1312920117",
+  "type": "github",
+  "repository": "zeroxjason/SillyTavern-ChatRenamer",
+  "repository_id": 1312920117,
+  "status": "active",
+  "status_reason": null,
+  "refresh_policy": "automatic"
+}

--- a/data/snapshots/github/github-1312920117.json
+++ b/data/snapshots/github/github-1312920117.json
@@ -1,0 +1,51 @@
+{
+  "schema_version": 4,
+  "provider": "github",
+  "source_id": "github-1312920117",
+  "repository": {
+    "id": 1312920117,
+    "owner": "zeroxjason",
+    "name": "SillyTavern-ChatRenamer",
+    "url": "https://github.com/zeroxjason/SillyTavern-ChatRenamer",
+    "description": "A simple extension for SillyTavern to rename new chats as '{char} - {model} - {yyyy-mm-dd-hhmmss}'",
+    "default_branch": "main",
+    "head_sha": "9069eacc258bddd579bd8feb5ded209cbae4e742",
+    "head_committed_at": "2026-07-26T15:42:10.000Z",
+    "archived": false,
+    "fork": false,
+    "parent": null,
+    "created_at": "2026-07-26T15:31:52.000Z",
+    "size_kb": 5
+  },
+  "source_health": "healthy",
+  "activity": {
+    "latest_source_activity_at": null,
+    "source_weeks": [],
+    "provisional_weeks": null,
+    "latest_release_at": null,
+    "evidence_status": "complete",
+    "baseline_completed_at": "2026-08-10T18:09:06.411Z",
+    "baseline_attempts": 0,
+    "evidence_head_sha": "9069eacc258bddd579bd8feb5ded209cbae4e742"
+  },
+  "community": {
+    "stars_count": 0,
+    "forks_count": 0,
+    "watchers_count": 0,
+    "aggregate": 0
+  },
+  "license": { "status": "missing", "spdx_id": null, "source_path": null },
+  "refreshed_at": "2026-08-10T18:09:06.411Z",
+  "stale_since": null,
+  "contributors": {
+    "accounts": [
+      { "login": "zeroxjason", "type": "User", "provider": "github" }
+    ],
+    "method": "repository-contributors",
+    "baseline_completed_at": null,
+    "scan": null,
+    "refreshed_at": "2026-08-10T18:09:06.411Z",
+    "stale_since": null
+  },
+  "activity_scan": null
+}


### PR DESCRIPTION
Closes #419

Publishes the admitted ChatRenamer submission through a source-backed maintainer transaction after automated enrichment remained blocked by provider authentication.

Verified locally:
- npm.cmd run check:content
- 103 focused tests passed
- 375 static pages generated and export verified