### PR TITLE
Contain targeted TavernKeeper imports

### DIFF
--- a/.github/workflows/import-tavernkeeper-reports.yml
+++ b/.github/workflows/import-tavernkeeper-reports.yml
@@ -194,7 +194,7 @@ jobs:
 
   continue:
     needs: import
-    if: ${{ always() && needs.import.result == 'success' && needs.import.outputs.remaining != '0' }}
+    if: ${{ always() && needs.import.result == 'success' && needs.import.outputs.remaining != '0' && inputs.retry_report_digest == '' }}
     runs-on: ubuntu-latest
     permissions:
       actions: write

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -664,6 +664,9 @@ test("reconciles reports independently and wakes TavernKeeper only after a chang
   expect(reportImport.jobs.continue.if).toContain(
     "needs.import.outputs.remaining != '0'",
   );
+  expect(reportImport.jobs.continue.if).toContain(
+    "inputs.retry_report_digest == ''",
+  );
   expect(JSON.stringify(reportImport.jobs.continue)).not.toContain(
     "needs.deploy",
   );


### PR DESCRIPTION
## Summary
- suppress automatic backlog continuation when an exact report digest was requested
- preserve continuation for scheduled and ordinary importer batches
- add a workflow contract regression test

## Verification
- npm.cmd run check
- 218 test files, 2,437 tests
- 375-page static export verified