### PR TITLE
Align Ko-fi header action with Submit Project

### DIFF
--- a/src/features/catalog/components/kofi-support.tsx
+++ b/src/features/catalog/components/kofi-support.tsx
@@ -29,16 +29,16 @@ export function KoFiSupport() {
   return (
     <Tooltip
       id={tooltipId}
-      label="Support Tavernary on Ko-fi"
+      label="Buy Me a Ko-Fi"
       className="kofi-support-tooltip"
     >
       <Link
         href="/support/"
         className="kofi-support-trigger"
-        aria-label="Support Tavernary on Ko-fi"
+        aria-label="Buy Me a Ko-Fi"
       >
         <CoffeeIcon />
-        <span className="kofi-support-label">Support Tavernary</span>
+        <span className="kofi-support-label">Buy Me a Ko-Fi</span>
       </Link>
     </Tooltip>
   );

--- a/src/styles/catalog.css
+++ b/src/styles/catalog.css
@@ -418,12 +418,11 @@
 
 .header-actions .kofi-support-trigger:hover,
 .header-actions .kofi-support-trigger:focus-visible {
-  border-color: var(--color-action-primary-hover);
+  color: var(--color-action-primary-text);
   background: var(--color-action-primary-hover);
 }
 
 .header-actions .kofi-support-trigger:active {
-  border-color: var(--color-action-primary-pressed);
   background: var(--color-action-primary-pressed);
 }
 

--- a/tests/e2e/contribution-links.spec.ts
+++ b/tests/e2e/contribution-links.spec.ts
@@ -72,7 +72,7 @@ test("links to the transparent support page beside Submit Project", async ({
 
   const submit = page.getByRole("link", { name: "Submit Project" });
   const support = page.getByRole("link", {
-    name: "Support Tavernary on Ko-fi",
+    name: "Buy Me a Ko-Fi",
   });
   const [submitBox, supportBox] = await Promise.all([
     submit.boundingBox(),
@@ -87,8 +87,30 @@ test("links to the transparent support page beside Submit Project", async ({
 
   await support.hover();
   await expect(
-    page.getByRole("tooltip", { name: "Support Tavernary on Ko-fi" }),
+    page.getByRole("tooltip", { name: "Buy Me a Ko-Fi" }),
   ).toBeVisible();
+  const supportHover = await support.evaluate((element) => {
+    const style = getComputedStyle(element);
+    return {
+      color: style.color,
+      backgroundColor: style.backgroundColor,
+      borderTopColor: style.borderTopColor,
+      boxShadow: style.boxShadow,
+      transform: style.transform,
+    };
+  });
+  await submit.hover();
+  const submitHover = await submit.evaluate((element) => {
+    const style = getComputedStyle(element);
+    return {
+      color: style.color,
+      backgroundColor: style.backgroundColor,
+      borderTopColor: style.borderTopColor,
+      boxShadow: style.boxShadow,
+      transform: style.transform,
+    };
+  });
+  expect(supportHover).toEqual(submitHover);
 
   await support.click();
   await expect(

--- a/tests/e2e/mobile.spec.ts
+++ b/tests/e2e/mobile.spec.ts
@@ -62,7 +62,7 @@ test("matches the approved mobile header hierarchy", async ({ page }) => {
 
   const submit = page.getByRole("link", { name: "Submit Project" });
   const support = page.getByRole("link", {
-    name: "Support Tavernary on Ko-fi",
+    name: "Buy Me a Ko-Fi",
   });
   await expect(support).toBeVisible();
   await expect(support.locator(".kofi-support-label")).toHaveCSS(
@@ -112,7 +112,7 @@ test("keeps the mobile support action inside a 412px viewport", async ({
   await page.goto(sitePath());
 
   const support = page.getByRole("link", {
-    name: "Support Tavernary on Ko-fi",
+    name: "Buy Me a Ko-Fi",
   });
   const supportBox = await support.boundingBox();
   expect(supportBox).not.toBeNull();
@@ -126,7 +126,7 @@ test("opens the Tavernary support page from a 320px viewport", async ({
 }) => {
   await page.setViewportSize({ width: 320, height: 700 });
   await page.goto(sitePath());
-  await page.getByRole("link", { name: "Support Tavernary on Ko-fi" }).click();
+  await page.getByRole("link", { name: "Buy Me a Ko-Fi" }).click();
 
   await expect(
     page.getByRole("heading", { name: "Support Tavernary", exact: true }),

--- a/tests/unit/kofi-support.test.tsx
+++ b/tests/unit/kofi-support.test.tsx
@@ -21,10 +21,10 @@ test("links the header support action to Tavernary's transparency page", () => {
   render(<KoFiSupport />);
 
   const support = screen.getByRole("link", {
-    name: "Support Tavernary on Ko-fi",
+    name: "Buy Me a Ko-Fi",
   });
   expect(support).toHaveAttribute("href", "/support");
-  expect(support).toHaveTextContent("Support Tavernary");
+  expect(support).toHaveTextContent("Buy Me a Ko-Fi");
   expect(support.querySelector("svg")).toHaveAttribute("aria-hidden", "true");
   expect(screen.queryByRole("button")).toBeNull();
   expect(screen.queryByRole("dialog")).toBeNull();
@@ -35,11 +35,11 @@ test("uses Tavernary's shared desktop tooltip", async () => {
   render(<KoFiSupport />);
 
   const support = screen.getByRole("link", {
-    name: "Support Tavernary on Ko-fi",
+    name: "Buy Me a Ko-Fi",
   });
   await user.hover(support);
 
   expect(
-    screen.getByRole("tooltip", { name: "Support Tavernary on Ko-fi" }),
+    screen.getByRole("tooltip", { name: "Buy Me a Ko-Fi" }),
   ).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- rename the header action and tooltip to **Buy Me a Ko-Fi**
- match its hover, focus, and pressed treatment to **Submit Project**
- preserve the existing icon-only 34 x 34 mobile control

## Validation
- `npm.cmd run check`
- 218 test files / 2,437 tests passed
- production build and static export verified
- focused Chromium contribution-link and mobile coverage passed