### PR TITLE
fix(provider): expose auth status safely

### DIFF
--- a/docs/superpowers/plans/2026-08-10-provider-auth-status-diagnostic.md
+++ b/docs/superpowers/plans/2026-08-10-provider-auth-status-diagnostic.md
@@ -1,0 +1,96 @@
+# Provider Authentication Status Diagnostic Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve Tavernary's stable provider-authentication error while safely distinguishing upstream HTTP 401 from HTTP 403.
+
+**Architecture:** Extend the existing `EnrichmentProviderError.diagnosticCode` field at the HTTP status-classification boundary. Authentication responses remain unread and cancelled; only a fixed token derived from the numeric status enters the error object and Actions logs.
+
+**Tech Stack:** Node.js 24, JavaScript ESM, TypeScript/Vitest tests, GitHub Actions
+
+## Global Constraints
+
+- Keep `provider-authentication-failed` as the stable error code.
+- Emit only `http-401` or `http-403`; never read or expose authentication response bodies.
+- Do not change retry, provider routing, workflow secrets, models, or public catalog copy.
+- Work in the isolated `codex/provider-auth-status-diagnostic` worktree and preserve the dirty primary checkout.
+
+---
+
+### Task 1: Attach safe HTTP status diagnostics
+
+**Files:**
+- Modify: `scripts/catalog/enrichment-provider.mjs`
+- Test: `tests/unit/enrichment-provider.test.ts`
+
+**Interfaces:**
+- Consumes: `EnrichmentProviderError(code, diagnosticCode, details)` and `statusError(response, maximumBytes)`.
+- Produces: authentication errors with `code === "provider-authentication-failed"` and `diagnosticCode === "http-401" | "http-403"`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add a parameterized test with HTTP 401 and 403 responses whose bodies contain a private marker. For each status, assert the thrown error matches:
+
+```ts
+{
+  code: "provider-authentication-failed",
+  diagnosticCode: `http-${status}`,
+}
+```
+
+Also assert the response body is cancelled and `JSON.stringify(error)` does not contain the private marker.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```powershell
+npm.cmd test -- tests/unit/enrichment-provider.test.ts
+```
+
+Expected: FAIL because authentication errors currently have `diagnosticCode: null`.
+
+- [ ] **Step 3: Implement the minimal status mapping**
+
+Change only the 401/403 branch in `statusError`:
+
+```js
+if (status === 401 || status === 403) {
+  await cancelResponseBody(response);
+  return new EnrichmentProviderError(
+    "provider-authentication-failed",
+    `http-${status}`,
+  );
+}
+```
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run:
+
+```powershell
+npm.cmd test -- tests/unit/enrichment-provider.test.ts
+```
+
+Expected: all tests in the file pass with no private marker in errors.
+
+- [ ] **Step 5: Run repository verification**
+
+Run:
+
+```powershell
+npm.cmd run check
+```
+
+Expected: formatting, lint, type checking, unit tests, catalog/security validation, build, and static export all pass.
+
+- [ ] **Step 6: Commit the implementation**
+
+```powershell
+git add -- scripts/catalog/enrichment-provider.mjs tests/unit/enrichment-provider.test.ts
+git commit -m "fix(provider): expose auth status safely"
+```
+
+- [ ] **Step 7: Publish and verify live diagnostic**
+
+Push the branch, open a PR, wait for all required checks, merge to `main`, then dispatch only issue #504 with `force_regeneration=false`. Confirm the run reports `http-401` or `http-403` without response content before deciding the next provider action.

--- a/docs/superpowers/specs/2026-08-10-provider-auth-status-diagnostic-design.md
+++ b/docs/superpowers/specs/2026-08-10-provider-auth-status-diagnostic-design.md
@@ -1,0 +1,19 @@
+# Provider Authentication Status Diagnostic
+
+## Purpose
+
+Distinguish an upstream HTTP 401 response from HTTP 403 when an OpenAI-compatible provider rejects Tavernary authentication. The current `provider-authentication-failed` code intentionally groups both statuses, which makes a bad credential indistinguishable from a valid credential denied access to a subscription route or model.
+
+## Design
+
+Keep `provider-authentication-failed` as the stable public error code. Attach only a sanitized diagnostic token, `http-401` or `http-403`, to the existing `EnrichmentProviderError`. Do not read, retain, or log the provider response body for either status. Existing cancellation and bounded-response behavior remains unchanged.
+
+The CLI's existing error rendering will expose the diagnostic property in GitHub Actions logs without exposing request content, credentials, headers, or provider response text.
+
+## Verification
+
+Add focused provider tests for HTTP 401 and HTTP 403. Each test must prove the stable error code, exact sanitized diagnostic token, response-body cancellation, and absence of the private response-body marker from the serialized error. Run the focused provider test first, then the repository's normal verification gate before publication.
+
+## Scope
+
+No retry behavior, provider routing, workflow secret scope, model selection, or public copy changes. After the change reaches `main`, rerun only issue #504 as the canary and inspect its exact diagnostic before any queue drain.

--- a/scripts/catalog/enrichment-provider.mjs
+++ b/scripts/catalog/enrichment-provider.mjs
@@ -235,7 +235,10 @@ async function statusError(response, maximumBytes) {
   }
   if (status === 401 || status === 403) {
     await cancelResponseBody(response);
-    return new EnrichmentProviderError("provider-authentication-failed");
+    return new EnrichmentProviderError(
+      "provider-authentication-failed",
+      `http-${status}`,
+    );
   }
   if (status >= 500) {
     await cancelResponseBody(response);

--- a/tests/unit/enrichment-provider.test.ts
+++ b/tests/unit/enrichment-provider.test.ts
@@ -754,8 +754,11 @@ test.each([
         canceled = true;
       },
     });
+    const getReader = vi.spyOn(body, "getReader");
+    const response = new Response(body, { status });
+    const readText = vi.spyOn(response, "text");
     const provider = createEnrichmentProvider(
-      utilityProviderOptions(async () => new Response(body, { status })),
+      utilityProviderOptions(async () => response),
     );
 
     let error: unknown;
@@ -770,6 +773,9 @@ test.each([
       diagnosticCode,
     });
     expect(canceled).toBe(true);
+    expect(getReader).not.toHaveBeenCalled();
+    expect(readText).not.toHaveBeenCalled();
+    expect(String(error)).not.toContain(privateMarker);
     expect(JSON.stringify(error)).not.toContain(privateMarker);
   },
 );

--- a/tests/unit/enrichment-provider.test.ts
+++ b/tests/unit/enrichment-provider.test.ts
@@ -739,6 +739,42 @@ test("does not attach damaged schema-invalid output to a thrown error", async ()
 });
 
 test.each([
+  [401, "http-401"],
+  [403, "http-403"],
+] as const)(
+  "records HTTP %i without reading the authentication response body",
+  async (status, diagnosticCode) => {
+    const privateMarker = `PRIVATE AUTHENTICATION BODY ${status}`;
+    let canceled = false;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(privateMarker));
+      },
+      cancel() {
+        canceled = true;
+      },
+    });
+    const provider = createEnrichmentProvider(
+      utilityProviderOptions(async () => new Response(body, { status })),
+    );
+
+    let error: unknown;
+    try {
+      await provider.generate(input);
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toMatchObject({
+      code: "provider-authentication-failed",
+      diagnosticCode,
+    });
+    expect(canceled).toBe(true);
+    expect(JSON.stringify(error)).not.toContain(privateMarker);
+  },
+);
+
+test.each([
   [
     "HTTP failure",
     () => new Response("private repair failure", { status: 500 }),


### PR DESCRIPTION
## Summary

- preserve `provider-authentication-failed` as the stable provider error code
- attach sanitized `http-401` or `http-403` diagnostics without reading the response body
- prove both status mappings, body cancellation, and private-body non-disclosure

## Root cause

Tavernary intentionally grouped HTTP 401 and 403, leaving NanoGPT credential rejection indistinguishable from denied subscription or model access during live recovery.

## Verification

- focused provider suite: 55 tests passed
- full static/unit gate: 218 files and 2,438 tests passed
- production build: 390 static pages generated
- static export verified
