### PR TITLE
fix(submissions): retain safe auth status

### DIFF
--- a/scripts/submissions/draft-project-record.d.mts
+++ b/scripts/submissions/draft-project-record.d.mts
@@ -58,6 +58,7 @@ export type DraftEnrichment =
   | {
       status: "failed";
       code: string;
+      diagnosticCode?: string | null;
       message: string;
     }
   | null;

--- a/scripts/submissions/draft-project-record.mjs
+++ b/scripts/submissions/draft-project-record.mjs
@@ -266,6 +266,12 @@ export async function draftProjectRecord(input) {
       typeof input.enrichment.message === "string"
         ? input.enrichment.message.trim()
         : "";
+    const diagnosticCode =
+      input.enrichment?.status === "failed" &&
+      input.enrichment.code === "provider-authentication-failed" &&
+      ["http-401", "http-403"].includes(input.enrichment.diagnosticCode)
+        ? input.enrichment.diagnosticCode
+        : null;
     throw Object.assign(
       new Error(
         `Validated catalog copy is required before this project can be drafted${
@@ -278,6 +284,7 @@ export async function draftProjectRecord(input) {
           typeof input.enrichment.code === "string"
             ? input.enrichment.code
             : "catalog-copy-required",
+        ...(diagnosticCode ? { diagnosticCode } : {}),
       },
     );
   }

--- a/scripts/submissions/generate-project-submission.mjs
+++ b/scripts/submissions/generate-project-submission.mjs
@@ -948,6 +948,8 @@ export async function prepareProjectSubmissionDraft({
     enrichment = {
       status: "failed",
       code: error.code ?? "enrichment-failed",
+      diagnosticCode:
+        typeof error.diagnosticCode === "string" ? error.diagnosticCode : null,
       message: error.message,
     };
   }

--- a/tests/unit/draft-project-record.test.ts
+++ b/tests/unit/draft-project-record.test.ts
@@ -508,6 +508,7 @@ test("reports why required catalog copy could not be validated", async () => {
     enrichment: {
       status: "failed",
       code: "provider-timeout",
+      diagnosticCode: "PRIVATE PROVIDER DETAIL",
       message: "The enrichment provider timed out.",
     },
     copyRequired: true,
@@ -519,6 +520,8 @@ test("reports why required catalog copy could not be validated", async () => {
     message:
       "Validated catalog copy is required before this project can be drafted: The enrichment provider timed out.",
   });
+  expect(error).not.toHaveProperty("diagnosticCode");
+  expect(String(error)).not.toContain("PRIVATE PROVIDER DETAIL");
 });
 
 test("drafts external presets with manual source policy", async () => {

--- a/tests/unit/generate-project-submission-cli.test.ts
+++ b/tests/unit/generate-project-submission-cli.test.ts
@@ -746,6 +746,40 @@ test("routes unavailable verified-owner copy review to manual publication", asyn
   expect(draft.publicationMode).toBe("manual");
 });
 
+test.each([["http-401"], ["http-403"]] as const)(
+  "preserves safe provider diagnostic %s when required automatic copy fails",
+  async (diagnosticCode) => {
+    const enrich = vi.fn(async () => {
+      throw new EnrichmentProviderError(
+        "provider-authentication-failed",
+        diagnosticCode,
+      );
+    });
+
+    await expect(
+      prepareProjectSubmissionDraft(
+        repositorySubmissionFixture({
+          user: { id: 23, login: "Contributor" },
+          ownerId: 11,
+          metadata: {
+            summary: { mode: "automatic" },
+            tags: { mode: "automatic" },
+          },
+          enrich,
+          copySummary: vi.fn(async () => {
+            throw new Error("Automatic copy must not use manual copy review.");
+          }),
+        }),
+      ),
+    ).rejects.toMatchObject({
+      code: "provider-authentication-failed",
+      diagnosticCode,
+      message:
+        "Validated catalog copy is required before this project can be drafted: The enrichment provider rejected authentication.",
+    });
+  },
+);
+
 test("discards community manual metadata before synthesized enrichment", async () => {
   const enrich = vi.fn(async () => ({
     status: "curated",


### PR DESCRIPTION
Propagates only the allowlisted http-401/http-403 provider authentication diagnostic through the required-copy failure boundary. Arbitrary provider diagnostics remain suppressed. Verified with npm.cmd run check (2,440 tests, production build, static export) and independent review.