### PR TITLE
fix(catalog): clarify GLM repair prompts

### DIFF
--- a/scripts/catalog/enrich-readmes.mjs
+++ b/scripts/catalog/enrich-readmes.mjs
@@ -395,7 +395,15 @@ function validateOutput(output, record, vocabularies, providerInput) {
         return "Summary must not contain URLs or domain-style links. If a dotted brand or project name resembles a domain, refer to the project generically instead.";
       }
       if (error.includes("evidence")) {
-        return "Include compact source evidence references.";
+        return "Include compact source evidence references. Return every evidence reference as a non-empty single-line string of 160 characters or fewer inside summary.evidence or tags[].evidence; do not return evidence objects.";
+      }
+      if (
+        error.includes("copy") ||
+        error.startsWith("accepted-") ||
+        error.startsWith("light edits") ||
+        error.startsWith("policy rewrites")
+      ) {
+        return 'Use result "accepted-unchanged" with change_reasons [] and policy_signal "none" when synthesis needs no catalog-policy edit. For "accepted-with-light-edits", return one or more allowed light change reasons ("emoji-removed", "whitespace-normalized", "punctuation-corrected", or "obvious-spelling-corrected") and policy_signal "none". For "accepted-with-policy-rewrite", return one or more policy reasons ("graphic-wording-neutralized", "slur-removed", or "discriminatory-framing-neutralized") and policy_signal "catalog-policy-rewrite".';
       }
       if (
         error.includes("tags") ||

--- a/tests/unit/enrich-readmes.test.ts
+++ b/tests/unit/enrich-readmes.test.ts
@@ -667,6 +667,49 @@ test("restates structured field shapes when repairing primitive output", async (
   );
 });
 
+test("restates evidence and copy metadata shapes during validation repair", async () => {
+  const validOutput = outputFor({
+    requestedFields: ["summary", "tags"],
+    allowedTags: vocabularies.tags,
+  });
+  const invalidOutput = {
+    ...validOutput,
+    summary: {
+      value: summary,
+      evidence: [{ section: "README" }],
+    },
+    result: "accepted-with-light-edits",
+    change_reasons: ["rewritten"],
+  } as unknown as ReturnType<typeof outputFor>;
+  const generate = vi.fn(async (_input: ProviderInput) => ({
+    output: generate.mock.calls.length === 1 ? invalidOutput : validOutput,
+    metadata: providerMetadata,
+  }));
+
+  await enrichRecord(
+    record,
+    sourceRecord,
+    snapshot,
+    { generate },
+    {
+      vocabularies,
+      loadSource: async () => readySource(),
+      maxProviderAttempts: 2,
+    },
+  );
+
+  const repairMessage = generate.mock.calls[1]?.[0].repair?.message;
+  expect(repairMessage).toContain(
+    "Return every evidence reference as a non-empty single-line string",
+  );
+  expect(repairMessage).toContain(
+    'Use result "accepted-unchanged" with change_reasons [] and policy_signal "none"',
+  );
+  expect(repairMessage).toContain(
+    'For "accepted-with-light-edits", return one or more allowed light change reasons',
+  );
+});
+
 test("gives a usable repair when a dotted brand looks like a link", async () => {
   const validOutput = outputFor({
     requestedFields: ["summary", "tags"],


### PR DESCRIPTION
## Summary
- give schema-validation repairs exact evidence-reference shapes
- restate valid copy result, change-reason, and policy-signal tuples
- cover GLM's rejected metadata shape with a regression test

## Verification
- `npm.cmd run check` (218 files, 2441 tests; 393 static pages; export verified)
- `npm.cmd exec vitest run tests/unit/enrich-readmes.test.ts`
- `npm.cmd run format:check`