### PR TITLE
fix(security): accept review protocol 2

### DIFF
--- a/data/schemas/tavernkeeper-scan-report.v5.schema.json
+++ b/data/schemas/tavernkeeper-scan-report.v5.schema.json
@@ -257,6 +257,7 @@
         "model_budget": {
           "type": "object",
           "properties": {
+            "review_protocol_version": { "type": "number", "const": 2 },
             "configured": {
               "type": "object",
               "properties": {

--- a/docs/superpowers/plans/2026-08-12-tavernkeeper-review-protocol-v2.md
+++ b/docs/superpowers/plans/2026-08-12-tavernkeeper-review-protocol-v2.md
@@ -1,0 +1,95 @@
+# TavernKeeper Review Protocol 2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore TavernKeeper reconciliation by accepting valid policy-5 review protocol 2 aggregate accounting.
+
+**Architecture:** Extend Tavernary's strict copy of the TavernKeeper v5 contract with the exact protocol marker. Keep every existing accounting invariant, but condition the five per-wave cap comparisons on the absence of protocol 2.
+
+**Tech Stack:** Node.js 24, JavaScript modules, JSON Schema with Ajv, TypeScript declarations, Vitest
+
+## Global Constraints
+
+- Preserve strict schema validation and reject unknown properties or protocol versions.
+- Preserve compatibility with immutable policy-5 reports that omit the marker.
+- Do not change wake/retry scheduling or TavernKeeper producer behavior.
+
+---
+
+### Task 1: Add protocol-2 regression coverage
+
+**Files:**
+- Modify: `tests/unit/tavernkeeper-reports.test.ts`
+
+**Interfaces:**
+- Consumes: `validateScanReport(report, entry)` and the policy-5 fixture.
+- Produces: A regression proving consistent protocol-2 aggregate totals are accepted.
+
+- [ ] **Step 1: Construct a protocol-2 policy-5 report in the unit test**
+
+Create 13 contextual candidates and assessments, seven reconciled review
+batches, aggregate token usage above the configured caps, and
+`review_protocol_version: 2`.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `npm.cmd test -- --run tests/unit/tavernkeeper-reports.test.ts`
+
+Expected: FAIL with `review_triage/model_budget must NOT have additional properties`.
+
+### Task 2: Accept the exact protocol-2 contract
+
+**Files:**
+- Modify: `data/schemas/tavernkeeper-scan-report.v5.schema.json`
+- Modify: `scripts/security/tavernkeeper-reports.mjs`
+- Modify: `scripts/security/tavernkeeper-reports.d.mts`
+
+**Interfaces:**
+- Consumes: `review_triage.model_budget.review_protocol_version`.
+- Produces: Strict schema/type support and protocol-aware cap validation.
+
+- [ ] **Step 1: Add the optional literal marker to schema and declarations**
+
+Add `review_protocol_version` with JSON Schema `const: 2` and TypeScript type
+`review_protocol_version?: 2`.
+
+- [ ] **Step 2: Condition only cap comparisons on protocol 2**
+
+Keep equality/accounting checks unconditional. Wrap the five `actual >
+configured` comparisons in
+`triage.model_budget.review_protocol_version !== 2 && (...)`.
+
+- [ ] **Step 3: Run the focused test and verify GREEN**
+
+Run: `npm.cmd test -- --run tests/unit/tavernkeeper-reports.test.ts`
+
+Expected: 76 tests pass with zero failures.
+
+### Task 3: Verify and publish
+
+**Files:**
+- Verify all files changed by Tasks 1 and 2.
+
+**Interfaces:**
+- Consumes: The completed compatibility patch.
+- Produces: A reviewed pull request and live successful reconciliation.
+
+- [ ] **Step 1: Run repository checks**
+
+Run `npm.cmd run check` and confirm every command exits zero.
+
+- [ ] **Step 2: Review the complete diff**
+
+Confirm the patch changes no retry scheduling and retains all non-cap
+invariants.
+
+- [ ] **Step 3: Commit and publish**
+
+Commit as `fix(security): accept review protocol 2`, push the feature branch,
+and open a pull request against `main`.
+
+- [ ] **Step 4: Verify GitHub and live behavior**
+
+Wait for required PR checks, merge the pull request, dispatch reconciliation,
+and verify the import job, summary publication if changed, and applicable Pages
+deployment complete successfully.

--- a/docs/superpowers/specs/2026-08-12-tavernkeeper-review-protocol-v2-design.md
+++ b/docs/superpowers/specs/2026-08-12-tavernkeeper-review-protocol-v2-design.md
@@ -1,0 +1,49 @@
+# TavernKeeper Review Protocol 2 Compatibility Design
+
+## Problem
+
+TavernKeeper policy-5 reports can now continue contextual review across several
+bounded waves. Those reports mark aggregate accounting with
+`review_triage.model_budget.review_protocol_version: 2`. Tavernary's strict v5
+schema does not recognize the marker, and its semantic validator applies the
+old single-wave caps to aggregate totals. Reconciliation therefore rejects
+valid published reports before importing any summaries.
+
+## Considered approaches
+
+1. **Accept any extra model-budget fields.** This would restore imports but
+   weakens the strict producer/consumer contract and could hide unrelated drift.
+2. **Raise or remove the configured caps.** This misrepresents the limits,
+   which remain per-wave controls under protocol 2.
+3. **Recognize protocol 2 explicitly.** Add the exact marker to the schema and
+   type declaration, preserve all accounting invariants, and waive only the
+   aggregate-versus-per-wave cap comparisons when the marker is `2`.
+
+Approach 3 is selected because it matches TavernKeeper's authoritative v5
+contract without weakening validation for legacy reports or unknown protocols.
+
+## Contract and validation
+
+- `review_protocol_version` is optional so immutable policy-5 reports produced
+  before protocol 2 remain readable.
+- When present, the only accepted value is the numeric literal `2`.
+- Protocol-2 reports may have aggregate fresh-case, provider-call, estimated
+  input, actual input, or actual output totals above the configured per-wave
+  caps.
+- Candidate, case, reason, batch, token-usage, identity, evidence, coverage,
+  and reviewer consistency checks remain unchanged.
+- Reports without the protocol-2 marker retain the existing cap enforcement.
+
+## Testing
+
+A unit regression constructs a fully consistent policy-5 report containing 13
+contextual cases and seven batches whose aggregate totals exceed every
+configured cap. It must fail against the current reader and pass only after the
+schema and semantic validator understand protocol 2. Existing mismatch tests
+continue protecting strict validation.
+
+## Scope
+
+Modify only the TavernKeeper report JSON schema, runtime validator, matching
+TypeScript declaration, regression tests, and these design/plan documents. No
+retry scheduling or TavernKeeper producer behavior changes are included.

--- a/scripts/security/tavernkeeper-reports.d.mts
+++ b/scripts/security/tavernkeeper-reports.d.mts
@@ -149,6 +149,7 @@ export interface TavernKeeperScanReportV5 {
     };
     reasons: Array<{ reason_code: string; count: number }>;
     model_budget: {
+      review_protocol_version?: 2;
       configured: {
         max_fresh_behavior_cases: 12;
         max_provider_calls: 6;

--- a/scripts/security/tavernkeeper-reports.mjs
+++ b/scripts/security/tavernkeeper-reports.mjs
@@ -566,11 +566,12 @@ function assertPolicy5Triage(report) {
     actual.estimated_input_tokens !== estimatedInputTokens ||
     actual.input_tokens !== report.review_usage.input_tokens ||
     actual.output_tokens !== report.review_usage.output_tokens ||
-    actual.fresh_behavior_cases > configured.max_fresh_behavior_cases ||
-    actual.provider_calls > configured.max_provider_calls ||
-    actual.estimated_input_tokens > configured.max_estimated_input_tokens ||
-    actual.input_tokens > configured.max_actual_input_tokens ||
-    actual.output_tokens > configured.max_actual_output_tokens
+    (triage.model_budget.review_protocol_version !== 2 &&
+      (actual.fresh_behavior_cases > configured.max_fresh_behavior_cases ||
+        actual.provider_calls > configured.max_provider_calls ||
+        actual.estimated_input_tokens > configured.max_estimated_input_tokens ||
+        actual.input_tokens > configured.max_actual_input_tokens ||
+        actual.output_tokens > configured.max_actual_output_tokens))
   ) {
     throw new Error("TavernKeeper policy-5 model budget is inconsistent");
   }

--- a/tests/unit/tavernkeeper-reports.test.ts
+++ b/tests/unit/tavernkeeper-reports.test.ts
@@ -423,6 +423,109 @@ describe("TavernKeeper V5 report import", () => {
     }
   });
 
+  test("accepts protocol-2 aggregate review totals above per-wave caps", async () => {
+    const fixture = JSON.parse(
+      await readFile(policy5ReportFixturePath, "utf8"),
+    );
+    const candidates = Array.from({ length: 13 }, (_, index) => ({
+      ...clone(fixture.candidates[0]),
+      candidate_id: (index + 1).toString(16).padStart(64, "0"),
+      evidence_id: (index + 101).toString(16).padStart(64, "0"),
+    }));
+    const assessments = candidates.map((candidate) => ({
+      ...clone(fixture.assessments[0]),
+      candidate_id: candidate.candidate_id,
+      evidence_ids: [candidate.evidence_id],
+      assessment_source: "contextual-model",
+    }));
+    const reviewBatches = Array.from({ length: 7 }, (_, index) => ({
+      kind: "contextual_review",
+      attempt: 1,
+      group_count: index === 6 ? 1 : 2,
+      candidate_count: index === 6 ? 1 : 2,
+      estimated_input_tokens: 30_000,
+      over_budget: false,
+      input_tokens: 40_000,
+      output_tokens: 6_000,
+      cache_read_tokens: 0,
+      reasoning_tokens: 0,
+    }));
+    const report = rebindReport({
+      ...fixture,
+      contextual_reviewer: {
+        provider: "provider.example",
+        model: "configured/model",
+      },
+      review_usage: {
+        input_tokens: 280_000,
+        output_tokens: 42_000,
+        cache_read_tokens: 0,
+        reasoning_tokens: 0,
+      },
+      review_batches: reviewBatches,
+      review_triage: {
+        ...fixture.review_triage,
+        candidates: {
+          total: 13,
+          deterministic: 0,
+          contextual: 13,
+          reused_contextual: 0,
+        },
+        cases: { total: 13, contextual: 13, reused_contextual: 0 },
+        reasons: [{ reason_code: "owned-structured-weakness", count: 13 }],
+        model_budget: {
+          review_protocol_version: 2,
+          configured: fixture.review_triage.model_budget.configured,
+          actual: {
+            fresh_behavior_cases: 13,
+            provider_calls: 7,
+            estimated_input_tokens: 210_000,
+            input_tokens: 280_000,
+            output_tokens: 42_000,
+          },
+        },
+      },
+      coverage: {
+        ...fixture.coverage,
+        javascript_analysis: {
+          ...fixture.coverage.javascript_analysis,
+          candidates: 13,
+        },
+        evidence_validation: {
+          ...fixture.coverage.evidence_validation,
+          validated_candidates: 13,
+        },
+      },
+      review_coverage: { required: 13, completed: 13 },
+      candidates,
+      assessments,
+      counts: {
+        candidates: 13,
+        assessments: 13,
+        observations: 0,
+        items: 13,
+        disposition: {
+          expected_behavior: 0,
+          minor_weakness: 0,
+          material_vulnerability: 13,
+          credible_malicious_behavior: 0,
+        },
+        impact: { none: 0, low: 13, medium: 0, high: 0, critical: 0 },
+        exploitability: {
+          unlikely: 0,
+          plausible: 13,
+          readily_exploitable: 0,
+        },
+        confidence: { low: 0, medium: 0, high: 13 },
+        recommended_risk: { low: 13, material: 0, high: 0 },
+      },
+    });
+
+    expect(validateScanReport(report, projectIndexReport(report))).toEqual(
+      report,
+    );
+  });
+
   test("uses scanner policy 5 as active catalog evidence", () => {
     expect(ACTIVE_TAVERNKEEPER_SCANNER_POLICY_VERSION).toBe("5");
   });

--- a/tests/unit/tavernkeeper-reports.test.ts
+++ b/tests/unit/tavernkeeper-reports.test.ts
@@ -524,6 +524,16 @@ describe("TavernKeeper V5 report import", () => {
     expect(validateScanReport(report, projectIndexReport(report))).toEqual(
       report,
     );
+
+    const legacyReport = clone(report);
+    delete legacyReport.review_triage.model_budget.review_protocol_version;
+    const reboundLegacyReport = rebindReport(legacyReport);
+    expect(() =>
+      validateScanReport(
+        reboundLegacyReport,
+        projectIndexReport(reboundLegacyReport),
+      ),
+    ).toThrow("TavernKeeper policy-5 model budget is inconsistent");
   });
 
   test("uses scanner policy 5 as active catalog evidence", () => {


### PR DESCRIPTION
## Summary

- accept TavernKeeper policy-5 `review_protocol_version: 2` in the strict v5 reader contract
- treat protocol-2 model-budget totals as aggregates while preserving all accounting invariants
- retain legacy per-wave cap enforcement and add regression coverage for both sides of the boundary

## Root cause

TavernKeeper began publishing valid protocol-2 reports after adding multi-wave contextual review continuation. Tavernary rejected the new marker as an unknown property, causing every reconciliation dispatch to fail before import.

## Verification

- `npm.cmd test -- --run tests/unit/tavernkeeper-reports.test.ts` (76 passed)
- patched reader validated the live failing report `8585ad6405b32aa3c434a6dd81257f60a384ad8dea5df02ad5211a3f1f5768cf`
- `npm.cmd run check` (2,442 tests; production build and static export verified)
- independent diff review completed with no remaining findings