### PR TITLE
chore(security): protect contributor publishing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @MentallyQuill

--- a/.github/workflows/admit-issue.yml
+++ b/.github/workflows/admit-issue.yml
@@ -26,6 +26,7 @@ concurrency:
 jobs:
   admit:
     runs-on: ubuntu-latest
+    environment: publisher
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -66,6 +67,16 @@ jobs:
           -f issue_number="${{ steps.admission.outputs.issue_number }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create Tavernary Publisher dispatch token
+        id: publisher-dispatch-token
+        if: >-
+          steps.admission.outputs.admitted == 'true' &&
+          steps.admission.outputs.route == 'kit-withdrawal'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.TAVERNARY_PUBLISHER_APP_ID }}
+          private-key: ${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}
+          permission-actions: write
       - name: Dispatch Kit withdrawal
         if: >-
           steps.admission.outputs.admitted == 'true' &&
@@ -75,7 +86,7 @@ jobs:
           --ref main
           -f issue_number="${{ steps.admission.outputs.issue_number }}"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.publisher-dispatch-token.outputs.token }}
       - name: Dispatch project owner request triage
         if: >-
           steps.admission.outputs.admitted == 'true' &&

--- a/.github/workflows/apply-kit-submission.yml
+++ b/.github/workflows/apply-kit-submission.yml
@@ -24,7 +24,7 @@ jobs:
       github.ref == 'refs/heads/main' &&
       (github.event_name != 'workflow_dispatch' ||
       github.actor_id == 2625904 ||
-      github.actor_id == 41898282)
+      github.actor_id == vars.TAVERNARY_PUBLISHER_BOT_ID)
     runs-on: ubuntu-latest
     environment: publisher
     steps:

--- a/.github/workflows/apply-kit-submission.yml
+++ b/.github/workflows/apply-kit-submission.yml
@@ -10,7 +10,7 @@ on:
         type: number
 
 permissions:
-  contents: write
+  contents: read
   issues: write
   actions: write
 
@@ -20,13 +20,26 @@ concurrency:
 
 jobs:
   publish:
-    if: github.ref == 'refs/heads/main'
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (github.event_name != 'workflow_dispatch' ||
+      github.actor_id == 2625904 ||
+      github.actor_id == 41898282)
     runs-on: ubuntu-latest
+    environment: publisher
     steps:
+      - name: Create Tavernary Publisher token
+        id: publisher-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.TAVERNARY_PUBLISHER_APP_ID }}
+          private-key: ${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}
+          permission-contents: write
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          token: ${{ steps.publisher-token.outputs.token }}
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:

--- a/.github/workflows/apply-kit-withdrawal.yml
+++ b/.github/workflows/apply-kit-withdrawal.yml
@@ -10,7 +10,7 @@ on:
         type: number
 
 permissions:
-  contents: write
+  contents: read
   issues: write
   actions: write
 
@@ -20,13 +20,26 @@ concurrency:
 
 jobs:
   withdraw:
-    if: github.ref == 'refs/heads/main'
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (github.event_name != 'workflow_dispatch' ||
+      github.actor_id == 2625904 ||
+      github.actor_id == 41898282)
     runs-on: ubuntu-latest
+    environment: publisher
     steps:
+      - name: Create Tavernary Publisher token
+        id: publisher-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.TAVERNARY_PUBLISHER_APP_ID }}
+          private-key: ${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}
+          permission-contents: write
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          token: ${{ steps.publisher-token.outputs.token }}
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:

--- a/.github/workflows/apply-kit-withdrawal.yml
+++ b/.github/workflows/apply-kit-withdrawal.yml
@@ -24,7 +24,7 @@ jobs:
       github.ref == 'refs/heads/main' &&
       (github.event_name != 'workflow_dispatch' ||
       github.actor_id == 2625904 ||
-      github.actor_id == 41898282)
+      github.actor_id == vars.TAVERNARY_PUBLISHER_BOT_ID)
     runs-on: ubuntu-latest
     environment: publisher
     steps:

--- a/.github/workflows/backfill-repository-identities.yml
+++ b/.github/workflows/backfill-repository-identities.yml
@@ -10,7 +10,7 @@ on:
         required: false
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: catalog-refresh
@@ -18,13 +18,26 @@ concurrency:
 
 jobs:
   backfill:
-    if: github.ref == 'refs/heads/main'
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (github.event_name != 'workflow_dispatch' ||
+      github.actor_id == 2625904 ||
+      github.actor_id == 41898282)
     runs-on: ubuntu-latest
+    environment: publisher
     steps:
+      - name: Create Tavernary Publisher token
+        id: publisher-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.TAVERNARY_PUBLISHER_APP_ID }}
+          private-key: ${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}
+          permission-contents: write
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          token: ${{ steps.publisher-token.outputs.token }}
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:

--- a/.github/workflows/backfill-repository-identities.yml
+++ b/.github/workflows/backfill-repository-identities.yml
@@ -22,7 +22,7 @@ jobs:
       github.ref == 'refs/heads/main' &&
       (github.event_name != 'workflow_dispatch' ||
       github.actor_id == 2625904 ||
-      github.actor_id == 41898282)
+      github.actor_id == vars.TAVERNARY_PUBLISHER_BOT_ID)
     runs-on: ubuntu-latest
     environment: publisher
     steps:

--- a/.github/workflows/enrich-catalog.yml
+++ b/.github/workflows/enrich-catalog.yml
@@ -25,7 +25,7 @@ on:
         default: 120
 
 permissions:
-  contents: write
+  contents: read
   actions: write
   issues: write
 
@@ -35,14 +35,27 @@ concurrency:
 
 jobs:
   enrich:
-    if: github.ref == 'refs/heads/main'
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (github.event_name != 'workflow_dispatch' ||
+      github.actor_id == 2625904 ||
+      github.actor_id == 41898282)
     runs-on: ubuntu-latest
+    environment: publisher
     timeout-minutes: 300
     steps:
+      - name: Create Tavernary Publisher token
+        id: publisher-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.TAVERNARY_PUBLISHER_APP_ID }}
+          private-key: ${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}
+          permission-contents: write
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          token: ${{ steps.publisher-token.outputs.token }}
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:

--- a/.github/workflows/enrich-catalog.yml
+++ b/.github/workflows/enrich-catalog.yml
@@ -39,7 +39,7 @@ jobs:
       github.ref == 'refs/heads/main' &&
       (github.event_name != 'workflow_dispatch' ||
       github.actor_id == 2625904 ||
-      github.actor_id == 41898282)
+      github.actor_id == vars.TAVERNARY_PUBLISHER_BOT_ID)
     runs-on: ubuntu-latest
     environment: publisher
     timeout-minutes: 300

--- a/.github/workflows/import-tavernkeeper-reports.yml
+++ b/.github/workflows/import-tavernkeeper-reports.yml
@@ -30,7 +30,8 @@ jobs:
       github.ref == 'refs/heads/main' &&
       (github.event_name != 'workflow_dispatch' ||
       github.actor_id == 2625904 ||
-      github.actor_id == 41898282)
+      github.actor_id == vars.TAVERNARY_PUBLISHER_BOT_ID ||
+      github.actor_id == 311860138)
     runs-on: ubuntu-latest
     environment: publisher
     outputs:
@@ -209,11 +210,19 @@ jobs:
     needs: import
     if: ${{ always() && needs.import.result == 'success' && needs.import.outputs.remaining != '0' && inputs.retry_report_digest == '' }}
     runs-on: ubuntu-latest
+    environment: publisher
     permissions:
       actions: write
       contents: read
     steps:
+      - name: Create Tavernary Publisher dispatch token
+        id: publisher-dispatch-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.TAVERNARY_PUBLISHER_APP_ID }}
+          private-key: ${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}
+          permission-actions: write
       - name: Continue due report imports independently of deployment
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.publisher-dispatch-token.outputs.token }}
         run: gh workflow run import-tavernkeeper-reports.yml --repo "$GITHUB_REPOSITORY" --ref main

--- a/.github/workflows/import-tavernkeeper-reports.yml
+++ b/.github/workflows/import-tavernkeeper-reports.yml
@@ -17,7 +17,7 @@ on:
 
 permissions:
   actions: write
-  contents: write
+  contents: read
   issues: write
 
 concurrency:
@@ -26,8 +26,13 @@ concurrency:
 
 jobs:
   import:
-    if: github.event_name == 'schedule' || github.ref == 'refs/heads/main'
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (github.event_name != 'workflow_dispatch' ||
+      github.actor_id == 2625904 ||
+      github.actor_id == 41898282)
     runs-on: ubuntu-latest
+    environment: publisher
     outputs:
       changed: ${{ steps.commit.outputs.changed }}
       sha: ${{ steps.commit.outputs.sha }}
@@ -35,11 +40,19 @@ jobs:
       quarantined: ${{ steps.import.outputs.quarantined }}
       remaining: ${{ steps.import.outputs.remaining }}
     steps:
+      - name: Create Tavernary Publisher token
+        id: publisher-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.TAVERNARY_PUBLISHER_APP_ID }}
+          private-key: ${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}
+          permission-contents: write
       - name: Check out main
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           ref: main
+          token: ${{ steps.publisher-token.outputs.token }}
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:

--- a/.github/workflows/publish-openai-usage.yml
+++ b/.github/workflows/publish-openai-usage.yml
@@ -21,7 +21,7 @@ jobs:
       github.ref == 'refs/heads/main' &&
       (github.event_name != 'workflow_dispatch' ||
       github.actor_id == 2625904 ||
-      github.actor_id == 41898282)
+      github.actor_id == vars.TAVERNARY_PUBLISHER_BOT_ID)
     runs-on: ubuntu-latest
     environment: publisher
     steps:

--- a/.github/workflows/publish-openai-usage.yml
+++ b/.github/workflows/publish-openai-usage.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
   actions: write
 
 concurrency:
@@ -17,14 +17,27 @@ concurrency:
 
 jobs:
   publish:
-    if: github.event_name == 'schedule' || github.ref == 'refs/heads/main'
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (github.event_name != 'workflow_dispatch' ||
+      github.actor_id == 2625904 ||
+      github.actor_id == 41898282)
     runs-on: ubuntu-latest
+    environment: publisher
     steps:
+      - name: Create Tavernary Publisher token
+        id: publisher-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.TAVERNARY_PUBLISHER_APP_ID }}
+          private-key: ${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}
+          permission-contents: write
       - name: Check out main
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           ref: main
+          token: ${{ steps.publisher-token.outputs.token }}
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:

--- a/.github/workflows/publish-project-transaction.yml
+++ b/.github/workflows/publish-project-transaction.yml
@@ -22,6 +22,7 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: publisher
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       AUTO_PUBLICATION_ENABLED: ${{ vars.PROJECT_AUTO_PUBLICATION_ENABLED }}
@@ -491,10 +492,20 @@ jobs:
         if: steps.notices.outcome == 'failure'
         run: |
           echo "Post-merge project notices failed and require an idempotent retry." >> "$GITHUB_STEP_SUMMARY"
+      - name: Create Tavernary Publisher dispatch token
+        id: publisher-dispatch-token
+        if: steps.merge.outputs.merge_sha != ''
+        continue-on-error: true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.TAVERNARY_PUBLISHER_APP_ID }}
+          private-key: ${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}
+          permission-actions: write
       - name: Dispatch non-blocking Catalog Policy advisory
         if: steps.merge.outputs.merge_sha != ''
         continue-on-error: true
         env:
+          GH_TOKEN: ${{ steps.publisher-dispatch-token.outputs.token }}
           PROJECT_ID: ${{ steps.state.outputs.project_id }}
           ISSUE_NUMBER: ${{ steps.state.outputs.issue_number }}
           PULL_NUMBER: ${{ steps.state.outputs.pull_number }}

--- a/.github/workflows/refresh-catalog.yml
+++ b/.github/workflows/refresh-catalog.yml
@@ -33,7 +33,7 @@ on:
         required: false
 
 permissions:
-  contents: write
+  contents: read
   actions: write
   issues: read
 
@@ -43,13 +43,26 @@ concurrency:
 
 jobs:
   refresh:
-    if: github.event_name == 'schedule' || github.ref == 'refs/heads/main'
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (github.event_name != 'workflow_dispatch' ||
+      github.actor_id == 2625904 ||
+      github.actor_id == 41898282)
     runs-on: ubuntu-latest
+    environment: publisher
     steps:
+      - name: Create Tavernary Publisher token
+        id: publisher-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.TAVERNARY_PUBLISHER_APP_ID }}
+          private-key: ${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}
+          permission-contents: write
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          token: ${{ steps.publisher-token.outputs.token }}
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:

--- a/.github/workflows/refresh-catalog.yml
+++ b/.github/workflows/refresh-catalog.yml
@@ -47,7 +47,7 @@ jobs:
       github.ref == 'refs/heads/main' &&
       (github.event_name != 'workflow_dispatch' ||
       github.actor_id == 2625904 ||
-      github.actor_id == 41898282)
+      github.actor_id == vars.TAVERNARY_PUBLISHER_BOT_ID)
     runs-on: ubuntu-latest
     environment: publisher
     steps:
@@ -57,6 +57,7 @@ jobs:
         with:
           app-id: ${{ vars.TAVERNARY_PUBLISHER_APP_ID }}
           private-key: ${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}
+          permission-actions: write
           permission-contents: write
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -143,7 +144,7 @@ jobs:
       - name: Dispatch advisory review for refreshed evidence
         if: steps.commit.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.publisher-token.outputs.token }}
           MERGE_SHA: ${{ steps.commit.outputs.head_sha }}
         shell: bash
         run: |

--- a/.github/workflows/review-catalog-policy.yml
+++ b/.github/workflows/review-catalog-policy.yml
@@ -24,7 +24,7 @@ on:
     - cron: "43 5 * * *"
 
 permissions:
-  contents: write
+  contents: read
   issues: write
   pull-requests: read
   actions: write
@@ -67,8 +67,13 @@ jobs:
           done < "${RUNNER_TEMP}/policy-review-retries.tsv"
 
   review:
-    if: github.event_name == 'workflow_dispatch'
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main' &&
+      (github.actor_id == 2625904 ||
+      github.actor_id == 41898282)
     runs-on: ubuntu-latest
+    environment: publisher
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PROJECT_ID: ${{ inputs.project_id }}
@@ -76,11 +81,19 @@ jobs:
       PULL_NUMBER: ${{ inputs.transaction_pull_number }}
       MERGE_SHA: ${{ inputs.merge_sha }}
     steps:
+      - name: Create Tavernary Publisher token
+        id: publisher-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.TAVERNARY_PUBLISHER_APP_ID }}
+          private-key: ${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}
+          permission-contents: write
       - name: Check out exact published state
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ inputs.merge_sha }}
           fetch-depth: 0
+          token: ${{ steps.publisher-token.outputs.token }}
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:

--- a/.github/workflows/review-catalog-policy.yml
+++ b/.github/workflows/review-catalog-policy.yml
@@ -37,11 +37,20 @@ jobs:
   retry:
     if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    environment: publisher
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Create Tavernary Publisher dispatch token
+        id: publisher-dispatch-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.TAVERNARY_PUBLISHER_APP_ID }}
+          private-key: ${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}
+          permission-actions: write
+          permission-contents: read
       - name: Dispatch unavailable advisory states
+        env:
+          GH_TOKEN: ${{ steps.publisher-dispatch-token.outputs.token }}
         shell: bash
         run: |
           set -euo pipefail
@@ -71,7 +80,7 @@ jobs:
       github.event_name == 'workflow_dispatch' &&
       github.ref == 'refs/heads/main' &&
       (github.actor_id == 2625904 ||
-      github.actor_id == 41898282)
+      github.actor_id == vars.TAVERNARY_PUBLISHER_BOT_ID)
     runs-on: ubuntu-latest
     environment: publisher
     env:
@@ -81,6 +90,28 @@ jobs:
       PULL_NUMBER: ${{ inputs.transaction_pull_number }}
       MERGE_SHA: ${{ inputs.merge_sha }}
     steps:
+      - name: Verify exact published state
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! "$MERGE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "merge_sha must be an exact lowercase commit SHA." >&2
+            exit 1
+          fi
+
+          if (( PULL_NUMBER > 0 )); then
+            expected_merge_sha="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/$PULL_NUMBER" --jq '.merge_commit_sha // empty')"
+            if [[ "$MERGE_SHA" != "$expected_merge_sha" ]]; then
+              echo "merge_sha does not match pull request #$PULL_NUMBER." >&2
+              exit 1
+            fi
+          fi
+
+          relation="$(gh api "repos/${GITHUB_REPOSITORY}/compare/${MERGE_SHA}...main" --jq '.status')"
+          if [[ "$relation" != "ahead" && "$relation" != "identical" ]]; then
+            echo "merge_sha is not an ancestor of current main." >&2
+            exit 1
+          fi
       - name: Create Tavernary Publisher token
         id: publisher-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0

--- a/.github/workflows/targeted-tavernkeeper-scan.yml
+++ b/.github/workflows/targeted-tavernkeeper-scan.yml
@@ -22,6 +22,7 @@ jobs:
   request:
     if: ${{ github.run_attempt == 1 }}
     runs-on: ubuntu-latest
+    environment: publisher
     steps:
       - name: Check out trusted Tavernary main
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -47,10 +48,17 @@ jobs:
           request="$(node scripts/security/resolve-tavernkeeper-scan-request.mjs)"
           echo "source_id=$(jq -r '.sourceId' <<< "$request")" >> "$GITHUB_OUTPUT"
           echo "repository_id=$(jq -r '.repositoryId' <<< "$request")" >> "$GITHUB_OUTPUT"
+      - name: Create Tavernary Publisher dispatch token
+        id: publisher-dispatch-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.TAVERNARY_PUBLISHER_APP_ID }}
+          private-key: ${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}
+          permission-actions: write
       - name: Dispatch project refresh
         id: refresh
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.publisher-dispatch-token.outputs.token }}
           SOURCE_ID: ${{ steps.resolve.outputs.source_id }}
         shell: bash
         run: |

--- a/.github/workflows/triage-kit-submission.yml
+++ b/.github/workflows/triage-kit-submission.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    environment: publisher
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -34,10 +35,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ inputs.issue_number }}
+      - name: Create Tavernary Publisher dispatch token
+        id: publisher-dispatch-token
+        if: steps.triage.outputs.publish == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.TAVERNARY_PUBLISHER_APP_ID }}
+          private-key: ${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}
+          permission-actions: write
       - name: Publish valid Kit
         if: steps.triage.outputs.publish == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.publisher-dispatch-token.outputs.token }}
           ISSUE_NUMBER: ${{ steps.triage.outputs.issue_number }}
         run: >
           gh workflow run apply-kit-submission.yml

--- a/docs/superpowers/plans/2026-08-16-github-contributor-security-policy.md
+++ b/docs/superpowers/plans/2026-08-16-github-contributor-security-policy.md
@@ -1,0 +1,86 @@
+# GitHub Contributor Security Policy Implementation Plan
+
+> **Execution skill:** Use `superpowers:executing-plans`; verify each security
+> boundary before progressing to the next live mutation.
+
+**Goal:** Protect `main` in Tavernary and TavernKeeper while preserving writable
+same-repository contributor branches, mandatory owner review, repository checks,
+publication automation, and Codex access through `MentallyQuill`.
+
+**Architecture:** Ordinary GitHub Actions remains unable to bypass `main`.
+Tavernary's eight content publishers use a repository-only GitHub App through a
+main-only protected environment. CODEOWNERS lands before code-owner enforcement;
+then each existing default-branch ruleset is replaced atomically and verified
+from fresh API responses.
+
+## Constraints
+
+- Target rules only at `~DEFAULT_BRANCH`.
+- Give `MentallyQuill` user ID `2625904` only `pull_request` bypass.
+- Preserve TavernKeeper Publisher Integration ID `4457566` with `always` bypass.
+- Give Tavernary's new Publisher integration the only Tavernary `always` bypass.
+- Bind checks to GitHub Actions Integration ID `15368`.
+- Use `verify` and `visual` for Tavernary; `check` and `scanner-toolchain` for
+  TavernKeeper.
+- Keep default workflow permissions Read; never give GitHub Actions a ruleset
+  bypass.
+- Use GitHub CLI with network permission enabled for every remote operation.
+- Never print, commit, or retain the Publisher private key after secret upload.
+
+## Task 1: Enforce the Publisher Boundary in Source
+
+- [ ] Add a failing test enumerating all direct and indirect `main` publishers.
+- [ ] Require each publisher job to use environment `publisher`.
+- [ ] Change workflow-level contents permission from Write to Read.
+- [ ] Add a full-SHA-pinned `actions/create-github-app-token` step with
+  `TAVERNARY_PUBLISHER_APP_ID` and `TAVERNARY_PUBLISHER_APP_PRIVATE_KEY`.
+- [ ] Use the App token for checkout and publication while retaining ordinary
+  tokens only for Issues and Actions APIs.
+- [ ] Gate manual privileged dispatches to user ID `2625904` or the trusted
+  repository automation actor ID `41898282`.
+- [ ] Add `.github/CODEOWNERS` with `* @MentallyQuill`.
+- [ ] Run focused workflow tests, content checks, full checks, and `git diff
+  --check`; commit only after all pass.
+
+## Task 2: Provision the Tavernary Publisher
+
+- [ ] Register the private account-owned `Tavernary Publisher` App with Contents
+  Read/Write, Metadata Read, no webhooks, and no other permissions.
+- [ ] Install it only on `MentallyQuill/Tavernary` and capture its Integration ID.
+- [ ] Create environment `publisher` with a custom deployment branch policy for
+  exactly `main`.
+- [ ] Store App ID as `TAVERNARY_PUBLISHER_APP_ID` and private key as
+  `TAVERNARY_PUBLISHER_APP_PRIVATE_KEY` in that environment.
+- [ ] Verify the installation, environment policy, variable, and secret metadata;
+  securely remove the local private-key file.
+
+## Task 3: Merge Repository-Owned Policy
+
+- [ ] Push `codex/github-contributor-security-policy`, open the Tavernary PR, and
+  wait for `verify` and `visual`.
+- [ ] Merge Tavernary and verify the exact workflow and CODEOWNERS commit on
+  `main`.
+- [ ] Create TavernKeeper's matching CODEOWNERS branch from fresh `main` through
+  the GitHub API, open the PR, wait for `check` and `scanner-toolchain`, and merge.
+
+## Task 4: Apply Live Repository Rules
+
+- [ ] Capture complete pre-change ruleset payloads for rollback.
+- [ ] Update Tavernary ruleset `19711101` with one approval, code-owner review,
+  stale dismissal, last-push approval, conversation resolution, strict `verify`
+  and `visual`, owner PR-only bypass, and Publisher always bypass.
+- [ ] Update TavernKeeper ruleset `20197146` equivalently with strict `check` and
+  `scanner-toolchain`, preserving Publisher ID `4457566`.
+- [ ] Restrict both repositories to GitHub-owned Actions, Read default tokens, no
+  workflow PR approvals, all-external fork approval, and merged-branch deletion.
+
+## Task 5: Prove the Complete Policy
+
+- [ ] Re-read rulesets, protected branches, Actions permissions, collaborator
+  access, CODEOWNERS, security analysis, environment policy, App installation,
+  and check provenance.
+- [ ] Confirm only `main` is protected and feature branches remain creatable.
+- [ ] Run a bounded no-change Publisher workflow and verify App authentication,
+  protected-environment access, and ruleset compatibility.
+- [ ] Record final PR URLs, merge commits, workflow run, ruleset IDs, and clean
+  local branch state.

--- a/docs/superpowers/plans/2026-08-16-github-contributor-security-policy.md
+++ b/docs/superpowers/plans/2026-08-16-github-contributor-security-policy.md
@@ -37,7 +37,13 @@ from fresh API responses.
 - [ ] Use the App token for checkout and publication while retaining ordinary
   tokens only for Issues and Actions APIs.
 - [ ] Gate manual privileged dispatches to user ID `2625904` or the trusted
-  repository automation actor ID `41898282`.
+  Tavernary Publisher actor; permit the scoped TavernKeeper wake App only for
+  report imports.
+- [ ] Convert every protected internal workflow dispatch to an Actions-scoped
+  Publisher App token from the main-only environment; never trust the shared
+  `github-actions[bot]` actor.
+- [ ] Verify advisory checkout SHAs are exact PR merge commits when applicable
+  and are always reachable from `main` before minting a privileged token.
 - [ ] Add `.github/CODEOWNERS` with `* @MentallyQuill`.
 - [ ] Run focused workflow tests, content checks, full checks, and `git diff
   --check`; commit only after all pass.
@@ -45,12 +51,15 @@ from fresh API responses.
 ## Task 2: Provision the Tavernary Publisher
 
 - [ ] Register the private account-owned `Tavernary Publisher` App with Contents
-  Read/Write, Metadata Read, no webhooks, and no other permissions.
+  Read/Write, Actions Read/Write, Metadata Read, no webhooks, and no other
+  permissions.
 - [ ] Install it only on `MentallyQuill/Tavernary` and capture its Integration ID.
 - [ ] Create environment `publisher` with a custom deployment branch policy for
   exactly `main`.
 - [ ] Store App ID as `TAVERNARY_PUBLISHER_APP_ID` and private key as
   `TAVERNARY_PUBLISHER_APP_PRIVATE_KEY` in that environment.
+- [ ] Store the App bot user ID as repository variable
+  `TAVERNARY_PUBLISHER_BOT_ID` for target-workflow actor checks.
 - [ ] Verify the installation, environment policy, variable, and secret metadata;
   securely remove the local private-key file.
 

--- a/docs/superpowers/specs/2026-08-16-github-contributor-security-policy-design.md
+++ b/docs/superpowers/specs/2026-08-16-github-contributor-security-policy-design.md
@@ -5,11 +5,11 @@
 
 ## Goal
 
-Give trusted contributors a safe lane to create and push feature branches while
+Give trusted Write contributors a same-repository feature-branch lane while
 requiring every change to `main` to pass repository checks and receive approval
 from `MentallyQuill`. Preserve Codex administration through the GitHub CLI
-identity `MentallyQuill` without permitting direct pushes, force-pushes, or
-deletion of `main`.
+identity `MentallyQuill`, and preserve narrowly scoped publication automation
+without granting ordinary GitHub Actions a protected-branch bypass.
 
 ## Authority Model
 
@@ -17,15 +17,59 @@ deletion of `main`.
   reviews, merges, and incident recovery.
 - Trusted contributors receive Write access. They may create and update feature
   branches and open pull requests, but may not update `main` directly.
-- `MentallyQuill` receives a ruleset bypass with mode `pull_request`. This
-  permits owner-authored pull requests to merge without an unavailable second
-  reviewer while retaining a pull request and audit trail.
+- `MentallyQuill` receives a ruleset bypass with mode `pull_request`. Owner work
+  still uses a pull request and audit trail, but does not require an unavailable
+  second reviewer.
 - Codex uses the authenticated GitHub CLI identity `MentallyQuill` and retains
-  the complete branch, pull request, review, merge, and repository-settings
-  workflow through that identity.
-- No contributor, workflow, or app receives a new broad bypass.
-- TavernKeeper's existing Publisher integration bypass remains unchanged so
-  its validated report-publication path continues to function.
+  branch, pull request, review, merge, and repository-settings access through
+  that identity.
+- The shared GitHub Actions integration does not receive a bypass. A contributor
+  must not be able to turn a branch workflow into a protected-branch writer.
+- TavernKeeper's existing Publisher integration bypass remains unchanged.
+- Tavernary receives a separate private Publisher GitHub App installed only on
+  `MentallyQuill/Tavernary`. Only that App receives an `always` bypass.
+
+## Tavernary Publisher App
+
+The Publisher is an unlisted, account-owned GitHub App with no server, callback,
+or webhook. It is installed only on Tavernary and has these repository
+permissions:
+
+- Contents: Read and write;
+- Metadata: Read-only, as required by GitHub;
+- no Actions, Issues, Pull requests, Administration, Workflows, or organization
+  permissions.
+
+The App's private key is stored only as the protected `publisher` environment
+secret `TAVERNARY_PUBLISHER_APP_PRIVATE_KEY`; its App ID is the environment
+variable `TAVERNARY_PUBLISHER_APP_ID`. The environment permits deployments only
+from the `main` branch.
+
+Each job that can push `HEAD:main` must:
+
+- reference the `publisher` environment;
+- keep ordinary `GITHUB_TOKEN` contents permission at Read;
+- generate a short-lived installation token with the full-SHA-pinned
+  `actions/create-github-app-token` action;
+- use that token for checkout and Git publication;
+- retain ordinary `GITHUB_TOKEN` permissions only for non-content operations
+  such as Issues or Actions dispatches;
+- reject a manual dispatch unless the actor is `MentallyQuill` or a trusted
+  repository workflow acting as `github-actions[bot]`.
+
+This boundary covers direct writers and the durable enrichment orchestrator:
+
+- `apply-kit-submission.yml`;
+- `apply-kit-withdrawal.yml`;
+- `backfill-repository-identities.yml`;
+- `enrich-catalog.yml`;
+- `import-tavernkeeper-reports.yml`;
+- `publish-openai-usage.yml`;
+- `refresh-catalog.yml`;
+- `review-catalog-policy.yml`.
+
+Repository tests enumerate this set so a future ordinary-token `main` writer
+fails CI.
 
 ## Repository-Owned Review
 
@@ -35,10 +79,8 @@ Add `.github/CODEOWNERS` to each repository with:
 * @MentallyQuill
 ```
 
-The default-branch ruleset will require code-owner review. This makes approval
-by `MentallyQuill` mandatory for contributor pull requests even if more Write
-collaborators are added later. The wildcard also protects changes to
-`.github/CODEOWNERS` and workflow files.
+The default-branch ruleset requires code-owner review. The wildcard protects
+all paths, including CODEOWNERS and workflow files.
 
 ## Default-Branch Rulesets
 
@@ -47,109 +89,76 @@ unprotected and writable by trusted contributors.
 
 Both rulesets enforce:
 
-- deletion protection;
-- non-fast-forward and force-push protection;
+- deletion and non-fast-forward protection;
 - a pull request before merge;
-- one approving review;
-- code-owner review;
-- dismissal of stale approvals after reviewable commits are pushed;
+- one approving code-owner review;
+- stale-review dismissal after reviewable commits;
 - approval of the most recent reviewable push by someone other than its author;
 - resolution of all review conversations;
 - strict required status checks against the latest `main`;
 - `MentallyQuill` user ID `2625904` as a `pull_request`-only bypass actor.
 
-Tavernary requires these GitHub Actions checks:
+Tavernary requires `verify` and `visual`, keeps merge, squash, and rebase, and
+adds the Tavernary Publisher integration as its sole `always` bypass. A skipped
+`visual` job remains an accepted successful conclusion for content-only work.
 
-- `verify`
-- `visual`
+TavernKeeper requires `check` and `scanner-toolchain`, remains merge-only, and
+preserves Publisher Integration ID `4457566` with `always` bypass.
 
-The `visual` job is present and successful for full changes and present with a
-successful skipped conclusion for content-only changes. Preserve Tavernary's
-currently enabled merge methods: merge, squash, and rebase.
+All required checks are bound to GitHub Actions Integration ID `15368`.
 
-TavernKeeper requires these GitHub Actions checks:
-
-- `check`
-- `scanner-toolchain`
-
-Preserve TavernKeeper's merge-only ruleset and the existing Integration actor
-ID `4457566` with `always` bypass mode for the TavernKeeper Publisher.
-
-## GitHub Actions Policy
+## Repository Actions Policy
 
 Apply these repository-level settings to both repositories:
 
-- keep Actions enabled;
-- allow GitHub-owned actions only;
+- keep Actions enabled and allow GitHub-owned actions only;
 - keep default `GITHUB_TOKEN` workflow permissions at Read;
 - prevent workflows from creating or approving pull request reviews;
 - require workflow approval for all external fork contributors;
 - automatically delete head branches after pull requests merge.
 
-The live workflow audit found no `pull_request_target` triggers. Pull-request
-validation uses read-only repository contents. Every external action reference
-is under `actions/*` and pinned to a full commit SHA, so restricting Actions to
-GitHub-owned actions preserves the current workflows. Tavernary does not use
-its currently enabled workflow review-approval permission.
-
-Fork workflow approval applies to external fork contributors. A trusted Write
-collaborator working on a same-repository feature branch may run the read-only
-pull-request checks normally.
+The workflow audit found no `pull_request_target` triggers. Pull-request
+validation uses read-only contents, and all external action references are
+SHA-pinned `actions/*` dependencies. A trusted Write collaborator's same-repo
+pull-request checks therefore run normally, while untrusted fork workflows
+require approval.
 
 ## Existing Security Controls
 
-Retain and verify the controls already enabled on both repositories:
+Retain and verify public visibility, fork support, secret scanning,
+secret-scanning push protection, Read default workflow permissions, and
+immutable action pins. Dependabot security updates, signed-commit requirements,
+release/tag rules, and feature-branch naming restrictions are outside this
+change.
 
-- public visibility and fork support;
-- secret scanning;
-- secret-scanning push protection;
-- repository default workflow permissions set to Read;
-- actions pinned to immutable commit SHAs.
+## Rollout and Verification
 
-Dependabot security updates, additional secret-pattern scanning, signed-commit
-requirements, release/tag rules, and restrictions on feature-branch creation
-are outside this change. They are not required to establish the approved
-contributor lane and could add unrelated maintenance or compatibility costs.
+1. Add a failing workflow-policy test, migrate all eight Tavernary publishers,
+   and prove the focused and full repository gates pass.
+2. Register and install the private App, create its protected environment, and
+   store the App ID and private key without exposing the key.
+3. Merge Tavernary's workflow and CODEOWNERS change, then merge TavernKeeper's
+   CODEOWNERS change.
+4. Update both default-branch rulesets in place, preserving existing integration
+   bypasses and adding only the approved owner and Publisher actors.
+5. Harden Actions and branch-cleanup settings, then re-read every setting from
+   GitHub.
+6. Confirm only `main` is protected, required check provenance is exact, the App
+   is installed only on Tavernary, and no feature-branch creation restriction
+   exists.
+7. Dispatch a bounded Publisher operation that is safe when no content changes
+   are pending, and verify the privileged job obtains its environment and runs
+   without a ruleset or credential failure.
 
-## Rollout
-
-1. Create the CODEOWNERS change on a feature branch in each repository and
-   merge it before requiring code-owner review.
-2. Update each existing default-branch ruleset in one request, preserving its
-   existing target and integration bypasses while adding the approved review,
-   check, and owner-bypass settings.
-3. Harden repository Actions permissions and enable automatic merged-branch
-   cleanup.
-4. Re-read every setting through the GitHub API.
-5. Confirm the required check contexts exist on recent pull-request heads and
-   confirm both default branches report protected.
-
-## Verification
-
-The completed policy must prove all of the following from live GitHub state:
-
-- both rulesets are active and target only the default branch;
-- contributor updates to `main` require a pull request, current owner approval,
-  resolved conversations, and all repository-specific checks;
-- `MentallyQuill` has only pull-request-mode bypass authority;
-- the TavernKeeper Publisher retains its existing integration bypass;
-- feature branches are not covered by a creation restriction;
-- Actions are limited to GitHub-owned actions with Read default permissions;
-- workflow PR review approval is disabled;
-- every external fork contributor requires workflow approval;
-- secret scanning and push protection remain enabled;
-- the current workflow action references remain compatible with the restricted
-  Actions policy.
-
-If a required check is absent from new pull requests or a Publisher operation
-is blocked, restore the immediately preceding ruleset payload, then diagnose
-the exact check or app identity before attempting another update.
+If a required check is absent or publication is blocked, restore the captured
+pre-change ruleset payload and diagnose the exact check or App identity before
+another update.
 
 ## Non-Goals
 
 - Contributors are not forced to work from forks.
 - Feature branches are not globally protected or name-restricted.
 - `MentallyQuill` does not receive an `always` bypass.
-- Codex does not receive a separate account, token, or app exemption.
-- This policy does not alter application code, publication semantics, workflow
-  triggers, secrets, or repository visibility.
+- Codex does not receive a separate identity or credential.
+- The Publisher App does not merge pull requests, edit workflows, administer
+  repositories, or access TavernKeeper.

--- a/docs/superpowers/specs/2026-08-16-github-contributor-security-policy-design.md
+++ b/docs/superpowers/specs/2026-08-16-github-contributor-security-policy-design.md
@@ -36,8 +36,9 @@ or webhook. It is installed only on Tavernary and has these repository
 permissions:
 
 - Contents: Read and write;
+- Actions: Read and write, used only to dispatch protected publisher workflows;
 - Metadata: Read-only, as required by GitHub;
-- no Actions, Issues, Pull requests, Administration, Workflows, or organization
+- no Issues, Pull requests, Administration, Workflows, or organization
   permissions.
 
 The App's private key is stored only as the protected `publisher` environment
@@ -54,8 +55,16 @@ Each job that can push `HEAD:main` must:
 - use that token for checkout and Git publication;
 - retain ordinary `GITHUB_TOKEN` permissions only for non-content operations
   such as Issues or Actions dispatches;
-- reject a manual dispatch unless the actor is `MentallyQuill` or a trusted
-  repository workflow acting as `github-actions[bot]`.
+- reject a manual dispatch unless the actor is `MentallyQuill`, the unique
+  Tavernary Publisher App, or, for report import only, the existing scoped
+  TavernKeeper wake App.
+
+Trusted main-branch workflows that dispatch a protected publisher also reference
+the `publisher` environment and mint an Actions-only App token for that dispatch.
+The target therefore sees the unique Publisher App actor, never the shared
+`github-actions[bot]` identity that contributor branch workflows can also use.
+The environment branch policy prevents a feature-branch workflow from obtaining
+the App credential.
 
 This boundary covers direct writers and the durable enrichment orchestrator:
 
@@ -69,7 +78,15 @@ This boundary covers direct writers and the durable enrichment orchestrator:
 - `review-catalog-policy.yml`.
 
 Repository tests enumerate this set so a future ordinary-token `main` writer
-fails CI.
+fails CI. They also enumerate every internal dispatch to these workflows,
+require exact App-action pins, scan both YAML extensions and multiple direct
+`main` write forms, and reject job-level contents-write overrides.
+
+`review-catalog-policy.yml` validates its requested SHA before minting an App
+token or checking out code. A transaction PR must supply its exact GitHub merge
+commit, and every supplied SHA must be identical to or an ancestor of current
+`main`. This prevents caller-controlled branch code from running with Publisher
+credentials.
 
 ## Repository-Owned Review
 

--- a/docs/superpowers/specs/2026-08-16-github-contributor-security-policy-design.md
+++ b/docs/superpowers/specs/2026-08-16-github-contributor-security-policy-design.md
@@ -1,0 +1,155 @@
+# GitHub Contributor Security Policy Design
+
+**Date:** 2026-08-16
+**Repositories:** `MentallyQuill/Tavernary`, `MentallyQuill/TavernKeeper`
+
+## Goal
+
+Give trusted contributors a safe lane to create and push feature branches while
+requiring every change to `main` to pass repository checks and receive approval
+from `MentallyQuill`. Preserve Codex administration through the GitHub CLI
+identity `MentallyQuill` without permitting direct pushes, force-pushes, or
+deletion of `main`.
+
+## Authority Model
+
+- `MentallyQuill` remains repository Admin for settings, access management,
+  reviews, merges, and incident recovery.
+- Trusted contributors receive Write access. They may create and update feature
+  branches and open pull requests, but may not update `main` directly.
+- `MentallyQuill` receives a ruleset bypass with mode `pull_request`. This
+  permits owner-authored pull requests to merge without an unavailable second
+  reviewer while retaining a pull request and audit trail.
+- Codex uses the authenticated GitHub CLI identity `MentallyQuill` and retains
+  the complete branch, pull request, review, merge, and repository-settings
+  workflow through that identity.
+- No contributor, workflow, or app receives a new broad bypass.
+- TavernKeeper's existing Publisher integration bypass remains unchanged so
+  its validated report-publication path continues to function.
+
+## Repository-Owned Review
+
+Add `.github/CODEOWNERS` to each repository with:
+
+```text
+* @MentallyQuill
+```
+
+The default-branch ruleset will require code-owner review. This makes approval
+by `MentallyQuill` mandatory for contributor pull requests even if more Write
+collaborators are added later. The wildcard also protects changes to
+`.github/CODEOWNERS` and workflow files.
+
+## Default-Branch Rulesets
+
+Both active rulesets target only `~DEFAULT_BRANCH`. Feature branches remain
+unprotected and writable by trusted contributors.
+
+Both rulesets enforce:
+
+- deletion protection;
+- non-fast-forward and force-push protection;
+- a pull request before merge;
+- one approving review;
+- code-owner review;
+- dismissal of stale approvals after reviewable commits are pushed;
+- approval of the most recent reviewable push by someone other than its author;
+- resolution of all review conversations;
+- strict required status checks against the latest `main`;
+- `MentallyQuill` user ID `2625904` as a `pull_request`-only bypass actor.
+
+Tavernary requires these GitHub Actions checks:
+
+- `verify`
+- `visual`
+
+The `visual` job is present and successful for full changes and present with a
+successful skipped conclusion for content-only changes. Preserve Tavernary's
+currently enabled merge methods: merge, squash, and rebase.
+
+TavernKeeper requires these GitHub Actions checks:
+
+- `check`
+- `scanner-toolchain`
+
+Preserve TavernKeeper's merge-only ruleset and the existing Integration actor
+ID `4457566` with `always` bypass mode for the TavernKeeper Publisher.
+
+## GitHub Actions Policy
+
+Apply these repository-level settings to both repositories:
+
+- keep Actions enabled;
+- allow GitHub-owned actions only;
+- keep default `GITHUB_TOKEN` workflow permissions at Read;
+- prevent workflows from creating or approving pull request reviews;
+- require workflow approval for all external fork contributors;
+- automatically delete head branches after pull requests merge.
+
+The live workflow audit found no `pull_request_target` triggers. Pull-request
+validation uses read-only repository contents. Every external action reference
+is under `actions/*` and pinned to a full commit SHA, so restricting Actions to
+GitHub-owned actions preserves the current workflows. Tavernary does not use
+its currently enabled workflow review-approval permission.
+
+Fork workflow approval applies to external fork contributors. A trusted Write
+collaborator working on a same-repository feature branch may run the read-only
+pull-request checks normally.
+
+## Existing Security Controls
+
+Retain and verify the controls already enabled on both repositories:
+
+- public visibility and fork support;
+- secret scanning;
+- secret-scanning push protection;
+- repository default workflow permissions set to Read;
+- actions pinned to immutable commit SHAs.
+
+Dependabot security updates, additional secret-pattern scanning, signed-commit
+requirements, release/tag rules, and restrictions on feature-branch creation
+are outside this change. They are not required to establish the approved
+contributor lane and could add unrelated maintenance or compatibility costs.
+
+## Rollout
+
+1. Create the CODEOWNERS change on a feature branch in each repository and
+   merge it before requiring code-owner review.
+2. Update each existing default-branch ruleset in one request, preserving its
+   existing target and integration bypasses while adding the approved review,
+   check, and owner-bypass settings.
+3. Harden repository Actions permissions and enable automatic merged-branch
+   cleanup.
+4. Re-read every setting through the GitHub API.
+5. Confirm the required check contexts exist on recent pull-request heads and
+   confirm both default branches report protected.
+
+## Verification
+
+The completed policy must prove all of the following from live GitHub state:
+
+- both rulesets are active and target only the default branch;
+- contributor updates to `main` require a pull request, current owner approval,
+  resolved conversations, and all repository-specific checks;
+- `MentallyQuill` has only pull-request-mode bypass authority;
+- the TavernKeeper Publisher retains its existing integration bypass;
+- feature branches are not covered by a creation restriction;
+- Actions are limited to GitHub-owned actions with Read default permissions;
+- workflow PR review approval is disabled;
+- every external fork contributor requires workflow approval;
+- secret scanning and push protection remain enabled;
+- the current workflow action references remain compatible with the restricted
+  Actions policy.
+
+If a required check is absent from new pull requests or a Publisher operation
+is blocked, restore the immediately preceding ruleset payload, then diagnose
+the exact check or app identity before attempting another update.
+
+## Non-Goals
+
+- Contributors are not forced to work from forks.
+- Feature branches are not globally protected or name-restricted.
+- `MentallyQuill` does not receive an `always` bypass.
+- Codex does not receive a separate account, token, or app exemption.
+- This policy does not alter application code, publication semantics, workflow
+  triggers, secrets, or repository visibility.

--- a/tests/unit/refresh-github-workflow-safety.test.ts
+++ b/tests/unit/refresh-github-workflow-safety.test.ts
@@ -44,9 +44,9 @@ test("validates before commit and deploys only after a committed change", async 
 test("rebases with bounded retries and never force-pushes", async () => {
   const source = await readFile(refreshPath, "utf8");
 
-  expect(source).toContain(
-    "if: github.event_name == 'schedule' || github.ref == 'refs/heads/main'",
-  );
+  expect(source).toContain("github.ref == 'refs/heads/main'");
+  expect(source).toContain("github.actor_id == 2625904");
+  expect(source).toContain("github.actor_id == 41898282");
   expect(source).toContain("fetch-depth: 0");
   expect(source).toContain("for attempt in 1 2 3");
   expect(source).toContain("git fetch origin main");

--- a/tests/unit/refresh-github-workflow-safety.test.ts
+++ b/tests/unit/refresh-github-workflow-safety.test.ts
@@ -46,7 +46,10 @@ test("rebases with bounded retries and never force-pushes", async () => {
 
   expect(source).toContain("github.ref == 'refs/heads/main'");
   expect(source).toContain("github.actor_id == 2625904");
-  expect(source).toContain("github.actor_id == 41898282");
+  expect(source).toContain(
+    "github.actor_id == vars.TAVERNARY_PUBLISHER_BOT_ID",
+  );
+  expect(source).not.toContain("github.actor_id == 41898282");
   expect(source).toContain("fetch-depth: 0");
   expect(source).toContain("for attempt in 1 2 3");
   expect(source).toContain("git fetch origin main");

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -37,6 +37,9 @@ const protectedPublisherJobs = {
   "review-catalog-policy": "review",
 } as const;
 
+const publisherActorExpression =
+  "github.actor_id == vars.TAVERNARY_PUBLISHER_BOT_ID";
+
 function exposesModelProviderEnvironment(step: {
   env?: Record<string, string>;
 }) {
@@ -155,6 +158,8 @@ test("pins every first-party action to its resolved commit", async () => {
     "apply-kit-submission",
     "apply-kit-withdrawal",
     "targeted-tavernkeeper-scan",
+    "publish-openai-usage",
+    "review-catalog-policy",
   ]) {
     for (const step of allSteps(await workflow(name))) {
       if (!step.uses?.startsWith("actions/")) continue;
@@ -168,13 +173,14 @@ test("pins every first-party action to its resolved commit", async () => {
 test("limits every main publisher to the protected Publisher App", async () => {
   const discoveredPublishers: string[] = [];
   for (const file of await readdir(workflowDirectory)) {
-    if (!file.endsWith(".yml")) continue;
+    if (!/\.ya?ml$/u.test(file)) continue;
     const source = await readFile(resolve(workflowDirectory, file), "utf8");
     if (
-      source.includes("git push origin HEAD:main") ||
+      /git\s+push[^\n]*(?:HEAD:main|refs\/heads\/main)/u.test(source) ||
+      /git\/refs\/heads\/main/u.test(source) ||
       source.includes("catalog:enrichment-rollout")
     ) {
-      discoveredPublishers.push(file.replace(/\.yml$/u, ""));
+      discoveredPublishers.push(file.replace(/\.ya?ml$/u, ""));
     }
   }
 
@@ -190,6 +196,7 @@ test("limits every main publisher to the protected Publisher App", async () => {
         {
           environment?: string;
           if?: string;
+          permissions?: Record<string, string>;
           steps: Array<{
             id?: string;
             uses?: string;
@@ -210,7 +217,15 @@ test("limits every main publisher to the protected Publisher App", async () => {
     expect(job.environment, name).toBe("publisher");
     expect(job.if, name).toContain("github.ref == 'refs/heads/main'");
     expect(job.if, name).toContain("github.actor_id == 2625904");
-    expect(job.if, name).toContain("github.actor_id == 41898282");
+    expect(job.if, name).toContain(publisherActorExpression);
+    expect(job.if, name).not.toContain("github.actor_id == 41898282");
+    if (name === "import-tavernkeeper-reports") {
+      expect(job.if, name).toContain("github.actor_id == 311860138");
+    }
+    expect(job.permissions?.contents, name).not.toBe("write");
+    expect(publisherToken?.uses, name).toBe(
+      `actions/create-github-app-token@${pinnedActions["actions/create-github-app-token"]}`,
+    );
     expect(publisherToken, name).toMatchObject({
       id: "publisher-token",
       with: {
@@ -223,6 +238,99 @@ test("limits every main publisher to the protected Publisher App", async () => {
       "${{ steps.publisher-token.outputs.token }}",
     );
   }
+});
+
+test("uses the Publisher App identity for every protected workflow dispatch", async () => {
+  const protectedTargets = new Set(
+    Object.keys(protectedPublisherJobs).map((name) => `${name}.yml`),
+  );
+  const dispatches: string[] = [];
+
+  for (const file of await readdir(workflowDirectory)) {
+    if (!/\.ya?ml$/u.test(file)) continue;
+    const document = parse(
+      await readFile(resolve(workflowDirectory, file), "utf8"),
+    ) as {
+      jobs: Record<
+        string,
+        {
+          environment?: string;
+          steps?: Array<{
+            id?: string;
+            uses?: string;
+            run?: string;
+            env?: Record<string, string>;
+            with?: Record<string, string>;
+          }>;
+        }
+      >;
+    };
+
+    for (const [jobName, job] of Object.entries(document.jobs)) {
+      for (const step of job.steps ?? []) {
+        const targets = [
+          ...(step.run ?? "").matchAll(/gh workflow run ([^\s\\]+)/gu),
+        ]
+          .map((match) => match[1])
+          .filter((target) => protectedTargets.has(target));
+        for (const target of targets) {
+          dispatches.push(`${file}:${jobName}->${target}`);
+          expect(job.environment, `${file}:${jobName}`).toBe("publisher");
+          const tokenExpression = step.env?.GH_TOKEN;
+          const tokenId = tokenExpression?.match(
+            /^\$\{\{ steps\.([a-z0-9-]+)\.outputs\.token \}\}$/u,
+          )?.[1];
+          expect(tokenId, `${file}:${jobName}->${target}`).toBeTruthy();
+          const tokenStep = job.steps?.find(({ id }) => id === tokenId);
+          expect(tokenStep?.uses, `${file}:${jobName}->${target}`).toBe(
+            `actions/create-github-app-token@${pinnedActions["actions/create-github-app-token"]}`,
+          );
+          expect(
+            tokenStep?.with?.["permission-actions"],
+            `${file}:${jobName}->${target}`,
+          ).toBe("write");
+        }
+      }
+    }
+  }
+
+  expect(dispatches.sort()).toEqual(
+    [
+      "admit-issue.yml:admit->apply-kit-withdrawal.yml",
+      "import-tavernkeeper-reports.yml:continue->import-tavernkeeper-reports.yml",
+      "publish-project-transaction.yml:publish->review-catalog-policy.yml",
+      "refresh-catalog.yml:refresh->review-catalog-policy.yml",
+      "review-catalog-policy.yml:retry->review-catalog-policy.yml",
+      "targeted-tavernkeeper-scan.yml:request->refresh-catalog.yml",
+      "triage-kit-submission.yml:validate->apply-kit-submission.yml",
+    ].sort(),
+  );
+});
+
+test("verifies advisory checkout SHAs against main before minting a Publisher token", async () => {
+  const document = await workflow("review-catalog-policy");
+  const steps = document.jobs.review.steps as Array<{
+    name?: string;
+    run?: string;
+  }>;
+  const verifyIndex = steps.findIndex(
+    ({ name }) => name === "Verify exact published state",
+  );
+  const tokenIndex = steps.findIndex(
+    ({ name }) => name === "Create Tavernary Publisher token",
+  );
+  const checkoutIndex = steps.findIndex(
+    ({ name }) => name === "Check out exact published state",
+  );
+  const verification = steps[verifyIndex]?.run ?? "";
+
+  expect(verifyIndex).toBeGreaterThanOrEqual(0);
+  expect(verifyIndex).toBeLessThan(tokenIndex);
+  expect(tokenIndex).toBeLessThan(checkoutIndex);
+  expect(verification).toContain("pulls/$PULL_NUMBER");
+  expect(verification).toContain("compare/${MERGE_SHA}...main");
+  expect(verification).toContain('"ahead"');
+  expect(verification).toContain('"identical"');
 });
 
 test("targeted TavernKeeper scans are actor-gated and accept only an exact repository URL", async () => {

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -40,6 +40,25 @@ const protectedPublisherJobs = {
 const publisherActorExpression =
   "github.actor_id == vars.TAVERNARY_PUBLISHER_BOT_ID";
 
+const expectedPublisherConditions = {
+  "review-catalog-policy":
+    "github.event_name == 'workflow_dispatch' && " +
+    "github.ref == 'refs/heads/main' && " +
+    "(github.actor_id == 2625904 || " +
+    `${publisherActorExpression})`,
+  "import-tavernkeeper-reports":
+    "github.ref == 'refs/heads/main' && " +
+    "(github.event_name != 'workflow_dispatch' || " +
+    "github.actor_id == 2625904 || " +
+    `${publisherActorExpression} || ` +
+    "github.actor_id == 311860138)",
+  default:
+    "github.ref == 'refs/heads/main' && " +
+    "(github.event_name != 'workflow_dispatch' || " +
+    "github.actor_id == 2625904 || " +
+    `${publisherActorExpression})`,
+} as const;
+
 function exposesModelProviderEnvironment(step: {
   env?: Record<string, string>;
 }) {
@@ -84,7 +103,7 @@ function stepWritesMain(step: WorkflowStep) {
   return shellCommands(step.run).some((command) => {
     const pushesMain =
       /\bgit\s+push\b/u.test(command) &&
-      /(?:^|\s|["'])(?:HEAD:)?(?:refs\/heads\/)?main(?::(?:refs\/heads\/)?main)?(?:\s|$|["';])/u.test(
+      /(?:^|\s|["'])(?:\+)?(?:[^:\s"']*:)?(?:refs\/heads\/)?main(?:\s|$|["';])/u.test(
         command,
       );
     const updatesMainRef =
@@ -98,16 +117,13 @@ function stepWritesMain(step: WorkflowStep) {
   });
 }
 
-function protectedDispatchTargets(
-  step: WorkflowStep,
-  protectedTargets: ReadonlySet<string>,
-) {
+function workflowDispatchTargets(step: WorkflowStep) {
   const candidates: string[] = [];
   const command = shellCommands(step.run).join(" ");
   for (const match of command.matchAll(
-    /\bgh\s+workflow\s+run\s+([^\s"'\\]+)/gu,
+    /\bgh\s+workflow\s+run\s+(?:"([^"]+)"|'([^']+)'|([^\s\\]+))/gu,
   )) {
-    candidates.push(match[1]);
+    candidates.push(match[1] ?? match[2] ?? match[3]);
   }
   for (const match of command.matchAll(
     /\/actions\/workflows\/([^/\s"'?]+)\/dispatches\b/gu,
@@ -121,9 +137,7 @@ function protectedDispatchTargets(
       ),
     );
   }
-  return [
-    ...new Set(candidates.filter((target) => protectedTargets.has(target))),
-  ];
+  return [...new Set(candidates)];
 }
 
 test("uses category-prefixed workflow display names", async () => {
@@ -277,23 +291,11 @@ test("limits every main publisher to the protected Publisher App", async () => {
 
     expect(document.permissions.contents, name).toBe("read");
     expect(job.environment, name).toBe("publisher");
-    expect(job.if, name).toContain("github.ref == 'refs/heads/main'");
-    const actorReferences = job.if?.match(/github\.actor(?:_id)?/gu) ?? [];
-    const literalActorIds = [
-      ...(job.if ?? "").matchAll(/github\.actor_id\s*==\s*['"]?(\d+)['"]?/gu),
-    ]
-      .map((match) => match[1])
-      .sort();
-    expect(job.if, name).toContain(publisherActorExpression);
-    expect(actorReferences, name).toHaveLength(
-      name === "import-tavernkeeper-reports" ? 3 : 2,
+    expect(job.if?.replace(/\s+/gu, " ").trim(), name).toBe(
+      expectedPublisherConditions[
+        name as keyof typeof expectedPublisherConditions
+      ] ?? expectedPublisherConditions.default,
     );
-    expect(literalActorIds, name).toEqual(
-      name === "import-tavernkeeper-reports"
-        ? ["2625904", "311860138"]
-        : ["2625904"],
-    );
-    expect(job.if, name).not.toMatch(/github\.actor(?!_id)/u);
     expect(job.permissions?.contents, name).not.toBe("write");
     expect(publisherToken?.uses, name).toBe(
       `actions/create-github-app-token@${pinnedActions["actions/create-github-app-token"]}`,
@@ -340,8 +342,12 @@ test("uses the Publisher App identity for every protected workflow dispatch", as
 
     for (const [jobName, job] of Object.entries(document.jobs)) {
       for (const step of job.steps ?? []) {
-        const targets = protectedDispatchTargets(step, protectedTargets);
+        const targets = workflowDispatchTargets(step);
         for (const target of targets) {
+          expect(target, `${file}:${jobName}`).toMatch(
+            /^[A-Za-z0-9._-]+\.ya?ml$/u,
+          );
+          if (!protectedTargets.has(target)) continue;
           dispatches.push(`${file}:${jobName}->${target}`);
           expect(job.environment, `${file}:${jobName}`).toBe("publisher");
           const tokenExpression = step.env?.GH_TOKEN;
@@ -378,8 +384,11 @@ test("uses the Publisher App identity for every protected workflow dispatch", as
 test.each([
   "git push origin main",
   "git push origin main:main",
+  "git push origin feature:main",
+  "git push origin +HEAD:main",
+  "git push origin :main",
   "git push origin HEAD:refs/heads/main",
-  "git push origin \\\n+    HEAD:main",
+  "git push origin \\" + "\n    HEAD:main",
   "gh api --method PATCH repos/example/project/git/refs/heads/main",
   "gh api --method POST repos/example/project/git/refs -f ref=refs/heads/main",
   "gh api --method PUT repos/example/project/contents/file -f branch=main",
@@ -401,8 +410,19 @@ test.each([
   },
 ])("detects protected dispatch escape form: %#", (step) => {
   expect(
-    protectedDispatchTargets(step, new Set(["refresh-catalog.yml"])),
+    workflowDispatchTargets(step).filter(
+      (target) => target === "refresh-catalog.yml",
+    ),
   ).toEqual(["refresh-catalog.yml"]);
+});
+
+test.each([
+  'gh workflow run "$WORKFLOW"',
+  "gh api --method POST repos/example/project/actions/workflows/12345/dispatches -f ref=main",
+])("rejects nonliteral workflow dispatch target: %s", (run) => {
+  for (const target of workflowDispatchTargets({ run })) {
+    expect(target).not.toMatch(/^[A-Za-z0-9._-]+\.ya?ml$/u);
+  }
 });
 
 test("verifies advisory checkout SHAs against main before minting a Publisher token", async () => {

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -1,4 +1,4 @@
-import { readFile } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 
 import { expect, test } from "vitest";
@@ -25,6 +25,17 @@ const modelProviderEnvironment = {
 } as const;
 
 const modelProviderEnvironmentKeys = Object.keys(modelProviderEnvironment);
+
+const protectedPublisherJobs = {
+  "apply-kit-submission": "publish",
+  "apply-kit-withdrawal": "withdraw",
+  "backfill-repository-identities": "backfill",
+  "enrich-catalog": "enrich",
+  "import-tavernkeeper-reports": "import",
+  "publish-openai-usage": "publish",
+  "refresh-catalog": "refresh",
+  "review-catalog-policy": "review",
+} as const;
 
 function exposesModelProviderEnvironment(step: {
   env?: Record<string, string>;
@@ -154,6 +165,66 @@ test("pins every first-party action to its resolved commit", async () => {
   }
 });
 
+test("limits every main publisher to the protected Publisher App", async () => {
+  const discoveredPublishers: string[] = [];
+  for (const file of await readdir(workflowDirectory)) {
+    if (!file.endsWith(".yml")) continue;
+    const source = await readFile(resolve(workflowDirectory, file), "utf8");
+    if (
+      source.includes("git push origin HEAD:main") ||
+      source.includes("catalog:enrichment-rollout")
+    ) {
+      discoveredPublishers.push(file.replace(/\.yml$/u, ""));
+    }
+  }
+
+  expect(discoveredPublishers.sort()).toEqual(
+    Object.keys(protectedPublisherJobs).sort(),
+  );
+
+  for (const [name, jobName] of Object.entries(protectedPublisherJobs)) {
+    const document = (await workflow(name)) as {
+      permissions: Record<string, string>;
+      jobs: Record<
+        string,
+        {
+          environment?: string;
+          if?: string;
+          steps: Array<{
+            id?: string;
+            uses?: string;
+            with?: Record<string, string>;
+          }>;
+        }
+      >;
+    };
+    const job = document.jobs[jobName];
+    const publisherToken = job.steps.find((step) =>
+      step.uses?.startsWith("actions/create-github-app-token@"),
+    );
+    const checkout = job.steps.find((step) =>
+      step.uses?.startsWith("actions/checkout@"),
+    );
+
+    expect(document.permissions.contents, name).toBe("read");
+    expect(job.environment, name).toBe("publisher");
+    expect(job.if, name).toContain("github.ref == 'refs/heads/main'");
+    expect(job.if, name).toContain("github.actor_id == 2625904");
+    expect(job.if, name).toContain("github.actor_id == 41898282");
+    expect(publisherToken, name).toMatchObject({
+      id: "publisher-token",
+      with: {
+        "app-id": "${{ vars.TAVERNARY_PUBLISHER_APP_ID }}",
+        "private-key": "${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}",
+        "permission-contents": "write",
+      },
+    });
+    expect(checkout?.with?.token, name).toBe(
+      "${{ steps.publisher-token.outputs.token }}",
+    );
+  }
+});
+
 test("targeted TavernKeeper scans are actor-gated and accept only an exact repository URL", async () => {
   const targeted = await workflow("targeted-tavernkeeper-scan");
   const source = await readFile(
@@ -230,7 +301,7 @@ test("publishes Kits only by manual dispatch and serializes registry writes", as
   expect(withdrawal.on.issues).toBeUndefined();
   for (const document of [publication, withdrawal]) {
     expect(document.permissions).toEqual({
-      contents: "write",
+      contents: "read",
       issues: "write",
       actions: "write",
     });
@@ -646,7 +717,7 @@ test("reconciles reports independently and wakes TavernKeeper only after a chang
   ).toMatchObject({ required: false, type: "string" });
   expect(reportImport.permissions).toEqual({
     actions: "write",
-    contents: "write",
+    contents: "read",
     issues: "write",
   });
   expect(deploy.jobs["wake-tavernkeeper"].needs).toEqual(["build", "deploy"]);
@@ -824,7 +895,7 @@ test("refreshes snapshots daily without granting production-record writes", asyn
   );
 
   expect(refresh.permissions).toEqual({
-    contents: "write",
+    contents: "read",
     actions: "write",
     issues: "read",
   });
@@ -917,7 +988,7 @@ test("runs enrichment through one tested durable orchestrator", async () => {
     default: "pending",
   });
   expect(enrich.permissions).toEqual({
-    contents: "write",
+    contents: "read",
     actions: "write",
     issues: "write",
   });
@@ -1689,7 +1760,7 @@ test("publishes only scoped aggregate OpenAI usage each month", async () => {
   expect(publication.on.schedule).toEqual([{ cron: "23 7 2 * *" }]);
   expect(publication.on.workflow_dispatch).toBeNull();
   expect(publication.permissions).toEqual({
-    contents: "write",
+    contents: "read",
     actions: "write",
   });
   expect(checkout?.with).toMatchObject({ ref: "main", "fetch-depth": 0 });

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -62,6 +62,70 @@ function allSteps(document: Record<string, unknown>) {
   return Object.values(jobs).flatMap((job) => job.steps ?? []);
 }
 
+type WorkflowStep = {
+  id?: string;
+  uses?: string;
+  run?: string;
+  env?: Record<string, string>;
+  with?: Record<string, string>;
+};
+
+function shellCommands(source = "") {
+  return source
+    .replace(/\\\r?\n\s*/gu, " ")
+    .split(/\r?\n/u)
+    .map((line) => line.replace(/\s+/gu, " ").trim())
+    .filter(Boolean);
+}
+
+function stepWritesMain(step: WorkflowStep) {
+  if (step.run?.includes("catalog:enrichment-rollout")) return true;
+
+  return shellCommands(step.run).some((command) => {
+    const pushesMain =
+      /\bgit\s+push\b/u.test(command) &&
+      /(?:^|\s|["'])(?:HEAD:)?(?:refs\/heads\/)?main(?::(?:refs\/heads\/)?main)?(?:\s|$|["';])/u.test(
+        command,
+      );
+    const updatesMainRef =
+      /\/git\/refs\/heads\/main\b/u.test(command) ||
+      /\/git\/refs\b.*\bref=(?:["'])?refs\/heads\/main\b/u.test(command) ||
+      /\bupdateRef\b.*refs\/heads\/main\b/u.test(command);
+    const writesMainContents =
+      /\/contents\/\S+/u.test(command) &&
+      /\bbranch=(?:["'])?main\b/u.test(command);
+    return pushesMain || updatesMainRef || writesMainContents;
+  });
+}
+
+function protectedDispatchTargets(
+  step: WorkflowStep,
+  protectedTargets: ReadonlySet<string>,
+) {
+  const candidates: string[] = [];
+  const command = shellCommands(step.run).join(" ");
+  for (const match of command.matchAll(
+    /\bgh\s+workflow\s+run\s+([^\s"'\\]+)/gu,
+  )) {
+    candidates.push(match[1]);
+  }
+  for (const match of command.matchAll(
+    /\/actions\/workflows\/([^/\s"'?]+)\/dispatches\b/gu,
+  )) {
+    candidates.push(match[1]);
+  }
+  if (step.uses && /workflow[-_]dispatch/iu.test(step.uses)) {
+    candidates.push(
+      ...Object.values(step.with ?? {}).filter((value) =>
+        /\.ya?ml$/u.test(value),
+      ),
+    );
+  }
+  return [
+    ...new Set(candidates.filter((target) => protectedTargets.has(target))),
+  ];
+}
+
 test("uses category-prefixed workflow display names", async () => {
   const expectedNames = {
     "admit-issue": "Submission intake: Check issue eligibility",
@@ -174,12 +238,10 @@ test("limits every main publisher to the protected Publisher App", async () => {
   const discoveredPublishers: string[] = [];
   for (const file of await readdir(workflowDirectory)) {
     if (!/\.ya?ml$/u.test(file)) continue;
-    const source = await readFile(resolve(workflowDirectory, file), "utf8");
-    if (
-      /git\s+push[^\n]*(?:HEAD:main|refs\/heads\/main)/u.test(source) ||
-      /git\/refs\/heads\/main/u.test(source) ||
-      source.includes("catalog:enrichment-rollout")
-    ) {
+    const document = parse(
+      await readFile(resolve(workflowDirectory, file), "utf8"),
+    ) as Record<string, unknown>;
+    if (allSteps(document).some((step) => stepWritesMain(step))) {
       discoveredPublishers.push(file.replace(/\.ya?ml$/u, ""));
     }
   }
@@ -216,12 +278,22 @@ test("limits every main publisher to the protected Publisher App", async () => {
     expect(document.permissions.contents, name).toBe("read");
     expect(job.environment, name).toBe("publisher");
     expect(job.if, name).toContain("github.ref == 'refs/heads/main'");
-    expect(job.if, name).toContain("github.actor_id == 2625904");
+    const actorReferences = job.if?.match(/github\.actor(?:_id)?/gu) ?? [];
+    const literalActorIds = [
+      ...(job.if ?? "").matchAll(/github\.actor_id\s*==\s*['"]?(\d+)['"]?/gu),
+    ]
+      .map((match) => match[1])
+      .sort();
     expect(job.if, name).toContain(publisherActorExpression);
-    expect(job.if, name).not.toContain("github.actor_id == 41898282");
-    if (name === "import-tavernkeeper-reports") {
-      expect(job.if, name).toContain("github.actor_id == 311860138");
-    }
+    expect(actorReferences, name).toHaveLength(
+      name === "import-tavernkeeper-reports" ? 3 : 2,
+    );
+    expect(literalActorIds, name).toEqual(
+      name === "import-tavernkeeper-reports"
+        ? ["2625904", "311860138"]
+        : ["2625904"],
+    );
+    expect(job.if, name).not.toMatch(/github\.actor(?!_id)/u);
     expect(job.permissions?.contents, name).not.toBe("write");
     expect(publisherToken?.uses, name).toBe(
       `actions/create-github-app-token@${pinnedActions["actions/create-github-app-token"]}`,
@@ -268,11 +340,7 @@ test("uses the Publisher App identity for every protected workflow dispatch", as
 
     for (const [jobName, job] of Object.entries(document.jobs)) {
       for (const step of job.steps ?? []) {
-        const targets = [
-          ...(step.run ?? "").matchAll(/gh workflow run ([^\s\\]+)/gu),
-        ]
-          .map((match) => match[1])
-          .filter((target) => protectedTargets.has(target));
+        const targets = protectedDispatchTargets(step, protectedTargets);
         for (const target of targets) {
           dispatches.push(`${file}:${jobName}->${target}`);
           expect(job.environment, `${file}:${jobName}`).toBe("publisher");
@@ -305,6 +373,36 @@ test("uses the Publisher App identity for every protected workflow dispatch", as
       "triage-kit-submission.yml:validate->apply-kit-submission.yml",
     ].sort(),
   );
+});
+
+test.each([
+  "git push origin main",
+  "git push origin main:main",
+  "git push origin HEAD:refs/heads/main",
+  "git push origin \\\n+    HEAD:main",
+  "gh api --method PATCH repos/example/project/git/refs/heads/main",
+  "gh api --method POST repos/example/project/git/refs -f ref=refs/heads/main",
+  "gh api --method PUT repos/example/project/contents/file -f branch=main",
+  'gh api graphql -f query="mutation { updateRef(ref: \\"refs/heads/main\\") }"',
+])("detects direct main writer escape form: %s", (run) => {
+  expect(stepWritesMain({ run })).toBe(true);
+});
+
+test.each([
+  {
+    run: "gh api --method POST repos/example/project/actions/workflows/refresh-catalog.yml/dispatches -f ref=main",
+  },
+  {
+    run: 'curl -X POST "https://api.github.com/repos/example/project/actions/workflows/refresh-catalog.yml/dispatches"',
+  },
+  {
+    uses: "example/workflow-dispatch@0123456789012345678901234567890123456789",
+    with: { workflow: "refresh-catalog.yml" },
+  },
+])("detects protected dispatch escape form: %#", (step) => {
+  expect(
+    protectedDispatchTargets(step, new Set(["refresh-catalog.yml"])),
+  ).toEqual(["refresh-catalog.yml"]);
 });
 
 test("verifies advisory checkout SHAs against main before minting a Publisher token", async () => {


### PR DESCRIPTION
Replaces #552 on current main after the independent visual-baseline repair in #553.

- Requires MentallyQuill ownership through CODEOWNERS.
- Moves every direct or indirect main publisher behind the repository-only Tavernary Publisher App and main-only environment.
- Rejects shared github-actions[bot] dispatch authority.
- Verifies advisory SHAs are already on main before any Publisher credential exists.
- Adds fail-closed workflow-policy coverage and implementation records.

Local final verification: 218 test files / 2,461 tests, production build, 403-page static generation, and export verification. Independent security review: no Critical or Important findings.