### PR TITLE
Use Publisher App client ID

### DIFF
--- a/.github/workflows/admit-issue.yml
+++ b/.github/workflows/admit-issue.yml
@@ -74,7 +74,7 @@ jobs:
           steps.admission.outputs.route == 'kit-withdrawal'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.TAVERNARY_PUBLISHER_APP_ID }}
+          client-id: ${{ vars.TAVERNARY_PUBLISHER_CLIENT_ID }}
           private-key: ${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}
           permission-actions: write
       - name: Dispatch Kit withdrawal

--- a/.github/workflows/apply-kit-submission.yml
+++ b/.github/workflows/apply-kit-submission.yml
@@ -32,7 +32,7 @@ jobs:
         id: publisher-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.TAVERNARY_PUBLISHER_APP_ID }}
+          client-id: ${{ vars.TAVERNARY_PUBLISHER_CLIENT_ID }}
           private-key: ${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}
           permission-contents: write
       - name: Check out repository

--- a/.github/workflows/apply-kit-withdrawal.yml
+++ b/.github/workflows/apply-kit-withdrawal.yml
@@ -32,7 +32,7 @@ jobs:
         id: publisher-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.TAVERNARY_PUBLISHER_APP_ID }}
+          client-id: ${{ vars.TAVERNARY_PUBLISHER_CLIENT_ID }}
           private-key: ${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}
           permission-contents: write
       - name: Check out repository

--- a/.github/workflows/backfill-repository-identities.yml
+++ b/.github/workflows/backfill-repository-identities.yml
@@ -30,7 +30,7 @@ jobs:
         id: publisher-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.TAVERNARY_PUBLISHER_APP_ID }}
+          client-id: ${{ vars.TAVERNARY_PUBLISHER_CLIENT_ID }}
           private-key: ${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}
           permission-contents: write
       - name: Check out repository

--- a/.github/workflows/enrich-catalog.yml
+++ b/.github/workflows/enrich-catalog.yml
@@ -48,7 +48,7 @@ jobs:
         id: publisher-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.TAVERNARY_PUBLISHER_APP_ID }}
+          client-id: ${{ vars.TAVERNARY_PUBLISHER_CLIENT_ID }}
           private-key: ${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}
           permission-contents: write
       - name: Check out repository

--- a/.github/workflows/import-tavernkeeper-reports.yml
+++ b/.github/workflows/import-tavernkeeper-reports.yml
@@ -45,7 +45,7 @@ jobs:
         id: publisher-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.TAVERNARY_PUBLISHER_APP_ID }}
+          client-id: ${{ vars.TAVERNARY_PUBLISHER_CLIENT_ID }}
           private-key: ${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}
           permission-contents: write
       - name: Check out main
@@ -219,7 +219,7 @@ jobs:
         id: publisher-dispatch-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.TAVERNARY_PUBLISHER_APP_ID }}
+          client-id: ${{ vars.TAVERNARY_PUBLISHER_CLIENT_ID }}
           private-key: ${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}
           permission-actions: write
       - name: Continue due report imports independently of deployment

--- a/.github/workflows/publish-openai-usage.yml
+++ b/.github/workflows/publish-openai-usage.yml
@@ -29,7 +29,7 @@ jobs:
         id: publisher-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.TAVERNARY_PUBLISHER_APP_ID }}
+          client-id: ${{ vars.TAVERNARY_PUBLISHER_CLIENT_ID }}
           private-key: ${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}
           permission-contents: write
       - name: Check out main

--- a/.github/workflows/publish-project-transaction.yml
+++ b/.github/workflows/publish-project-transaction.yml
@@ -498,7 +498,7 @@ jobs:
         continue-on-error: true
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.TAVERNARY_PUBLISHER_APP_ID }}
+          client-id: ${{ vars.TAVERNARY_PUBLISHER_CLIENT_ID }}
           private-key: ${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}
           permission-actions: write
       - name: Dispatch non-blocking Catalog Policy advisory

--- a/.github/workflows/refresh-catalog.yml
+++ b/.github/workflows/refresh-catalog.yml
@@ -55,7 +55,7 @@ jobs:
         id: publisher-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.TAVERNARY_PUBLISHER_APP_ID }}
+          client-id: ${{ vars.TAVERNARY_PUBLISHER_CLIENT_ID }}
           private-key: ${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}
           permission-actions: write
           permission-contents: write

--- a/.github/workflows/review-catalog-policy.yml
+++ b/.github/workflows/review-catalog-policy.yml
@@ -44,7 +44,7 @@ jobs:
         id: publisher-dispatch-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.TAVERNARY_PUBLISHER_APP_ID }}
+          client-id: ${{ vars.TAVERNARY_PUBLISHER_CLIENT_ID }}
           private-key: ${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}
           permission-actions: write
           permission-contents: read
@@ -116,7 +116,7 @@ jobs:
         id: publisher-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.TAVERNARY_PUBLISHER_APP_ID }}
+          client-id: ${{ vars.TAVERNARY_PUBLISHER_CLIENT_ID }}
           private-key: ${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}
           permission-contents: write
       - name: Check out exact published state

--- a/.github/workflows/targeted-tavernkeeper-scan.yml
+++ b/.github/workflows/targeted-tavernkeeper-scan.yml
@@ -52,7 +52,7 @@ jobs:
         id: publisher-dispatch-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.TAVERNARY_PUBLISHER_APP_ID }}
+          client-id: ${{ vars.TAVERNARY_PUBLISHER_CLIENT_ID }}
           private-key: ${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}
           permission-actions: write
       - name: Dispatch project refresh

--- a/.github/workflows/triage-kit-submission.yml
+++ b/.github/workflows/triage-kit-submission.yml
@@ -40,7 +40,7 @@ jobs:
         if: steps.triage.outputs.publish == 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.TAVERNARY_PUBLISHER_APP_ID }}
+          client-id: ${{ vars.TAVERNARY_PUBLISHER_CLIENT_ID }}
           private-key: ${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}
           permission-actions: write
       - name: Publish valid Kit

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -303,7 +303,7 @@ test("limits every main publisher to the protected Publisher App", async () => {
     expect(publisherToken, name).toMatchObject({
       id: "publisher-token",
       with: {
-        "app-id": "${{ vars.TAVERNARY_PUBLISHER_APP_ID }}",
+        "client-id": "${{ vars.TAVERNARY_PUBLISHER_CLIENT_ID }}",
         "private-key": "${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}",
         "permission-contents": "write",
       },


### PR DESCRIPTION
## Summary

- switch every Tavernary Publisher token step from the legacy App ID input to the recommended Client ID input
- keep the private key and per-step permission restrictions unchanged
- update workflow contract coverage for the new variable

## Why

`actions/create-github-app-token` v3 accepts App ID for compatibility but emits a deprecation warning and recommends Client ID. This keeps the Publisher path warning-free and aligned with GitHub's current authentication guidance.

## Validation

- `npm.cmd test -- tests/unit/workflows.test.ts` (60 passed)
- Prettier check on all changed workflows and the workflow test
- successful live Publisher App run before this migration: `32040848125`
