### PR TITLE
feat(security): verify Publisher write lane

### DIFF
--- a/.github/workflows/publisher-verification.yml
+++ b/.github/workflows/publisher-verification.yml
@@ -1,0 +1,55 @@
+name: "Security: Verify Tavernary Publisher"
+run-name: "Security: Verify Publisher write lane #${{ github.run_number }}"
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tavernary-publisher-verification
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    if: >-
+      github.ref == 'refs/heads/main' && github.actor_id == 2625904
+    runs-on: ubuntu-latest
+    environment: publisher
+    permissions:
+      contents: read
+    steps:
+      - name: Create Tavernary Publisher token
+        id: publisher-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.TAVERNARY_PUBLISHER_CLIENT_ID }}
+          private-key: ${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}
+          owner: MentallyQuill
+          repositories: Tavernary
+          permission-contents: write
+      - name: Check out trusted Tavernary main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ steps.publisher-token.outputs.token }}
+      - name: Commit Publisher verification
+        shell: bash
+        run: |
+          git config user.name "Tavernary Publisher"
+          git config user.email "tavernary-publisher[bot]@users.noreply.github.com"
+          git commit --allow-empty -m "chore(security): verify Publisher write lane"
+          for attempt in 1 2 3; do
+            if git fetch origin main &&
+              git rebase --keep-empty origin/main; then
+              if git push origin HEAD:main; then
+                exit 0
+              fi
+            fi
+            git rebase --abort || true
+            if (( attempt == 3 )); then
+              exit 1
+            fi
+          done

--- a/docs/superpowers/plans/2026-08-16-github-contributor-security-policy.md
+++ b/docs/superpowers/plans/2026-08-16-github-contributor-security-policy.md
@@ -33,7 +33,7 @@ from fresh API responses.
 - [ ] Require each publisher job to use environment `publisher`.
 - [ ] Change workflow-level contents permission from Write to Read.
 - [ ] Add a full-SHA-pinned `actions/create-github-app-token` step with
-  `TAVERNARY_PUBLISHER_APP_ID` and `TAVERNARY_PUBLISHER_APP_PRIVATE_KEY`.
+  `TAVERNARY_PUBLISHER_CLIENT_ID` and `TAVERNARY_PUBLISHER_APP_PRIVATE_KEY`.
 - [ ] Use the App token for checkout and publication while retaining ordinary
   tokens only for Issues and Actions APIs.
 - [ ] Gate manual privileged dispatches to user ID `2625904` or the trusted
@@ -56,7 +56,7 @@ from fresh API responses.
 - [ ] Install it only on `MentallyQuill/Tavernary` and capture its Integration ID.
 - [ ] Create environment `publisher` with a custom deployment branch policy for
   exactly `main`.
-- [ ] Store App ID as `TAVERNARY_PUBLISHER_APP_ID` and private key as
+- [ ] Store Client ID as `TAVERNARY_PUBLISHER_CLIENT_ID` and private key as
   `TAVERNARY_PUBLISHER_APP_PRIVATE_KEY` in that environment.
 - [ ] Store the App bot user ID as repository variable
   `TAVERNARY_PUBLISHER_BOT_ID` for target-workflow actor checks.
@@ -89,7 +89,7 @@ from fresh API responses.
   access, CODEOWNERS, security analysis, environment policy, App installation,
   and check provenance.
 - [ ] Confirm only `main` is protected and feature branches remain creatable.
-- [ ] Run a bounded no-change Publisher workflow and verify App authentication,
-  protected-environment access, and ruleset compatibility.
+- [ ] Run `publisher-verification.yml`, verify its empty App-authenticated commit
+  reaches protected `main`, and confirm token revocation during cleanup.
 - [ ] Record final PR URLs, merge commits, workflow run, ruleset IDs, and clean
   local branch state.

--- a/docs/superpowers/plans/2026-08-17-publisher-full-verification.md
+++ b/docs/superpowers/plans/2026-08-17-publisher-full-verification.md
@@ -1,0 +1,132 @@
+# Tavernary Publisher Full Verification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a repeatable, policy-enforced live test of Tavernary Publisher protected-main writes and prove ordinary owner direct writes remain blocked.
+
+**Architecture:** A manual owner-only workflow uses the existing main-only `publisher` environment and repository-scoped App token to push one empty audit commit. Existing parsed-YAML policy tests enumerate the workflow as a protected Publisher writer and reject changes to its authority or token boundary.
+
+**Tech Stack:** GitHub Actions YAML, `actions/create-github-app-token`, Vitest, YAML parser, GitHub rulesets, GitHub CLI.
+
+## Global Constraints
+
+- Use `vars.TAVERNARY_PUBLISHER_CLIENT_ID`; never restore the deprecated App ID input.
+- Keep ordinary `GITHUB_TOKEN` permissions at `contents: read`.
+- Run only from `main` through environment `publisher` and actor ID `2625904`.
+- Push only `HEAD:main`, never force-push, and change no repository content.
+- Pin every external action to the repository-approved 40-character SHA.
+
+---
+
+### Task 1: Define the failing workflow contract
+
+**Files:**
+- Modify: `tests/unit/workflows.test.ts`
+- Create: `.github/workflows/publisher-verification.yml`
+
+**Interfaces:**
+- Consumes: `protectedPublisherJobs`, `pinnedActions`, and `workflow()` from the existing workflow tests.
+- Produces: a parsed-YAML contract for job `verify` in `publisher-verification.yml`.
+
+- [ ] **Step 1: Add the missing workflow to the Publisher allowlist and action-pin enumeration**
+
+Add `"publisher-verification": "verify"` and assert an input-free manual trigger,
+owner/main guard, environment `publisher`, exact Client ID/private-key inputs,
+`git commit --allow-empty`, `git rebase --keep-empty origin/main`, and a
+non-force `git push origin HEAD:main`.
+
+- [ ] **Step 2: Run the focused test and observe Red**
+
+Run: `npm.cmd test -- tests/unit/workflows.test.ts`
+
+Expected: FAIL because `.github/workflows/publisher-verification.yml` does not
+exist.
+
+- [ ] **Step 3: Add the minimal workflow**
+
+Create an owner-only `workflow_dispatch` workflow with root
+`permissions: { contents: read }`, protected environment `publisher`, the
+approved token and checkout action pins, an empty audit commit, three bounded
+fetch/rebase/push attempts, and no inputs.
+
+- [ ] **Step 4: Run the focused test and observe Green**
+
+Run: `npm.cmd test -- tests/unit/workflows.test.ts`
+
+Expected: PASS with the new workflow included in the direct-writer audit.
+
+### Task 2: Update the reviewed security contract
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-08-16-github-contributor-security-policy-design.md`
+- Modify: `docs/superpowers/plans/2026-08-16-github-contributor-security-policy.md`
+
+**Interfaces:**
+- Consumes: the live Client ID migration already merged in PR 555.
+- Produces: documentation that names the current Client ID variable and repeatable canary.
+
+- [ ] **Step 1: Replace stale App ID references**
+
+Document `TAVERNARY_PUBLISHER_CLIENT_ID` as an environment variable and add
+`publisher-verification.yml` to the reviewed direct-writer boundary.
+
+- [ ] **Step 2: Run formatting and diff checks**
+
+Run: `npm.cmd run format:check`
+
+Run: `git diff --check`
+
+Expected: both exit zero.
+
+### Task 3: Verify, review, and merge
+
+**Files:**
+- Verify: all branch changes
+
+**Interfaces:**
+- Consumes: Tasks 1-2.
+- Produces: a merged protected-main verification workflow.
+
+- [ ] **Step 1: Run the full gate**
+
+Run: `npm.cmd run check`
+
+Expected: formatting, lint, catalog validation/build, typecheck, unit tests,
+production build, and export verification all pass.
+
+- [ ] **Step 2: Review the complete diff**
+
+Review `origin/main..HEAD` for credential expansion, unpinned actions, force
+pushes, extra triggers, or unprotected jobs. Fix every Critical or Important
+finding and rerun the gate.
+
+- [ ] **Step 3: Push, open a PR, wait for `verify` and `visual`, and merge**
+
+Merge only the tested head SHA through the protected PR lane and verify the
+merge commit is current `main`.
+
+### Task 4: Run positive and negative live verification
+
+**Files:**
+- Live GitHub state only
+
+**Interfaces:**
+- Consumes: merged `publisher-verification.yml` and ruleset `19711101`.
+- Produces: successful App push evidence and rejected ordinary-owner push evidence.
+
+- [ ] **Step 1: Dispatch the Publisher verification workflow from `main`**
+
+Verify token creation uses `client-id`, checkout uses the App token, the empty
+commit reaches `main`, and the action post step reports `Token revoked`.
+
+- [ ] **Step 2: Attempt an ordinary owner direct push**
+
+From a disposable detached worktree at current `main`, create an empty commit
+and run `git push origin HEAD:main`. Expected: repository rules reject the
+update. Remove only the disposable worktree after recording the rejection.
+
+- [ ] **Step 3: Re-read final security state**
+
+Verify ruleset actors/rules, App installation and permissions, environment
+policy/credential names, Actions policy, secret scanning, collaborator count,
+the verification commit, and downstream push-run conclusions.

--- a/docs/superpowers/specs/2026-08-16-github-contributor-security-policy-design.md
+++ b/docs/superpowers/specs/2026-08-16-github-contributor-security-policy-design.md
@@ -42,9 +42,9 @@ permissions:
   permissions.
 
 The App's private key is stored only as the protected `publisher` environment
-secret `TAVERNARY_PUBLISHER_APP_PRIVATE_KEY`; its App ID is the environment
-variable `TAVERNARY_PUBLISHER_APP_ID`. The environment permits deployments only
-from the `main` branch.
+secret `TAVERNARY_PUBLISHER_APP_PRIVATE_KEY`; its GitHub-recommended Client ID
+is the environment variable `TAVERNARY_PUBLISHER_CLIENT_ID`. The environment
+permits deployments only from the `main` branch.
 
 Each job that can push `HEAD:main` must:
 
@@ -74,6 +74,7 @@ This boundary covers direct writers and the durable enrichment orchestrator:
 - `enrich-catalog.yml`;
 - `import-tavernkeeper-reports.yml`;
 - `publish-openai-usage.yml`;
+- `publisher-verification.yml`;
 - `refresh-catalog.yml`;
 - `review-catalog-policy.yml`.
 
@@ -153,7 +154,7 @@ change.
 1. Add a failing workflow-policy test, migrate all eight Tavernary publishers,
    and prove the focused and full repository gates pass.
 2. Register and install the private App, create its protected environment, and
-   store the App ID and private key without exposing the key.
+   store the Client ID and private key without exposing the key.
 3. Merge Tavernary's workflow and CODEOWNERS change, then merge TavernKeeper's
    CODEOWNERS change.
 4. Update both default-branch rulesets in place, preserving existing integration
@@ -163,9 +164,9 @@ change.
 6. Confirm only `main` is protected, required check provenance is exact, the App
    is installed only on Tavernary, and no feature-branch creation restriction
    exists.
-7. Dispatch a bounded Publisher operation that is safe when no content changes
-   are pending, and verify the privileged job obtains its environment and runs
-   without a ruleset or credential failure.
+7. Dispatch the input-free Publisher verification workflow, verify its harmless
+   empty commit reaches protected `main`, and confirm the short-lived token is
+   revoked during job cleanup.
 
 If a required check is absent or publication is blocked, restore the captured
 pre-change ruleset payload and diagnose the exact check or App identity before

--- a/docs/superpowers/specs/2026-08-16-github-contributor-security-policy-design.md
+++ b/docs/superpowers/specs/2026-08-16-github-contributor-security-policy-design.md
@@ -151,7 +151,7 @@ change.
 
 ## Rollout and Verification
 
-1. Add a failing workflow-policy test, migrate all eight Tavernary publishers,
+1. Add a failing workflow-policy test, migrate all nine Tavernary publishers,
    and prove the focused and full repository gates pass.
 2. Register and install the private App, create its protected environment, and
    store the Client ID and private key without exposing the key.

--- a/docs/superpowers/specs/2026-08-17-publisher-full-verification-design.md
+++ b/docs/superpowers/specs/2026-08-17-publisher-full-verification-design.md
@@ -1,0 +1,44 @@
+# Tavernary Publisher Full Verification Design
+
+**Status:** Approved on 2026-08-17
+
+## Goal
+
+Provide repeatable proof that the Tavernary Publisher can authenticate with the
+GitHub-recommended Client ID, obtain only its reviewed repository permissions,
+and make a normal direct push through the protected `main` ruleset while an
+ordinary owner token remains unable to push directly.
+
+## Verification workflow
+
+Add `publisher-verification.yml` as an owner-only, input-free
+`workflow_dispatch` workflow. Its single job runs only from `main`, uses the
+main-only `publisher` environment, keeps `GITHUB_TOKEN` at `contents: read`, and
+mints a short-lived installation token from
+`vars.TAVERNARY_PUBLISHER_CLIENT_ID` and
+`secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY`.
+
+The job checks out the trusted default branch with the App token, creates one
+empty audit commit, rebases that empty commit onto the latest `main` with
+`--keep-empty`, and pushes `HEAD:main` without force. The action's post step
+revokes the installation token. The empty commit deliberately changes no
+repository content while proving the App's protected-branch bypass.
+
+## Policy boundary
+
+The workflow is added to the existing Publisher writer allowlist and action-pin
+tests. Tests require the exact protected environment, Client ID variable,
+private-key secret, owner actor guard, input-free trigger, pinned actions,
+non-force push, and App-token checkout. Any additional direct `main` writer or
+credential placement continues to fail CI.
+
+## Live proof
+
+After the PR is merged, dispatch the workflow from `main` and verify token
+creation, the protected-main commit, token revocation, and downstream push
+workflows. Then create a disposable empty owner-authored commit from current
+`main` and attempt the same direct push. The ruleset must reject it. The feature
+branch and its PR provide the positive same-repository branch and PR lane proof.
+
+No collaborator is invited by this verification; onboarding remains an
+identity-specific access-management step.

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -33,6 +33,7 @@ const protectedPublisherJobs = {
   "enrich-catalog": "enrich",
   "import-tavernkeeper-reports": "import",
   "publish-openai-usage": "publish",
+  "publisher-verification": "verify",
   "refresh-catalog": "refresh",
   "review-catalog-policy": "review",
 } as const;
@@ -41,6 +42,8 @@ const publisherActorExpression =
   "github.actor_id == vars.TAVERNARY_PUBLISHER_BOT_ID";
 
 const expectedPublisherConditions = {
+  "publisher-verification":
+    "github.ref == 'refs/heads/main' && github.actor_id == 2625904",
   "review-catalog-policy":
     "github.event_name == 'workflow_dispatch' && " +
     "github.ref == 'refs/heads/main' && " +
@@ -169,6 +172,7 @@ test("uses category-prefixed workflow display names", async () => {
     "deploy-pages": "Site: Deploy to GitHub Pages",
     "targeted-tavernkeeper-scan": "Security: Run targeted TavernKeeper scan",
     "publish-openai-usage": "Support transparency: Publish OpenAI usage",
+    "publisher-verification": "Security: Verify Tavernary Publisher",
   } as const;
 
   for (const [file, expectedName] of Object.entries(expectedNames)) {
@@ -204,6 +208,7 @@ test("identifies the object and action in every workflow run name", async () => 
     "deploy-pages": ["Site:", "Deploy"],
     "targeted-tavernkeeper-scan": ["Security:", "Scan"],
     "publish-openai-usage": ["Support:", "Publish prior-month usage"],
+    "publisher-verification": ["Security:", "Verify Publisher write lane"],
   } as const;
 
   for (const [file, expectedParts] of Object.entries(expectedRunNameParts)) {
@@ -237,6 +242,7 @@ test("pins every first-party action to its resolved commit", async () => {
     "apply-kit-withdrawal",
     "targeted-tavernkeeper-scan",
     "publish-openai-usage",
+    "publisher-verification",
     "review-catalog-policy",
   ]) {
     for (const step of allSteps(await workflow(name))) {
@@ -312,6 +318,55 @@ test("limits every main publisher to the protected Publisher App", async () => {
       "${{ steps.publisher-token.outputs.token }}",
     );
   }
+});
+
+test("keeps Publisher verification owner-only and content-neutral", async () => {
+  const document = await workflow("publisher-verification");
+  const job = document.jobs.verify;
+  const token = job.steps.find((step: WorkflowStep) =>
+    step.uses?.startsWith("actions/create-github-app-token@"),
+  );
+  const checkout = job.steps.find((step: WorkflowStep) =>
+    step.uses?.startsWith("actions/checkout@"),
+  );
+  const push = job.steps.find((step: WorkflowStep) =>
+    step.run?.includes("git push origin HEAD:main"),
+  );
+
+  expect(document.on).toEqual({ workflow_dispatch: null });
+  expect(document.permissions).toEqual({ contents: "read" });
+  expect(document.concurrency).toEqual({
+    group: "tavernary-publisher-verification",
+    "cancel-in-progress": false,
+  });
+  expect(job.environment).toBe("publisher");
+  expect(job.permissions).toEqual({ contents: "read" });
+  expect(job.if).toBe(
+    "github.ref == 'refs/heads/main' && github.actor_id == 2625904",
+  );
+  expect(token).toMatchObject({
+    id: "publisher-token",
+    uses: `actions/create-github-app-token@${pinnedActions["actions/create-github-app-token"]}`,
+    with: {
+      "client-id": "${{ vars.TAVERNARY_PUBLISHER_CLIENT_ID }}",
+      "private-key": "${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}",
+      owner: "MentallyQuill",
+      repositories: "Tavernary",
+      "permission-contents": "write",
+    },
+  });
+  expect(checkout).toMatchObject({
+    uses: `actions/checkout@${pinnedActions["actions/checkout"]}`,
+    with: {
+      ref: "main",
+      "fetch-depth": 0,
+      token: "${{ steps.publisher-token.outputs.token }}",
+    },
+  });
+  expect(push?.run).toContain("git commit --allow-empty");
+  expect(push?.run).toContain("git rebase --keep-empty origin/main");
+  expect(push?.run).toContain("git push origin HEAD:main");
+  expect(push?.run).not.toMatch(/--force|push\s+origin\s+\+HEAD/iu);
 });
 
 test("uses the Publisher App identity for every protected workflow dispatch", async () => {


### PR DESCRIPTION
## Summary

- add an owner-only, input-free Publisher verification workflow
- prove the Client-ID-authenticated App can make a harmless empty commit through protected main
- enforce the canary in the existing direct-writer and action-pin policy tests
- update the contributor-security contract to the current Client ID model

## Security boundaries

- protected publisher environment on main only
- actor ID 2625904 only
- ordinary GITHUB_TOKEN remains contents-read
- App token is scoped to MentallyQuill/Tavernary with Contents write
- no force push, no content mutation, automatic token revocation

## Verification

- 
pm.cmd test -- tests/unit/workflows.test.ts — 61 passed
- 
pm.cmd run check — passed
- full suite — 2,462 passed
- production build and static export — passed