### PR TITLE
feat(security): reserve automation branches for Publisher

### DIFF
--- a/.github/workflows/admit-issue.yml
+++ b/.github/workflows/admit-issue.yml
@@ -25,6 +25,9 @@ concurrency:
 
 jobs:
   admit:
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (github.event_name != 'workflow_dispatch' || github.actor_id == 2625904)
     runs-on: ubuntu-latest
     environment: publisher
     steps:
@@ -47,6 +50,20 @@ jobs:
         run: |
           echo "::error::Issue has conflicting submission routing labels."
           exit 1
+      - name: Create Tavernary Publisher dispatch token
+        id: publisher-dispatch-token
+        if: >-
+          steps.admission.outputs.admitted == 'true' &&
+          (
+            steps.admission.outputs.route == 'project' ||
+            steps.admission.outputs.route == 'project-owner' ||
+            steps.admission.outputs.route == 'kit-withdrawal'
+          )
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.TAVERNARY_PUBLISHER_CLIENT_ID }}
+          private-key: ${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}
+          permission-actions: write
       - name: Dispatch project submission triage
         if: >-
           steps.admission.outputs.admitted == 'true' &&
@@ -56,7 +73,7 @@ jobs:
           --ref main
           -f issue_number="${{ steps.admission.outputs.issue_number }}"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.publisher-dispatch-token.outputs.token }}
       - name: Dispatch Kit submission triage
         if: >-
           steps.admission.outputs.admitted == 'true' &&
@@ -67,16 +84,6 @@ jobs:
           -f issue_number="${{ steps.admission.outputs.issue_number }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Create Tavernary Publisher dispatch token
-        id: publisher-dispatch-token
-        if: >-
-          steps.admission.outputs.admitted == 'true' &&
-          steps.admission.outputs.route == 'kit-withdrawal'
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          client-id: ${{ vars.TAVERNARY_PUBLISHER_CLIENT_ID }}
-          private-key: ${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}
-          permission-actions: write
       - name: Dispatch Kit withdrawal
         if: >-
           steps.admission.outputs.admitted == 'true' &&
@@ -96,7 +103,7 @@ jobs:
           --ref "${{ github.event.repository.default_branch }}"
           -f issue_number="${{ steps.admission.outputs.issue_number }}"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.publisher-dispatch-token.outputs.token }}
       - name: Dispatch Help request triage
         if: >-
           steps.admission.outputs.admitted == 'true' &&

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,7 @@ jobs:
     if: >-
       always() &&
       github.event_name == 'workflow_dispatch' &&
+      github.ref_name != 'automation/project-submission-0' &&
       (startsWith(github.ref_name, 'automation/project-submission-') ||
        startsWith(github.ref_name, 'automation/project-owner-request-')) &&
       needs.verify.result == 'success' &&

--- a/.github/workflows/generate-project-owner-request.yml
+++ b/.github/workflows/generate-project-owner-request.yml
@@ -15,7 +15,7 @@ on:
         default: false
 
 permissions:
-  contents: write
+  contents: read
   issues: write
   pull-requests: write
   actions: write
@@ -28,16 +28,27 @@ jobs:
   generate:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    environment: publisher
     env:
       ISSUE_NUMBER: ${{ inputs.issue_number }}
       FORCE_REGENERATION: ${{ inputs.force_regeneration }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
+      - name: Create Tavernary Publisher branch token
+        id: publisher-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.TAVERNARY_PUBLISHER_CLIENT_ID }}
+          private-key: ${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}
+          owner: MentallyQuill
+          repositories: Tavernary
+          permission-contents: write
       - name: Check out full current main
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           ref: main
+          token: ${{ steps.publisher-token.outputs.token }}
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
@@ -132,8 +143,8 @@ jobs:
         run: |
           set -euo pipefail
           git fetch origin main
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "Tavernary Publisher"
+          git config user.email "tavernary-publisher[bot]@users.noreply.github.com"
           if [[ -n "$PR_NUMBER" ]]; then
             git fetch origin "refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"
             git checkout -B "$BRANCH" "origin/$BRANCH"

--- a/.github/workflows/generate-project-owner-request.yml
+++ b/.github/workflows/generate-project-owner-request.yml
@@ -26,7 +26,10 @@ concurrency:
 
 jobs:
   generate:
-    if: github.ref == 'refs/heads/main'
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (github.actor_id == 2625904 ||
+       github.actor_id == vars.TAVERNARY_PUBLISHER_BOT_ID)
     runs-on: ubuntu-latest
     environment: publisher
     env:

--- a/.github/workflows/generate-project-submission.yml
+++ b/.github/workflows/generate-project-submission.yml
@@ -15,7 +15,7 @@ on:
         default: false
 
 permissions:
-  contents: write
+  contents: read
   issues: write
   pull-requests: write
   actions: write
@@ -28,16 +28,27 @@ jobs:
   generate:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    environment: publisher
     env:
       ISSUE_NUMBER: ${{ inputs.issue_number }}
       FORCE_REGENERATION: ${{ inputs.force_regeneration }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
+      - name: Create Tavernary Publisher branch token
+        id: publisher-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.TAVERNARY_PUBLISHER_CLIENT_ID }}
+          private-key: ${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}
+          owner: MentallyQuill
+          repositories: Tavernary
+          permission-contents: write
       - name: Check out full main history
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           ref: main
+          token: ${{ steps.publisher-token.outputs.token }}
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
@@ -115,8 +126,8 @@ jobs:
         run: |
           set -euo pipefail
           git fetch origin main
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "Tavernary Publisher"
+          git config user.email "tavernary-publisher[bot]@users.noreply.github.com"
           if [[ -n "$PR_NUMBER" && -n "$REMOTE_SHA" && -n "$MARKER_SHA" ]]; then
             node scripts/submissions/reset-project-submission-branch.mjs --branch "$BRANCH"
             while IFS= read -r generated_path; do

--- a/.github/workflows/generate-project-submission.yml
+++ b/.github/workflows/generate-project-submission.yml
@@ -26,7 +26,10 @@ concurrency:
 
 jobs:
   generate:
-    if: github.ref == 'refs/heads/main'
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (github.actor_id == 2625904 ||
+       github.actor_id == vars.TAVERNARY_PUBLISHER_BOT_ID)
     runs-on: ubuntu-latest
     environment: publisher
     env:

--- a/.github/workflows/generated-project-branch-cleanup.yml
+++ b/.github/workflows/generated-project-branch-cleanup.yml
@@ -1,0 +1,145 @@
+name: "Security: Clean generated project branch"
+run-name: "Generated branch cleanup for PR #${{ inputs.pull_number }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      pull_number:
+        description: Closed generated pull request number
+        required: true
+        type: number
+      expected_branch:
+        description: Exact generated branch to clean up
+        required: true
+        type: string
+      expected_head_sha:
+        description: Exact closed pull request head SHA
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: generated-project-branch-cleanup-${{ inputs.expected_branch }}
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment: publisher
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PULL_NUMBER: ${{ inputs.pull_number }}
+      EXPECTED_BRANCH: ${{ inputs.expected_branch }}
+      EXPECTED_HEAD_SHA: ${{ inputs.expected_head_sha }}
+    steps:
+      - name: Check out trusted cleanup code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: main
+          fetch-depth: 1
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24
+      - name: Revalidate closed pull request and branch head
+        id: plan
+        shell: bash
+        run: |
+          set -euo pipefail
+          pull_path="${RUNNER_TEMP}/generated-branch-cleanup-pull.json"
+          validated_branch_path="${RUNNER_TEMP}/generated-branch-cleanup-branch.txt"
+          current_sha_path="${RUNNER_TEMP}/generated-branch-cleanup-current-sha.txt"
+          plan_path="${RUNNER_TEMP}/generated-branch-cleanup-plan.json"
+          gh api "repos/${GITHUB_REPOSITORY}/pulls/${PULL_NUMBER}" > "$pull_path"
+          node --input-type=module <<'NODE'
+          import fs from "node:fs";
+          import { planGeneratedProjectBranchCleanup } from "./scripts/security/generated-branch-custody.mjs";
+
+          const pull = JSON.parse(
+            fs.readFileSync(`${process.env.RUNNER_TEMP}/generated-branch-cleanup-pull.json`, "utf8"),
+          );
+          const validation = planGeneratedProjectBranchCleanup({
+            repository: process.env.GITHUB_REPOSITORY,
+            defaultBranch: process.env.GITHUB_REF_NAME,
+            pullNumber: Number(process.env.PULL_NUMBER),
+            expectedBranch: process.env.EXPECTED_BRANCH,
+            expectedHeadSha: process.env.EXPECTED_HEAD_SHA,
+            currentHeadSha: null,
+            pull,
+          });
+          fs.writeFileSync(
+            `${process.env.RUNNER_TEMP}/generated-branch-cleanup-branch.txt`,
+            validation.branch,
+          );
+          NODE
+          branch="$(cat "$validated_branch_path")"
+          current_sha="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/git/ref/heads/${branch}" \
+            --jq '.object.sha' 2>/dev/null || true)"
+          printf '%s' "$current_sha" > "$current_sha_path"
+          node --input-type=module <<'NODE'
+          import fs from "node:fs";
+          import { planGeneratedProjectBranchCleanup } from "./scripts/security/generated-branch-custody.mjs";
+
+          const pull = JSON.parse(
+            fs.readFileSync(`${process.env.RUNNER_TEMP}/generated-branch-cleanup-pull.json`, "utf8"),
+          );
+          const currentHeadSha = fs.readFileSync(
+            `${process.env.RUNNER_TEMP}/generated-branch-cleanup-current-sha.txt`,
+            "utf8",
+          );
+          const plan = planGeneratedProjectBranchCleanup({
+            repository: process.env.GITHUB_REPOSITORY,
+            defaultBranch: process.env.GITHUB_REF_NAME,
+            pullNumber: Number(process.env.PULL_NUMBER),
+            expectedBranch: process.env.EXPECTED_BRANCH,
+            expectedHeadSha: process.env.EXPECTED_HEAD_SHA,
+            currentHeadSha,
+            pull,
+          });
+          fs.writeFileSync(
+            `${process.env.RUNNER_TEMP}/generated-branch-cleanup-plan.json`,
+            JSON.stringify(plan),
+          );
+          fs.appendFileSync(
+            process.env.GITHUB_OUTPUT,
+            [
+              `action=${plan.action}`,
+              `branch=${plan.branch}`,
+              `expected_head_sha=${plan.expectedHeadSha}`,
+            ].join("\n") + "\n",
+          );
+          NODE
+          cat "$plan_path"
+      - name: Create Tavernary Publisher branch token
+        id: publisher-token
+        if: steps.plan.outputs.action == 'delete'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.TAVERNARY_PUBLISHER_CLIENT_ID }}
+          private-key: ${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}
+          owner: MentallyQuill
+          repositories: Tavernary
+          permission-contents: write
+      - name: Install Publisher branch credential
+        if: steps.plan.outputs.action == 'delete'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: main
+          fetch-depth: 1
+          clean: false
+          token: ${{ steps.publisher-token.outputs.token }}
+      - name: Delete exact generated branch
+        if: steps.plan.outputs.action == 'delete'
+        shell: bash
+        env:
+          BRANCH: ${{ steps.plan.outputs.branch }}
+          EXPECTED_SHA: ${{ steps.plan.outputs.expected_head_sha }}
+        run: |
+          set -euo pipefail
+          git push --force-with-lease="refs/heads/$BRANCH:$EXPECTED_SHA" \
+            origin ":refs/heads/$BRANCH"

--- a/.github/workflows/generated-project-branch-cleanup.yml
+++ b/.github/workflows/generated-project-branch-cleanup.yml
@@ -1,7 +1,12 @@
 name: "Security: Clean generated project branch"
-run-name: "Generated branch cleanup for PR #${{ inputs.pull_number }}"
+run-name: "Generated branch cleanup for PR #${{ inputs.pull_number || github.event.pull_request.number }}"
 
 on:
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - closed
   workflow_dispatch:
     inputs:
       pull_number:
@@ -22,19 +27,30 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: generated-project-branch-cleanup-${{ inputs.expected_branch }}
+  group: generated-project-branch-cleanup-${{ inputs.expected_branch || github.event.pull_request.head.ref }}
   cancel-in-progress: false
 
 jobs:
   cleanup:
-    if: github.ref == 'refs/heads/main'
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (
+        (
+          github.event_name == 'pull_request_target' &&
+          (
+            startsWith(github.event.pull_request.head.ref, 'automation/project-submission-') ||
+            startsWith(github.event.pull_request.head.ref, 'automation/project-owner-request-')
+          )
+        ) ||
+        (github.event_name == 'workflow_dispatch' && github.actor_id == 2625904)
+      )
     runs-on: ubuntu-latest
     environment: publisher
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      PULL_NUMBER: ${{ inputs.pull_number }}
-      EXPECTED_BRANCH: ${{ inputs.expected_branch }}
-      EXPECTED_HEAD_SHA: ${{ inputs.expected_head_sha }}
+      PULL_NUMBER: ${{ inputs.pull_number || github.event.pull_request.number }}
+      EXPECTED_BRANCH: ${{ inputs.expected_branch || github.event.pull_request.head.ref }}
+      EXPECTED_HEAD_SHA: ${{ inputs.expected_head_sha || github.event.pull_request.head.sha }}
     steps:
       - name: Check out trusted cleanup code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -51,9 +67,11 @@ jobs:
         run: |
           set -euo pipefail
           pull_path="${RUNNER_TEMP}/generated-branch-cleanup-pull.json"
+          repository_path="${RUNNER_TEMP}/generated-branch-cleanup-repository.json"
           validated_branch_path="${RUNNER_TEMP}/generated-branch-cleanup-branch.txt"
           current_sha_path="${RUNNER_TEMP}/generated-branch-cleanup-current-sha.txt"
           plan_path="${RUNNER_TEMP}/generated-branch-cleanup-plan.json"
+          gh api "repos/${GITHUB_REPOSITORY}" > "$repository_path"
           gh api "repos/${GITHUB_REPOSITORY}/pulls/${PULL_NUMBER}" > "$pull_path"
           node --input-type=module <<'NODE'
           import fs from "node:fs";
@@ -62,9 +80,15 @@ jobs:
           const pull = JSON.parse(
             fs.readFileSync(`${process.env.RUNNER_TEMP}/generated-branch-cleanup-pull.json`, "utf8"),
           );
+          const repository = JSON.parse(
+            fs.readFileSync(`${process.env.RUNNER_TEMP}/generated-branch-cleanup-repository.json`, "utf8"),
+          );
+          if (`refs/heads/${repository.default_branch}` !== process.env.GITHUB_REF) {
+            throw new Error("Cleanup is not running from the current default branch.");
+          }
           const validation = planGeneratedProjectBranchCleanup({
             repository: process.env.GITHUB_REPOSITORY,
-            defaultBranch: process.env.GITHUB_REF_NAME,
+            defaultBranch: repository.default_branch,
             pullNumber: Number(process.env.PULL_NUMBER),
             expectedBranch: process.env.EXPECTED_BRANCH,
             expectedHeadSha: process.env.EXPECTED_HEAD_SHA,
@@ -77,9 +101,17 @@ jobs:
           );
           NODE
           branch="$(cat "$validated_branch_path")"
-          current_sha="$(gh api \
+          ref_error_path="${RUNNER_TEMP}/generated-branch-cleanup-ref-error.txt"
+          if current_sha="$(gh api \
             "repos/${GITHUB_REPOSITORY}/git/ref/heads/${branch}" \
-            --jq '.object.sha' 2>/dev/null || true)"
+            --jq '.object.sha' 2> "$ref_error_path")"; then
+            :
+          elif grep -Fq "(HTTP 404)" "$ref_error_path"; then
+            current_sha=""
+          else
+            cat "$ref_error_path" >&2
+            exit 1
+          fi
           printf '%s' "$current_sha" > "$current_sha_path"
           node --input-type=module <<'NODE'
           import fs from "node:fs";
@@ -88,13 +120,16 @@ jobs:
           const pull = JSON.parse(
             fs.readFileSync(`${process.env.RUNNER_TEMP}/generated-branch-cleanup-pull.json`, "utf8"),
           );
+          const repository = JSON.parse(
+            fs.readFileSync(`${process.env.RUNNER_TEMP}/generated-branch-cleanup-repository.json`, "utf8"),
+          );
           const currentHeadSha = fs.readFileSync(
             `${process.env.RUNNER_TEMP}/generated-branch-cleanup-current-sha.txt`,
             "utf8",
           );
           const plan = planGeneratedProjectBranchCleanup({
             repository: process.env.GITHUB_REPOSITORY,
-            defaultBranch: process.env.GITHUB_REF_NAME,
+            defaultBranch: repository.default_branch,
             pullNumber: Number(process.env.PULL_NUMBER),
             expectedBranch: process.env.EXPECTED_BRANCH,
             expectedHeadSha: process.env.EXPECTED_HEAD_SHA,

--- a/.github/workflows/project-owner-request-lifecycle.yml
+++ b/.github/workflows/project-owner-request-lifecycle.yml
@@ -16,7 +16,6 @@ permissions:
   contents: read
   issues: write
   pull-requests: read
-  actions: write
 
 concurrency:
   group: project-owner-lifecycle-${{ inputs.pull_number || github.event.pull_request.number }}
@@ -156,16 +155,3 @@ jobs:
               -f state=closed \
               -f state_reason=not_planned
           fi
-      - name: Queue exact owner request branch cleanup
-        if: steps.plan.outputs.action != 'ignore'
-        shell: bash
-        env:
-          BRANCH: ${{ steps.plan.outputs.branch }}
-          EXPECTED_SHA: ${{ steps.plan.outputs.head_sha }}
-        run: |
-          set -euo pipefail
-          gh workflow run generated-project-branch-cleanup.yml \
-            --ref "${{ github.event.repository.default_branch || 'main' }}" \
-            -f pull_number="$PULL_NUMBER" \
-            -f expected_branch="$BRANCH" \
-            -f expected_head_sha="$EXPECTED_SHA"

--- a/.github/workflows/project-owner-request-lifecycle.yml
+++ b/.github/workflows/project-owner-request-lifecycle.yml
@@ -13,9 +13,10 @@ on:
         type: number
 
 permissions:
-  contents: write
+  contents: read
   issues: write
   pull-requests: read
+  actions: write
 
 concurrency:
   group: project-owner-lifecycle-${{ inputs.pull_number || github.event.pull_request.number }}
@@ -83,7 +84,7 @@ jobs:
               `action=${plan.action}`,
               `issue_number=${plan.issueNumber ?? ""}`,
               `branch=${plan.deleteBranch ?? ""}`,
-              `head_sha=${process.env.CLOSED_PR_HEAD_SHA}`,
+              `head_sha=${pull.head.sha}`,
               `pr_number=${pull.number}`,
               `pr_url=${pull.html_url}`,
             ].join("\n") + "\n",
@@ -155,7 +156,7 @@ jobs:
               -f state=closed \
               -f state_reason=not_planned
           fi
-      - name: Delete unchanged owner request branch
+      - name: Queue exact owner request branch cleanup
         if: steps.plan.outputs.action != 'ignore'
         shell: bash
         env:
@@ -163,12 +164,8 @@ jobs:
           EXPECTED_SHA: ${{ steps.plan.outputs.head_sha }}
         run: |
           set -euo pipefail
-          current_sha="$(gh api \
-            "repos/${GITHUB_REPOSITORY}/git/ref/heads/${BRANCH}" \
-            --jq '.object.sha' 2>/dev/null || true)"
-          if [[ -n "$current_sha" && "$current_sha" == "$EXPECTED_SHA" ]]; then
-            gh api --method DELETE \
-              "repos/${GITHUB_REPOSITORY}/git/refs/heads/${BRANCH}"
-          else
-            echo "Owner request branch moved after PR closure; leaving it intact."
-          fi
+          gh workflow run generated-project-branch-cleanup.yml \
+            --ref "${{ github.event.repository.default_branch || 'main' }}" \
+            -f pull_number="$PULL_NUMBER" \
+            -f expected_branch="$BRANCH" \
+            -f expected_head_sha="$EXPECTED_SHA"

--- a/.github/workflows/project-submission-lifecycle.yml
+++ b/.github/workflows/project-submission-lifecycle.yml
@@ -13,7 +13,7 @@ on:
         type: number
 
 permissions:
-  contents: write
+  contents: read
   issues: write
   pull-requests: read
   actions: write
@@ -133,7 +133,7 @@ jobs:
           gh workflow run retry-fork-dependencies.yml
           --ref "${{ github.event.repository.default_branch || 'main' }}"
           -f upstream_issue_number="$UPSTREAM_ISSUE_NUMBER"
-      - name: Delete unchanged generated branch
+      - name: Queue exact generated branch cleanup
         if: steps.plan.outputs.action != 'ignore'
         shell: bash
         env:
@@ -141,9 +141,8 @@ jobs:
           EXPECTED_SHA: ${{ steps.plan.outputs.head_sha }}
         run: |
           set -euo pipefail
-          current_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/${BRANCH}" --jq '.object.sha' 2>/dev/null || true)"
-          if [[ -n "$current_sha" && "$current_sha" == "$EXPECTED_SHA" ]]; then
-            gh api --method DELETE "repos/${GITHUB_REPOSITORY}/git/refs/heads/${BRANCH}"
-          else
-            echo "Generated branch moved after PR closure; leaving it intact."
-          fi
+          gh workflow run generated-project-branch-cleanup.yml \
+            --ref "${{ github.event.repository.default_branch || 'main' }}" \
+            -f pull_number="$PULL_NUMBER" \
+            -f expected_branch="$BRANCH" \
+            -f expected_head_sha="$EXPECTED_SHA"

--- a/.github/workflows/project-submission-lifecycle.yml
+++ b/.github/workflows/project-submission-lifecycle.yml
@@ -133,16 +133,3 @@ jobs:
           gh workflow run retry-fork-dependencies.yml
           --ref "${{ github.event.repository.default_branch || 'main' }}"
           -f upstream_issue_number="$UPSTREAM_ISSUE_NUMBER"
-      - name: Queue exact generated branch cleanup
-        if: steps.plan.outputs.action != 'ignore'
-        shell: bash
-        env:
-          BRANCH: ${{ steps.plan.outputs.branch }}
-          EXPECTED_SHA: ${{ steps.plan.outputs.head_sha }}
-        run: |
-          set -euo pipefail
-          gh workflow run generated-project-branch-cleanup.yml \
-            --ref "${{ github.event.repository.default_branch || 'main' }}" \
-            -f pull_number="$PULL_NUMBER" \
-            -f expected_branch="$BRANCH" \
-            -f expected_head_sha="$EXPECTED_SHA"

--- a/.github/workflows/publish-project-transaction.yml
+++ b/.github/workflows/publish-project-transaction.yml
@@ -300,10 +300,19 @@ jobs:
             `## Project publication\n\nAction: \`${plan.action}\`\n\nReason: \`${plan.reasonCode ?? "validated"}\`\n`,
           );
           NODE
+      - name: Create Tavernary Publisher regeneration token
+        id: publisher-regeneration-token
+        if: steps.plan.outputs.action == 'regenerate'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.TAVERNARY_PUBLISHER_CLIENT_ID }}
+          private-key: ${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}
+          permission-actions: write
       - name: Regenerate stale transaction
         if: steps.plan.outputs.action == 'regenerate'
         shell: bash
         env:
+          GH_TOKEN: ${{ steps.publisher-regeneration-token.outputs.token }}
           PRODUCER: ${{ steps.state.outputs.producer }}
           ISSUE_NUMBER: ${{ steps.state.outputs.issue_number }}
         run: |

--- a/.github/workflows/publisher-automation-branch-verification.yml
+++ b/.github/workflows/publisher-automation-branch-verification.yml
@@ -1,0 +1,77 @@
+name: "Security: Verify Publisher automation branches"
+run-name: "Security: Verify Publisher branch custody #${{ github.run_number }}"
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tavernary-publisher-automation-branch-verification
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    if: >-
+      github.ref == 'refs/heads/main' && github.actor_id == 2625904
+    runs-on: ubuntu-latest
+    environment: publisher
+    steps:
+      - name: Create Tavernary Publisher branch token
+        id: publisher-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.TAVERNARY_PUBLISHER_CLIENT_ID }}
+          private-key: ${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}
+          owner: MentallyQuill
+          repositories: Tavernary
+          permission-contents: write
+      - name: Verify Publisher automation branch custody
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.publisher-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          branch=automation/project-submission-0
+          ref_read_endpoint="repos/${GITHUB_REPOSITORY}/git/ref/heads/${branch}"
+          ref_write_endpoint="repos/${GITHUB_REPOSITORY}/git/refs/heads/${branch}"
+          cleanup() {
+            gh api --method DELETE "$ref_write_endpoint" > /dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+          cleanup
+
+          main_sha="$(gh api "repos/${GITHUB_REPOSITORY}/commits/main" --jq '.sha')"
+          tree_sha="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/git/commits/${main_sha}" \
+            --jq '.tree.sha')"
+          commit_path="${RUNNER_TEMP}/publisher-branch-canary-commit.json"
+          jq -n \
+            --arg message "chore(security): verify Publisher branch custody" \
+            --arg tree "$tree_sha" \
+            --arg parent "$main_sha" \
+            '{message: $message, tree: $tree, parents: [$parent]}' \
+            > "$commit_path"
+          canary_sha="$(gh api --method POST \
+            "repos/${GITHUB_REPOSITORY}/git/commits" \
+            --input "$commit_path" --jq '.sha')"
+
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+            -f ref="refs/heads/$branch" \
+            -f sha="$main_sha" > /dev/null
+          gh api --method PATCH "$ref_write_endpoint" \
+            -f sha="$canary_sha" \
+            -F force=false > /dev/null
+          published_sha="$(gh api "$ref_read_endpoint" --jq '.object.sha')"
+          if [[ "$published_sha" != "$canary_sha" ]]; then
+            echo "::error::Publisher canary branch did not reach the expected SHA."
+            exit 1
+          fi
+
+          gh api --method DELETE "$ref_write_endpoint"
+          trap - EXIT
+          if gh api "$ref_read_endpoint" > /dev/null 2>&1; then
+            echo "::error::Publisher canary branch still exists after deletion."
+            exit 1
+          fi

--- a/.github/workflows/triage-project-owner-request.yml
+++ b/.github/workflows/triage-project-owner-request.yml
@@ -12,7 +12,6 @@ on:
 permissions:
   contents: read
   issues: write
-  actions: write
 
 concurrency:
   group: project-owner-triage-${{ inputs.issue_number }}
@@ -20,7 +19,12 @@ concurrency:
 
 jobs:
   validate:
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (github.actor_id == 2625904 ||
+       github.actor_id == vars.TAVERNARY_PUBLISHER_BOT_ID)
     runs-on: ubuntu-latest
+    environment: publisher
     steps:
       - name: Check out default branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -194,10 +198,20 @@ jobs:
             `admitted=${decision.status === "admitted"}\nissue_number=${issueNumber}\n`,
           );
           NODE
+      - name: Create Tavernary Publisher dispatch token
+        id: publisher-dispatch-token
+        if: steps.triage.outputs.admitted == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.TAVERNARY_PUBLISHER_CLIENT_ID }}
+          private-key: ${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}
+          owner: MentallyQuill
+          repositories: Tavernary
+          permission-actions: write
       - name: Generate admitted owner request
         if: steps.triage.outputs.admitted == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.publisher-dispatch-token.outputs.token }}
           ISSUE_NUMBER: ${{ inputs.issue_number }}
         run: >
           gh workflow run generate-project-owner-request.yml

--- a/.github/workflows/triage-submission.yml
+++ b/.github/workflows/triage-submission.yml
@@ -12,7 +12,6 @@ on:
 permissions:
   contents: read
   issues: write
-  actions: write
 
 concurrency:
   group: triage-project-${{ inputs.issue_number }}
@@ -20,7 +19,12 @@ concurrency:
 
 jobs:
   validate:
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (github.actor_id == 2625904 ||
+       github.actor_id == vars.TAVERNARY_PUBLISHER_BOT_ID)
     runs-on: ubuntu-latest
+    environment: publisher
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -34,10 +38,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ inputs.issue_number }}
+      - name: Create Tavernary Publisher dispatch token
+        id: publisher-dispatch-token
+        if: steps.triage.outputs.admitted == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.TAVERNARY_PUBLISHER_CLIENT_ID }}
+          private-key: ${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}
+          owner: MentallyQuill
+          repositories: Tavernary
+          permission-actions: write
       - name: Generate admitted submission
         if: steps.triage.outputs.admitted == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.publisher-dispatch-token.outputs.token }}
           ISSUE_NUMBER: ${{ steps.triage.outputs.issue_number }}
         run: >
           gh workflow run generate-project-submission.yml

--- a/docs/superpowers/plans/2026-08-17-publisher-automation-branch-custody.md
+++ b/docs/superpowers/plans/2026-08-17-publisher-automation-branch-custody.md
@@ -1,0 +1,230 @@
+# Publisher Automation Branch Custody Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the Tavernary Publisher App exclusive custody of generated project-review branches without restricting ordinary contributor branches.
+
+**Architecture:** Main-only generation jobs persist a short-lived Publisher token as their Git credential while ordinary `GITHUB_TOKEN` remains limited to non-content APIs. Closed-PR jobs queue a separate main-only cleanup workflow that revalidates exact PR and ref state before deleting with the App. A narrowly targeted live ruleset then restricts both generated namespaces to the Publisher integration.
+
+**Tech Stack:** GitHub Actions YAML, `actions/create-github-app-token`, Node.js 24 ESM, Vitest, GitHub REST API, GitHub rulesets, GitHub CLI.
+
+## Global Constraints
+
+- Keep `TAVERNARY_PUBLISHER_APP_PRIVATE_KEY` only in the main-only `publisher` environment.
+- Use `vars.TAVERNARY_PUBLISHER_CLIENT_ID`; do not use the deprecated App ID input.
+- Give the shared `GITHUB_TOKEN` only Contents Read in generation and cleanup workflows.
+- Never add GitHub Actions, `MentallyQuill`, or a repository role as a generated-branch bypass actor.
+- Reserve `automation/project-submission-0` exclusively for live Publisher verification.
+- Leave TavernKeeper source and live settings unchanged.
+- Use GitHub CLI with network permission enabled for every remote operation.
+
+---
+
+### Task 1: Define generated-branch custody behavior
+
+**Files:**
+- Create: `scripts/security/generated-branch-custody.mjs`
+- Create: `scripts/security/generated-branch-custody.d.mts`
+- Create: `tests/unit/generated-branch-custody.test.ts`
+
+**Interfaces:**
+- Consumes: closed pull-request JSON and exact expected branch/SHA inputs.
+- Produces: `planGeneratedProjectBranchCleanup(input)` returning action `delete`, `absent`, or `moved` with the validated branch and SHA.
+
+- [ ] **Step 1: Write failing behavior tests**
+
+Cover an exact same-repository closed PR, absent ref, moved ref, open PR, foreign
+head repository, wrong base, mismatched PR head, SHA injection, branch-path
+injection, branch zero, and both approved numeric namespace forms. Expected
+values must be literal and independent of the implementation.
+
+- [ ] **Step 2: Run the focused test and observe Red**
+
+Run: `npm.cmd test -- tests/unit/generated-branch-custody.test.ts`
+
+Expected: FAIL because `scripts/security/generated-branch-custody.mjs` does not
+exist.
+
+- [ ] **Step 3: Implement the minimum planner**
+
+Export:
+
+```js
+planGeneratedProjectBranchCleanup({
+  repository,
+  defaultBranch,
+  pullNumber,
+  expectedBranch,
+  expectedHeadSha,
+  currentHeadSha,
+  pull,
+})
+```
+
+Accept only positive issue-number branches, lowercase or uppercase 40-character
+hex SHAs, a closed same-repository pull request targeting the default branch,
+and exact head ref/SHA equality. Return `absent` for no current ref and `moved`
+for a changed ref; return `delete` only for complete equality.
+
+- [ ] **Step 4: Run the focused test and observe Green**
+
+Run: `npm.cmd test -- tests/unit/generated-branch-custody.test.ts`
+
+Expected: PASS.
+
+### Task 2: Move generation and cleanup Git writes to the Publisher App
+
+**Files:**
+- Modify: `.github/workflows/generate-project-submission.yml`
+- Modify: `.github/workflows/generate-project-owner-request.yml`
+- Modify: `.github/workflows/project-submission-lifecycle.yml`
+- Modify: `.github/workflows/project-owner-request-lifecycle.yml`
+- Create: `.github/workflows/generated-project-branch-cleanup.yml`
+- Modify: `tests/unit/generated-branch-custody.test.ts`
+
+**Interfaces:**
+- Consumes: the existing main-only `publisher` environment and App credentials.
+- Produces: App-authenticated Git branch pushes and exact-state cleanup dispatches.
+
+- [ ] **Step 1: Add failing parsed-workflow contracts**
+
+Require both generators to use environment `publisher`, root Contents Read,
+the pinned Publisher token action with Contents Write, and App-token checkout
+credentials while retaining ordinary `GH_TOKEN` for Issues/PR/Actions calls.
+Require both lifecycle workflows to queue the cleanup workflow instead of
+deleting refs. Require cleanup to run only from `main`, use the Publisher
+environment, call the planner, and expose the App token only to the delete step.
+
+- [ ] **Step 2: Run the focused workflow test and observe Red**
+
+Run: `npm.cmd test -- tests/unit/generated-branch-custody.test.ts tests/unit/workflows.test.ts`
+
+Expected: FAIL on the missing App custody and cleanup workflow.
+
+- [ ] **Step 3: Implement App-owned generation**
+
+Add the pinned `actions/create-github-app-token` step before checkout in each
+generator, request only `permission-contents: write`, pass the token to checkout,
+set the job environment to `publisher`, reduce root Contents to Read, and use the
+`Tavernary Publisher` Git identity.
+
+- [ ] **Step 4: Implement main-only App cleanup**
+
+Replace direct lifecycle deletion with `gh workflow run
+generated-project-branch-cleanup.yml --ref main` and exact pull/branch/SHA
+inputs. The cleanup workflow re-fetches PR/ref state, invokes the planner, mints
+the Publisher token only after a `delete` plan, and performs one exact ref delete.
+
+- [ ] **Step 5: Run focused tests and observe Green**
+
+Run: `npm.cmd test -- tests/unit/generated-branch-custody.test.ts tests/unit/workflows.test.ts tests/unit/project-submission-lifecycle.test.ts tests/unit/project-owner-lifecycle.test.ts`
+
+Expected: PASS.
+
+### Task 3: Add repeatable App branch canary
+
+**Files:**
+- Create: `.github/workflows/publisher-automation-branch-verification.yml`
+- Modify: `.github/workflows/ci.yml`
+- Modify: `tests/unit/generated-branch-custody.test.ts`
+
+**Interfaces:**
+- Consumes: Publisher Contents-write token and current `main` tree.
+- Produces: create/update/delete proof for `automation/project-submission-0`.
+
+- [ ] **Step 1: Add the failing canary contract**
+
+Require an owner-only, input-free, main-only workflow using environment
+`publisher`; require an App-created empty commit, ref create, fast-forward ref
+update, exact SHA readback, and trap-backed deletion. Require CI publication
+dispatch to exclude exactly `automation/project-submission-0`.
+
+- [ ] **Step 2: Run the focused test and observe Red**
+
+Run: `npm.cmd test -- tests/unit/generated-branch-custody.test.ts`
+
+Expected: FAIL because the canary workflow and CI exclusion are absent.
+
+- [ ] **Step 3: Implement the canary and CI exclusion**
+
+Use GitHub's Git database API with the Publisher token to create a commit whose
+tree equals current `main`, create the reserved ref at current `main`, update it
+to the empty child commit with `force=false`, verify the head, and delete it.
+Exclude only the reserved branch from automatic publication dispatch.
+
+- [ ] **Step 4: Run focused tests and observe Green**
+
+Run: `npm.cmd test -- tests/unit/generated-branch-custody.test.ts tests/unit/workflows.test.ts`
+
+Expected: PASS.
+
+### Task 4: Verify and merge source hardening
+
+**Files:**
+- Verify: all branch changes.
+
+**Interfaces:**
+- Consumes: Tasks 1-3.
+- Produces: merged main-only Publisher custody workflows.
+
+- [ ] **Step 1: Run repository verification**
+
+Run: `npm.cmd run format:check`
+
+Run: `npm.cmd run lint`
+
+Run: `npm.cmd run typecheck`
+
+Run: `npm.cmd test`
+
+Run: `git diff --check`
+
+Expected: every command exits zero.
+
+- [ ] **Step 2: Review the complete diff**
+
+Reject credential exposure, pull-request environment access, generic Actions
+bypass, unpinned actions, unsafe branch interpolation, non-exact deletion, and
+changes outside Tavernary's generated project branch boundary.
+
+- [ ] **Step 3: Push, open a PR, verify checks, and merge**
+
+Push the tested head, open a PR to `main`, wait for required `verify` and
+`visual`, merge through the owner PR-only bypass, and verify the merge SHA is
+current `main`.
+
+### Task 5: Activate and prove the live ruleset
+
+**Files:**
+- Live GitHub state only.
+
+**Interfaces:**
+- Consumes: merged workflows and Tavernary Publisher Integration ID `4624827`.
+- Produces: active generated-branch ruleset plus positive and negative canaries.
+
+- [ ] **Step 1: Create the narrow active ruleset**
+
+Target only `refs/heads/automation/project-submission-*` and
+`refs/heads/automation/project-owner-request-*`; add creation, update, deletion,
+and non-fast-forward rules; give only Integration ID `4624827` an `always`
+bypass.
+
+- [ ] **Step 2: Run the positive App canary**
+
+Dispatch `publisher-automation-branch-verification.yml` from `main`; verify the
+run succeeds, the create/update/delete calls use the Publisher identity, token
+revocation succeeds, and the reserved branch is absent afterward.
+
+- [ ] **Step 3: Run the negative ordinary-token canary**
+
+Attempt to create `automation/project-submission-0` from current `main` using
+the authenticated `MentallyQuill` Git credential. Expected: GitHub rejects the
+push under the generated-branch ruleset and no ref is created.
+
+- [ ] **Step 4: Re-audit both repositories**
+
+Verify Tavernary's new ruleset target/rules/bypass, unchanged `main` ruleset,
+ordinary feature-branch freedom, pending automation branch coverage, main-only
+Publisher environment, and absent reserved canary ref. Verify TavernKeeper has
+only its existing `main` ruleset and no generated automation branches.
+

--- a/docs/superpowers/plans/2026-08-17-publisher-automation-branch-custody.md
+++ b/docs/superpowers/plans/2026-08-17-publisher-automation-branch-custody.md
@@ -113,7 +113,8 @@ set the job environment to `publisher`, reduce root Contents to Read, and use th
 Replace direct lifecycle deletion with `gh workflow run
 generated-project-branch-cleanup.yml --ref main` and exact pull/branch/SHA
 inputs. The cleanup workflow re-fetches PR/ref state, invokes the planner, mints
-the Publisher token only after a `delete` plan, and performs one exact ref delete.
+the Publisher token only after a `delete` plan, and performs one exact-SHA
+`--force-with-lease` ref delete.
 
 - [ ] **Step 5: Run focused tests and observe Green**
 
@@ -227,4 +228,3 @@ Verify Tavernary's new ruleset target/rules/bypass, unchanged `main` ruleset,
 ordinary feature-branch freedom, pending automation branch coverage, main-only
 Publisher environment, and absent reserved canary ref. Verify TavernKeeper has
 only its existing `main` ruleset and no generated automation branches.
-

--- a/docs/superpowers/plans/2026-08-17-publisher-automation-branch-custody.md
+++ b/docs/superpowers/plans/2026-08-17-publisher-automation-branch-custody.md
@@ -4,7 +4,7 @@
 
 **Goal:** Give the Tavernary Publisher App exclusive custody of generated project-review branches without restricting ordinary contributor branches.
 
-**Architecture:** Main-only generation jobs persist a short-lived Publisher token as their Git credential while ordinary `GITHUB_TOKEN` remains limited to non-content APIs. Closed-PR jobs queue a separate main-only cleanup workflow that revalidates exact PR and ref state before deleting with the App. A narrowly targeted live ruleset then restricts both generated namespaces to the Publisher integration.
+**Architecture:** Main-only generation jobs persist a short-lived Publisher token as their Git credential while ordinary `GITHUB_TOKEN` remains limited to non-content APIs. Admission and triage use Actions-only Publisher tokens, and every privileged target accepts only the owner or Publisher actor. A trusted `pull_request_target` cleanup workflow revalidates exact repository, PR, and ref state before deleting with the App. A narrowly targeted live ruleset then restricts both generated namespaces to the Publisher integration.
 
 **Tech Stack:** GitHub Actions YAML, `actions/create-github-app-token`, Node.js 24 ESM, Vitest, GitHub REST API, GitHub rulesets, GitHub CLI.
 
@@ -77,6 +77,9 @@ Expected: PASS.
 **Files:**
 - Modify: `.github/workflows/generate-project-submission.yml`
 - Modify: `.github/workflows/generate-project-owner-request.yml`
+- Modify: `.github/workflows/admit-issue.yml`
+- Modify: `.github/workflows/triage-submission.yml`
+- Modify: `.github/workflows/triage-project-owner-request.yml`
 - Modify: `.github/workflows/project-submission-lifecycle.yml`
 - Modify: `.github/workflows/project-owner-request-lifecycle.yml`
 - Create: `.github/workflows/generated-project-branch-cleanup.yml`
@@ -84,16 +87,20 @@ Expected: PASS.
 
 **Interfaces:**
 - Consumes: the existing main-only `publisher` environment and App credentials.
-- Produces: App-authenticated Git branch pushes and exact-state cleanup dispatches.
+- Produces: App-authenticated Git branch pushes, App-authenticated trusted dispatches, and exact-state cleanup.
 
 - [ ] **Step 1: Add failing parsed-workflow contracts**
 
-Require both generators to use environment `publisher`, root Contents Read,
+Require both generators to accept only `MentallyQuill` or the Publisher actor,
+use environment `publisher`, root Contents Read,
 the pinned Publisher token action with Contents Write, and App-token checkout
 credentials while retaining ordinary `GH_TOKEN` for Issues/PR/Actions calls.
-Require both lifecycle workflows to queue the cleanup workflow instead of
-deleting refs. Require cleanup to run only from `main`, use the Publisher
-environment, call the planner, and expose the App token only to the delete step.
+Require admission and triage to dispatch privileged targets with Actions-only
+Publisher tokens and reject shared Actions callers. Require lifecycle workflows
+to leave ref cleanup to trusted default-branch code. Require cleanup to run from
+`main` via `pull_request_target` or an owner-only manual dispatch, use the
+Publisher environment, call the planner, and expose the App token only to the
+delete step.
 
 - [ ] **Step 2: Run the focused workflow test and observe Red**
 
@@ -110,11 +117,12 @@ set the job environment to `publisher`, reduce root Contents to Read, and use th
 
 - [ ] **Step 4: Implement main-only App cleanup**
 
-Replace direct lifecycle deletion with `gh workflow run
-generated-project-branch-cleanup.yml --ref main` and exact pull/branch/SHA
-inputs. The cleanup workflow re-fetches PR/ref state, invokes the planner, mints
-the Publisher token only after a `delete` plan, and performs one exact-SHA
-`--force-with-lease` ref delete.
+Remove ref mutation from lifecycle jobs. The cleanup workflow runs trusted
+default-branch code on closed `pull_request_target` events, re-fetches the
+repository default branch plus PR/ref state, invokes the planner, mints the
+Publisher token only after a `delete` plan, and performs one exact-SHA
+`--force-with-lease` ref delete. Only HTTP 404 is an absent ref; other API errors
+fail closed.
 
 - [ ] **Step 5: Run focused tests and observe Green**
 

--- a/docs/superpowers/specs/2026-08-16-github-contributor-security-policy-design.md
+++ b/docs/superpowers/specs/2026-08-16-github-contributor-security-policy-design.md
@@ -135,11 +135,14 @@ Apply these repository-level settings to both repositories:
 - require workflow approval for all external fork contributors;
 - automatically delete head branches after pull requests merge.
 
-The workflow audit found no `pull_request_target` triggers. Pull-request
-validation uses read-only contents, and all external action references are
-SHA-pinned `actions/*` dependencies. A trusted Write collaborator's same-repo
-pull-request checks therefore run normally, while untrusted fork workflows
-require approval.
+The sole `pull_request_target` trigger is the generated-project branch cleanup
+workflow. It runs trusted default-branch code for closed PRs, never checks out or
+executes pull-request head code, revalidates exact same-repository PR/ref state,
+and uses the Publisher token only for an atomic exact-SHA delete. Other
+pull-request validation uses read-only contents, and all external action
+references are SHA-pinned `actions/*` dependencies. A trusted Write
+collaborator's same-repository pull-request checks therefore run normally, while
+untrusted fork workflows require approval.
 
 ## Existing Security Controls
 

--- a/docs/superpowers/specs/2026-08-17-publisher-automation-branch-custody-design.md
+++ b/docs/superpowers/specs/2026-08-17-publisher-automation-branch-custody-design.md
@@ -34,6 +34,12 @@ Contents-write Publisher installation token, and gives that token only to
 `actions/checkout` for persisted Git credentials. Root `GITHUB_TOKEN` Contents
 permission is reduced from Write to Read.
 
+Generation jobs accept dispatches only from `MentallyQuill` or the unique
+Tavernary Publisher bot. The trusted automatic chain uses Actions-only Publisher
+tokens for `admit-issue.yml` -> project triage -> project generation. Manual
+admission reruns are owner-only. The shared `github-actions[bot]` identity is
+never accepted by a Publisher-credentialed triage or generation job.
+
 The Publisher private key remains available only through the environment whose
 sole deployment branch policy is `main`. It is not copied into repository
 secrets and the environment is not widened to `refs/pull/*/merge`.
@@ -41,10 +47,17 @@ secrets and the environment is not widened to `refs/pull/*/merge`.
 ## Lifecycle cleanup
 
 Closed-PR lifecycle workflows must not access Publisher credentials from a
-pull-request ref. They continue to process issue state with ordinary
-`GITHUB_TOKEN`, then dispatch a dedicated cleanup workflow on `main`.
+pull-request merge ref. They continue to process issue state with ordinary
+`GITHUB_TOKEN` and never mutate generated refs.
 
-The cleanup workflow re-reads the closed pull request and current branch ref. It
+A dedicated `pull_request_target` cleanup workflow runs trusted default-branch
+code for closed pull requests targeting `main`. It never checks out or executes
+the pull-request head. Because `pull_request_target` uses the base ref, the
+main-only Publisher environment remains available without widening its branch
+policy. Manual cleanup dispatch is restricted to `MentallyQuill` on `main`.
+
+The cleanup workflow re-reads the repository default branch, closed pull
+request, and current branch ref. It
 deletes only when all of these values match:
 
 - the branch exactly matches `automation/project-submission-<positive integer>`
@@ -56,7 +69,9 @@ deletes only when all of these values match:
 
 A missing or moved branch is a successful no-op. Only the final delete call uses
 the Publisher token. Deletion uses Git's exact-SHA `--force-with-lease` form, so
-the remote rejects the delete atomically if the ref moves after validation.
+the remote rejects the delete atomically if the ref moves after validation. Only
+an HTTP 404 ref read is treated as absent; authentication, rate-limit, and server
+errors fail the cleanup before token minting.
 
 ## Branch ruleset
 

--- a/docs/superpowers/specs/2026-08-17-publisher-automation-branch-custody-design.md
+++ b/docs/superpowers/specs/2026-08-17-publisher-automation-branch-custody-design.md
@@ -55,7 +55,8 @@ deletes only when all of these values match:
 - the current branch ref still equals that exact SHA.
 
 A missing or moved branch is a successful no-op. Only the final delete call uses
-the Publisher token.
+the Publisher token. Deletion uses Git's exact-SHA `--force-with-lease` form, so
+the remote rejects the delete atomically if the ref moves after validation.
 
 ## Branch ruleset
 
@@ -99,4 +100,3 @@ Workflow authentication lands and passes before the ruleset is created. If the
 App canary fails after activation, disable only the new automation-branch
 ruleset, diagnose the exact App token or ref operation, and leave the existing
 `main` ruleset intact. Never broaden the bypass to GitHub Actions as a shortcut.
-

--- a/docs/superpowers/specs/2026-08-17-publisher-automation-branch-custody-design.md
+++ b/docs/superpowers/specs/2026-08-17-publisher-automation-branch-custody-design.md
@@ -1,0 +1,102 @@
+# Publisher Automation Branch Custody Design
+
+**Status:** Approved on 2026-08-17
+**Repositories:** `MentallyQuill/Tavernary`, `MentallyQuill/TavernKeeper`
+
+## Goal
+
+Prevent trusted Write collaborators from creating, replacing, updating, force
+pushing, or deleting Tavernary's generated project-review branches while
+preserving their ability to create ordinary same-repository feature branches and
+submit pull requests to protected `main`.
+
+## Repository scope
+
+Tavernary owns two generated branch namespaces:
+
+- `automation/project-submission-*`;
+- `automation/project-owner-request-*`.
+
+TavernKeeper has no equivalent generated-branch publication path. Its Publisher
+continues to write validated operational changes directly to protected `main`,
+so TavernKeeper receives no new branch ruleset or workflow change.
+
+## Authority model
+
+The Tavernary Publisher App becomes the sole writer and deleter for both
+generated namespaces. Ordinary `GITHUB_TOKEN` remains responsible for Issues,
+Pull requests, and Actions APIs, but never authenticates Git branch creation,
+update, force-with-lease regeneration, or deletion in those namespaces.
+
+Generation runs remain `workflow_dispatch` jobs pinned to `main`. Each generation
+job uses the existing main-only `publisher` environment, creates a short-lived
+Contents-write Publisher installation token, and gives that token only to
+`actions/checkout` for persisted Git credentials. Root `GITHUB_TOKEN` Contents
+permission is reduced from Write to Read.
+
+The Publisher private key remains available only through the environment whose
+sole deployment branch policy is `main`. It is not copied into repository
+secrets and the environment is not widened to `refs/pull/*/merge`.
+
+## Lifecycle cleanup
+
+Closed-PR lifecycle workflows must not access Publisher credentials from a
+pull-request ref. They continue to process issue state with ordinary
+`GITHUB_TOKEN`, then dispatch a dedicated cleanup workflow on `main`.
+
+The cleanup workflow re-reads the closed pull request and current branch ref. It
+deletes only when all of these values match:
+
+- the branch exactly matches `automation/project-submission-<positive integer>`
+  or `automation/project-owner-request-<positive integer>`;
+- the pull request is closed, belongs to Tavernary, and targets the default
+  branch;
+- the pull request head repository, branch, and SHA match the requested cleanup;
+- the current branch ref still equals that exact SHA.
+
+A missing or moved branch is a successful no-op. Only the final delete call uses
+the Publisher token.
+
+## Branch ruleset
+
+Create one active Tavernary branch ruleset targeting only:
+
+- `refs/heads/automation/project-submission-*`;
+- `refs/heads/automation/project-owner-request-*`.
+
+The ruleset restricts creation, updates, and deletion and blocks
+non-fast-forward updates. Tavernary Publisher Integration ID `4624827` is the
+only bypass actor, with mode `always`. Neither `MentallyQuill`, repository
+administrators, repository roles, nor the shared GitHub Actions integration
+receive bypass.
+
+The existing `main` ruleset remains unchanged. No rule targets ordinary branches
+such as `feat/*`, `fix/*`, `codex/*`, or contributor-named branches.
+
+## Verification
+
+Add an owner-only manual canary that runs from `main`, uses the protected
+Publisher environment, and exercises App-authenticated create, fast-forward
+update, and deletion on the reserved branch
+`automation/project-submission-0`. The canary creates an empty commit with the
+current `main` tree so it changes no repository content. CI must never dispatch
+automatic publication for this reserved branch.
+
+After the workflow changes merge and the ruleset is active:
+
+1. the Publisher canary must create, update, and remove the reserved branch;
+2. an ordinary `MentallyQuill` Git push attempting to create that same branch
+   must fail with repository-rule enforcement;
+3. live rule inspection must show only the two generated namespaces and only
+   Publisher Integration ID `4624827` as bypass;
+4. ordinary feature-branch creation and the protected `main` ruleset must remain
+   unchanged;
+5. TavernKeeper must still have no automation-namespace ruleset.
+
+## Failure and rollback
+
+Workflow authentication lands and passes before the ruleset is created. If the
+App canary fails after activation, disable only the new automation-branch
+ruleset, diagnose the exact App token or ref operation, and leave the existing
+`main` ruleset intact. Never broaden the bypass to GitHub Actions as a shortcut.
+

--- a/scripts/security/generated-branch-custody.d.mts
+++ b/scripts/security/generated-branch-custody.d.mts
@@ -1,0 +1,36 @@
+export type GeneratedProjectBranchCleanupPlan =
+  | {
+      action: "delete" | "absent";
+      branch: string;
+      expectedHeadSha: string;
+    }
+  | {
+      action: "moved";
+      branch: string;
+      expectedHeadSha: string;
+      currentHeadSha: string;
+    };
+
+export type GeneratedProjectBranchCleanupPull = {
+  number: number;
+  state: string;
+  head?: {
+    ref?: string;
+    sha?: string;
+    repo?: { full_name?: string | null } | null;
+  } | null;
+  base?: {
+    ref?: string;
+    repo?: { full_name?: string | null } | null;
+  } | null;
+};
+
+export function planGeneratedProjectBranchCleanup(input: {
+  repository: string;
+  defaultBranch: string;
+  pullNumber: number;
+  expectedBranch: string;
+  expectedHeadSha: string;
+  currentHeadSha: string | null;
+  pull: GeneratedProjectBranchCleanupPull;
+}): GeneratedProjectBranchCleanupPlan;

--- a/scripts/security/generated-branch-custody.mjs
+++ b/scripts/security/generated-branch-custody.mjs
@@ -1,0 +1,95 @@
+const generatedProjectBranchPattern =
+  /^automation\/(?:project-submission|project-owner-request)-[1-9]\d*$/u;
+const objectShaPattern = /^[0-9a-f]{40}$/iu;
+
+function requireNonEmptyString(value, label) {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${label} must be a non-empty string.`);
+  }
+  return value;
+}
+
+function normalizeObjectSha(value, label) {
+  if (typeof value !== "string" || !objectShaPattern.test(value)) {
+    throw new Error(`${label} must be a 40-character hexadecimal SHA.`);
+  }
+  return value.toLowerCase();
+}
+
+function sameRepository(left, right) {
+  return left.toLowerCase() === right.toLowerCase();
+}
+
+export function planGeneratedProjectBranchCleanup(input) {
+  const repository = requireNonEmptyString(input?.repository, "repository");
+  const defaultBranch = requireNonEmptyString(
+    input?.defaultBranch,
+    "default branch",
+  );
+  const expectedBranch = requireNonEmptyString(
+    input?.expectedBranch,
+    "expected branch",
+  );
+  if (!generatedProjectBranchPattern.test(expectedBranch)) {
+    throw new Error("Expected branch is not a generated project branch.");
+  }
+  if (!Number.isSafeInteger(input?.pullNumber) || input.pullNumber <= 0) {
+    throw new Error("Pull request number must be a positive integer.");
+  }
+
+  const expectedHeadSha = normalizeObjectSha(
+    input?.expectedHeadSha,
+    "expected head SHA",
+  );
+  const pull = input?.pull;
+  if (!pull || typeof pull !== "object") {
+    throw new Error("Pull request state is required.");
+  }
+  if (pull.number !== input.pullNumber) {
+    throw new Error("Pull request number does not match the cleanup request.");
+  }
+  if (pull.state !== "closed") {
+    throw new Error("Generated branch cleanup requires a closed pull request.");
+  }
+
+  const headRepository = requireNonEmptyString(
+    pull.head?.repo?.full_name,
+    "pull request head repository",
+  );
+  if (!sameRepository(headRepository, repository)) {
+    throw new Error("Pull request head repository is outside this repository.");
+  }
+  const baseRepository = requireNonEmptyString(
+    pull.base?.repo?.full_name,
+    "pull request base repository",
+  );
+  if (!sameRepository(baseRepository, repository)) {
+    throw new Error("Pull request base repository is outside this repository.");
+  }
+  if (pull.base?.ref !== defaultBranch) {
+    throw new Error("Pull request does not target the default branch.");
+  }
+  if (pull.head?.ref !== expectedBranch) {
+    throw new Error("Pull request head branch does not match cleanup input.");
+  }
+  const pullHeadSha = normalizeObjectSha(
+    pull.head?.sha,
+    "pull request head SHA",
+  );
+  if (pullHeadSha !== expectedHeadSha) {
+    throw new Error("Pull request head SHA does not match cleanup input.");
+  }
+
+  const common = { branch: expectedBranch, expectedHeadSha };
+  if (input.currentHeadSha === null || input.currentHeadSha === "") {
+    return { action: "absent", ...common };
+  }
+  const currentHeadSha = normalizeObjectSha(
+    input.currentHeadSha,
+    "current head SHA",
+  );
+  if (currentHeadSha !== expectedHeadSha) {
+    return { action: "moved", ...common, currentHeadSha };
+  }
+  return { action: "delete", ...common };
+}

--- a/tests/unit/generated-branch-custody.test.ts
+++ b/tests/unit/generated-branch-custody.test.ts
@@ -1,9 +1,32 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
 import { describe, expect, test } from "vitest";
+import { parse } from "yaml";
 
 import { planGeneratedProjectBranchCleanup } from "../../scripts/security/generated-branch-custody.mjs";
 
 const repository = "MentallyQuill/Tavernary";
 const headSha = "a".repeat(40);
+const workflowDirectory = resolve(".github/workflows");
+const publisherTokenAction =
+  "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1";
+
+type WorkflowStep = {
+  id?: string;
+  if?: string;
+  name?: string;
+  uses?: string;
+  run?: string;
+  env?: Record<string, string>;
+  with?: Record<string, string>;
+};
+
+async function workflow(name: string) {
+  return parse(
+    await readFile(resolve(workflowDirectory, `${name}.yml`), "utf8"),
+  );
+}
 
 function pull(overrides: Record<string, unknown> = {}) {
   return {
@@ -193,5 +216,210 @@ describe("generated project branch cleanup", () => {
         input({ currentHeadSha: `${headSha};echo unsafe` }),
       ),
     ).toThrow("current head SHA");
+  });
+});
+
+describe("generated project branch workflow custody", () => {
+  test.each(["generate-project-submission", "generate-project-owner-request"])(
+    "uses the Publisher App as the persisted Git writer in %s",
+    async (name) => {
+      const document = await workflow(name);
+      const job = document.jobs.generate as {
+        environment?: string;
+        env?: Record<string, string>;
+        steps: WorkflowStep[];
+      };
+      const token = job.steps.find((step) => step.id === "publisher-token");
+      const checkout = job.steps.find((step) =>
+        step.uses?.startsWith("actions/checkout@"),
+      );
+      const source = await readFile(
+        resolve(workflowDirectory, `${name}.yml`),
+        "utf8",
+      );
+
+      expect(document.permissions).toEqual({
+        contents: "read",
+        issues: "write",
+        "pull-requests": "write",
+        actions: "write",
+      });
+      expect(job.environment).toBe("publisher");
+      expect(job.env?.GH_TOKEN).toBe("${{ secrets.GITHUB_TOKEN }}");
+      expect(token).toMatchObject({
+        uses: publisherTokenAction,
+        with: {
+          "client-id": "${{ vars.TAVERNARY_PUBLISHER_CLIENT_ID }}",
+          "private-key": "${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}",
+          owner: "MentallyQuill",
+          repositories: "Tavernary",
+          "permission-contents": "write",
+        },
+      });
+      expect(checkout?.with?.token).toBe(
+        "${{ steps.publisher-token.outputs.token }}",
+      );
+      expect(job.steps.indexOf(token as WorkflowStep)).toBeLessThan(
+        job.steps.indexOf(checkout as WorkflowStep),
+      );
+      expect(source).toContain('git config user.name "Tavernary Publisher"');
+      expect(source).toContain(
+        'git config user.email "tavernary-publisher[bot]@users.noreply.github.com"',
+      );
+      expect(source).not.toContain(
+        'git config user.name "github-actions[bot]"',
+      );
+    },
+  );
+
+  test.each([
+    "project-submission-lifecycle",
+    "project-owner-request-lifecycle",
+  ])("queues exact-state App cleanup from %s", async (name) => {
+    const document = await workflow(name);
+    const source = await readFile(
+      resolve(workflowDirectory, `${name}.yml`),
+      "utf8",
+    );
+
+    expect(document.permissions).toMatchObject({
+      contents: "read",
+      issues: "write",
+      "pull-requests": "read",
+      actions: "write",
+    });
+    expect(source).toContain(
+      "gh workflow run generated-project-branch-cleanup.yml",
+    );
+    expect(source).toContain('-f pull_number="$PULL_NUMBER"');
+    expect(source).toContain('-f expected_branch="$BRANCH"');
+    expect(source).toContain('-f expected_head_sha="$EXPECTED_SHA"');
+    expect(source).not.toContain("git/refs/heads/${BRANCH}");
+    expect(source).not.toContain("--method DELETE");
+    expect(source).not.toContain("TAVERNARY_PUBLISHER_APP_PRIVATE_KEY");
+  });
+
+  test("deletes a revalidated generated ref only with the Publisher token", async () => {
+    const document = await workflow("generated-project-branch-cleanup");
+    const job = document.jobs.cleanup as {
+      if?: string;
+      environment?: string;
+      env?: Record<string, string>;
+      steps: WorkflowStep[];
+    };
+    const plan = job.steps.find((step) => step.id === "plan");
+    const token = job.steps.find((step) => step.id === "publisher-token");
+    const publisherCheckout = job.steps.find(
+      (step) => step.name === "Install Publisher branch credential",
+    );
+    const deletion = job.steps.find(
+      (step) => step.name === "Delete exact generated branch",
+    );
+    const source = await readFile(
+      resolve(workflowDirectory, "generated-project-branch-cleanup.yml"),
+      "utf8",
+    );
+
+    expect(Object.keys(document.on)).toEqual(["workflow_dispatch"]);
+    expect(document.on.workflow_dispatch.inputs).toEqual({
+      pull_number: {
+        description: "Closed generated pull request number",
+        required: true,
+        type: "number",
+      },
+      expected_branch: {
+        description: "Exact generated branch to clean up",
+        required: true,
+        type: "string",
+      },
+      expected_head_sha: {
+        description: "Exact closed pull request head SHA",
+        required: true,
+        type: "string",
+      },
+    });
+    expect(document.permissions).toEqual({
+      contents: "read",
+      "pull-requests": "read",
+    });
+    expect(job.if).toBe("github.ref == 'refs/heads/main'");
+    expect(job.environment).toBe("publisher");
+    expect(job.env?.GH_TOKEN).toBe("${{ secrets.GITHUB_TOKEN }}");
+    expect(plan?.run).toContain("generated-branch-custody.mjs");
+    expect(plan?.run).toContain("planGeneratedProjectBranchCleanup");
+    expect(token).toMatchObject({
+      uses: publisherTokenAction,
+      with: {
+        "client-id": "${{ vars.TAVERNARY_PUBLISHER_CLIENT_ID }}",
+        "private-key": "${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}",
+        owner: "MentallyQuill",
+        repositories: "Tavernary",
+        "permission-contents": "write",
+      },
+    });
+    expect(token?.if).toBe("steps.plan.outputs.action == 'delete'");
+    expect(publisherCheckout).toMatchObject({
+      if: "steps.plan.outputs.action == 'delete'",
+      with: { token: "${{ steps.publisher-token.outputs.token }}" },
+    });
+    expect(deletion).toMatchObject({
+      if: "steps.plan.outputs.action == 'delete'",
+    });
+    expect(deletion?.run).toContain(
+      'git push --force-with-lease="refs/heads/$BRANCH:$EXPECTED_SHA"',
+    );
+    expect(deletion?.run).toContain('origin ":refs/heads/$BRANCH"');
+    expect(deletion?.env).not.toHaveProperty("GH_TOKEN");
+    expect(source.match(/TAVERNARY_PUBLISHER_APP_PRIVATE_KEY/gu)).toHaveLength(
+      1,
+    );
+  });
+
+  test("reserves an App-owned create-update-delete branch canary", async () => {
+    const document = await workflow("publisher-automation-branch-verification");
+    const job = document.jobs.verify as {
+      if?: string;
+      environment?: string;
+      steps: WorkflowStep[];
+    };
+    const token = job.steps.find((step) => step.id === "publisher-token");
+    const verify = job.steps.find(
+      (step) => step.name === "Verify Publisher automation branch custody",
+    );
+
+    expect(document.on.workflow_dispatch).toBeNull();
+    expect(document.permissions).toEqual({ contents: "read" });
+    expect(job.if).toBe(
+      "github.ref == 'refs/heads/main' && github.actor_id == 2625904",
+    );
+    expect(job.environment).toBe("publisher");
+    expect(token).toMatchObject({
+      uses: publisherTokenAction,
+      with: {
+        "client-id": "${{ vars.TAVERNARY_PUBLISHER_CLIENT_ID }}",
+        "private-key": "${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}",
+        owner: "MentallyQuill",
+        repositories: "Tavernary",
+        "permission-contents": "write",
+      },
+    });
+    expect(verify?.env).toEqual({
+      GH_TOKEN: "${{ steps.publisher-token.outputs.token }}",
+    });
+    expect(verify?.run).toContain("branch=automation/project-submission-0");
+    expect(verify?.run).toContain("trap cleanup EXIT");
+    expect(verify?.run).toContain("/git/commits");
+    expect(verify?.run).toContain("--method POST");
+    expect(verify?.run).toContain("--method PATCH");
+    expect(verify?.run).toContain("-F force=false");
+    expect(verify?.run).toContain("published_sha");
+    expect(verify?.run).toContain("--method DELETE");
+  });
+
+  test("never auto-publishes the reserved branch canary", async () => {
+    const continuousIntegration = await workflow("ci");
+    expect(
+      continuousIntegration.jobs["dispatch-project-publication"].if,
+    ).toContain("github.ref_name != 'automation/project-submission-0'");
   });
 });

--- a/tests/unit/generated-branch-custody.test.ts
+++ b/tests/unit/generated-branch-custody.test.ts
@@ -1,4 +1,4 @@
-import { readFile } from "node:fs/promises";
+import { readFile, readdir } from "node:fs/promises";
 import { resolve } from "node:path";
 
 import { describe, expect, test } from "vitest";
@@ -377,6 +377,18 @@ describe("generated project branch workflow custody", () => {
     expect(plan?.run).not.toContain(
       "defaultBranch: process.env.GITHUB_REF_NAME",
     );
+    const tokenIndex = job.steps.indexOf(token as WorkflowStep);
+    const trustedCheckouts = job.steps
+      .slice(0, tokenIndex)
+      .filter((step) => step.uses?.startsWith("actions/checkout@"));
+    expect(tokenIndex).toBeGreaterThan(job.steps.indexOf(plan as WorkflowStep));
+    expect(trustedCheckouts).not.toHaveLength(0);
+    for (const checkout of trustedCheckouts) {
+      expect(checkout.with?.ref).toBe("main");
+      expect(JSON.stringify(checkout.with)).not.toContain(
+        "github.event.pull_request.head",
+      );
+    }
     expect(token).toMatchObject({
       uses: publisherTokenAction,
       with: {
@@ -453,35 +465,71 @@ describe("generated project branch workflow custody", () => {
     ).toContain("github.ref_name != 'automation/project-submission-0'");
   });
 
-  test.each([
-    ["triage-submission", "generate-project-submission.yml"],
-    ["triage-project-owner-request", "generate-project-owner-request.yml"],
-  ])(
-    "permits only owner or Publisher dispatch through %s",
-    async (name, target) => {
-      const document = await workflow(name);
-      const job = document.jobs.validate as {
-        if?: string;
-        environment?: string;
-        steps: WorkflowStep[];
-      };
-      const token = job.steps.find(
-        (step) => step.id === "publisher-dispatch-token",
-      );
-      const dispatch = job.steps.find((step) => step.run?.includes(target));
+  test("dispatches every privileged generator with a Publisher token", async () => {
+    const workflowNames = (await readdir(workflowDirectory))
+      .filter((name) => /\.ya?ml$/u.test(name))
+      .map((name) => name.replace(/\.ya?ml$/u, ""));
+    const privilegedTargets = [
+      "generate-project-submission.yml",
+      "generate-project-owner-request.yml",
+    ];
+    const callers: string[] = [];
 
-      expect(normalizedExpression(job.if)).toBe(publisherCallerCondition);
-      expect(job.environment).toBe("publisher");
-      expect(token).toMatchObject({
-        uses: publisherTokenAction,
-        with: {
-          "client-id": "${{ vars.TAVERNARY_PUBLISHER_CLIENT_ID }}",
-          "private-key": "${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}",
-          "permission-actions": "write",
-        },
-      });
-      expect(dispatch?.env?.GH_TOKEN).toBe(
-        "${{ steps.publisher-dispatch-token.outputs.token }}",
+    for (const name of workflowNames) {
+      const document = await workflow(name);
+      for (const [jobName, rawJob] of Object.entries(document.jobs ?? {})) {
+        const job = rawJob as {
+          environment?: string;
+          steps?: WorkflowStep[];
+        };
+        for (const [stepIndex, step] of (job.steps ?? []).entries()) {
+          const targets = privilegedTargets.filter((candidate) =>
+            step.run?.includes(`gh workflow run ${candidate}`),
+          );
+          if (targets.length === 0) continue;
+
+          const tokenReference = step.env?.GH_TOKEN?.match(
+            /^\$\{\{ steps\.([a-z0-9-]+)\.outputs\.token \}\}$/u,
+          )?.[1];
+          const tokenIndex = (job.steps ?? []).findIndex(
+            (candidate) => candidate.id === tokenReference,
+          );
+          const token = job.steps?.[tokenIndex];
+
+          expect(job.environment).toBe("publisher");
+          expect(tokenReference).toBeTruthy();
+          expect(tokenIndex).toBeGreaterThanOrEqual(0);
+          expect(tokenIndex).toBeLessThan(stepIndex);
+          expect(token).toMatchObject({
+            uses: publisherTokenAction,
+            with: {
+              "client-id": "${{ vars.TAVERNARY_PUBLISHER_CLIENT_ID }}",
+              "private-key":
+                "${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}",
+              "permission-actions": "write",
+            },
+          });
+          for (const target of targets) {
+            callers.push(`${name}:${jobName}:${target}`);
+          }
+        }
+      }
+    }
+
+    expect(callers.sort()).toEqual([
+      "publish-project-transaction:publish:generate-project-owner-request.yml",
+      "publish-project-transaction:publish:generate-project-submission.yml",
+      "triage-project-owner-request:validate:generate-project-owner-request.yml",
+      "triage-submission:validate:generate-project-submission.yml",
+    ]);
+  });
+
+  test.each(["triage-submission", "triage-project-owner-request"])(
+    "permits only owner or Publisher callers into %s",
+    async (name) => {
+      const document = await workflow(name);
+      expect(normalizedExpression(document.jobs.validate.if)).toBe(
+        publisherCallerCondition,
       );
     },
   );

--- a/tests/unit/generated-branch-custody.test.ts
+++ b/tests/unit/generated-branch-custody.test.ts
@@ -11,6 +11,10 @@ const headSha = "a".repeat(40);
 const workflowDirectory = resolve(".github/workflows");
 const publisherTokenAction =
   "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1";
+const publisherCallerCondition =
+  "github.ref == 'refs/heads/main' && " +
+  "(github.actor_id == 2625904 || " +
+  "github.actor_id == vars.TAVERNARY_PUBLISHER_BOT_ID)";
 
 type WorkflowStep = {
   id?: string;
@@ -26,6 +30,10 @@ async function workflow(name: string) {
   return parse(
     await readFile(resolve(workflowDirectory, `${name}.yml`), "utf8"),
   );
+}
+
+function normalizedExpression(value: string | undefined) {
+  return value?.replace(/\s+/gu, " ").trim();
 }
 
 function pull(overrides: Record<string, unknown> = {}) {
@@ -225,6 +233,7 @@ describe("generated project branch workflow custody", () => {
     async (name) => {
       const document = await workflow(name);
       const job = document.jobs.generate as {
+        if?: string;
         environment?: string;
         env?: Record<string, string>;
         steps: WorkflowStep[];
@@ -244,6 +253,7 @@ describe("generated project branch workflow custody", () => {
         "pull-requests": "write",
         actions: "write",
       });
+      expect(normalizedExpression(job.if)).toBe(publisherCallerCondition);
       expect(job.environment).toBe("publisher");
       expect(job.env?.GH_TOKEN).toBe("${{ secrets.GITHUB_TOKEN }}");
       expect(token).toMatchObject({
@@ -275,29 +285,28 @@ describe("generated project branch workflow custody", () => {
   test.each([
     "project-submission-lifecycle",
     "project-owner-request-lifecycle",
-  ])("queues exact-state App cleanup from %s", async (name) => {
-    const document = await workflow(name);
-    const source = await readFile(
-      resolve(workflowDirectory, `${name}.yml`),
-      "utf8",
-    );
+  ])(
+    "leaves generated ref cleanup to trusted default-branch code in %s",
+    async (name) => {
+      const document = await workflow(name);
+      const source = await readFile(
+        resolve(workflowDirectory, `${name}.yml`),
+        "utf8",
+      );
 
-    expect(document.permissions).toMatchObject({
-      contents: "read",
-      issues: "write",
-      "pull-requests": "read",
-      actions: "write",
-    });
-    expect(source).toContain(
-      "gh workflow run generated-project-branch-cleanup.yml",
-    );
-    expect(source).toContain('-f pull_number="$PULL_NUMBER"');
-    expect(source).toContain('-f expected_branch="$BRANCH"');
-    expect(source).toContain('-f expected_head_sha="$EXPECTED_SHA"');
-    expect(source).not.toContain("git/refs/heads/${BRANCH}");
-    expect(source).not.toContain("--method DELETE");
-    expect(source).not.toContain("TAVERNARY_PUBLISHER_APP_PRIVATE_KEY");
-  });
+      expect(document.permissions).toMatchObject({
+        contents: "read",
+        issues: "write",
+        "pull-requests": "read",
+      });
+      expect(source).not.toContain(
+        "gh workflow run generated-project-branch-cleanup.yml",
+      );
+      expect(source).not.toContain("git/refs/heads/${BRANCH}");
+      expect(source).not.toContain("--method DELETE");
+      expect(source).not.toContain("TAVERNARY_PUBLISHER_APP_PRIVATE_KEY");
+    },
+  );
 
   test("deletes a revalidated generated ref only with the Publisher token", async () => {
     const document = await workflow("generated-project-branch-cleanup");
@@ -320,7 +329,14 @@ describe("generated project branch workflow custody", () => {
       "utf8",
     );
 
-    expect(Object.keys(document.on)).toEqual(["workflow_dispatch"]);
+    expect(Object.keys(document.on)).toEqual([
+      "pull_request_target",
+      "workflow_dispatch",
+    ]);
+    expect(document.on.pull_request_target).toEqual({
+      branches: ["main"],
+      types: ["closed"],
+    });
     expect(document.on.workflow_dispatch.inputs).toEqual({
       pull_number: {
         description: "Closed generated pull request number",
@@ -342,11 +358,25 @@ describe("generated project branch workflow custody", () => {
       contents: "read",
       "pull-requests": "read",
     });
-    expect(job.if).toBe("github.ref == 'refs/heads/main'");
+    expect(job.if).toContain("github.event_name == 'pull_request_target'");
+    expect(job.if).toContain("github.event_name == 'workflow_dispatch'");
+    expect(job.if).toContain("github.actor_id == 2625904");
+    expect(job.if).toContain(
+      "startsWith(github.event.pull_request.head.ref, 'automation/project-submission-')",
+    );
+    expect(job.if).toContain(
+      "startsWith(github.event.pull_request.head.ref, 'automation/project-owner-request-')",
+    );
     expect(job.environment).toBe("publisher");
     expect(job.env?.GH_TOKEN).toBe("${{ secrets.GITHUB_TOKEN }}");
     expect(plan?.run).toContain("generated-branch-custody.mjs");
     expect(plan?.run).toContain("planGeneratedProjectBranchCleanup");
+    expect(plan?.run).toContain("default_branch");
+    expect(plan?.run).toContain("(HTTP 404)");
+    expect(plan?.run).not.toContain("2>/dev/null || true");
+    expect(plan?.run).not.toContain(
+      "defaultBranch: process.env.GITHUB_REF_NAME",
+    );
     expect(token).toMatchObject({
       uses: publisherTokenAction,
       with: {
@@ -421,5 +451,67 @@ describe("generated project branch workflow custody", () => {
     expect(
       continuousIntegration.jobs["dispatch-project-publication"].if,
     ).toContain("github.ref_name != 'automation/project-submission-0'");
+  });
+
+  test.each([
+    ["triage-submission", "generate-project-submission.yml"],
+    ["triage-project-owner-request", "generate-project-owner-request.yml"],
+  ])(
+    "permits only owner or Publisher dispatch through %s",
+    async (name, target) => {
+      const document = await workflow(name);
+      const job = document.jobs.validate as {
+        if?: string;
+        environment?: string;
+        steps: WorkflowStep[];
+      };
+      const token = job.steps.find(
+        (step) => step.id === "publisher-dispatch-token",
+      );
+      const dispatch = job.steps.find((step) => step.run?.includes(target));
+
+      expect(normalizedExpression(job.if)).toBe(publisherCallerCondition);
+      expect(job.environment).toBe("publisher");
+      expect(token).toMatchObject({
+        uses: publisherTokenAction,
+        with: {
+          "client-id": "${{ vars.TAVERNARY_PUBLISHER_CLIENT_ID }}",
+          "private-key": "${{ secrets.TAVERNARY_PUBLISHER_APP_PRIVATE_KEY }}",
+          "permission-actions": "write",
+        },
+      });
+      expect(dispatch?.env?.GH_TOKEN).toBe(
+        "${{ steps.publisher-dispatch-token.outputs.token }}",
+      );
+    },
+  );
+
+  test("admits public issue events but reserves manual Publisher dispatch for the owner", async () => {
+    const document = await workflow("admit-issue");
+    const job = document.jobs.admit as {
+      if?: string;
+      steps: WorkflowStep[];
+    };
+    const token = job.steps.find(
+      (step) => step.id === "publisher-dispatch-token",
+    );
+
+    expect(job.if).toBe(
+      "github.ref == 'refs/heads/main' && " +
+        "(github.event_name != 'workflow_dispatch' || github.actor_id == 2625904)",
+    );
+    expect(token?.if).toContain("steps.admission.outputs.route == 'project'");
+    expect(token?.if).toContain(
+      "steps.admission.outputs.route == 'project-owner'",
+    );
+    for (const target of [
+      "triage-submission.yml",
+      "triage-project-owner-request.yml",
+    ]) {
+      const dispatch = job.steps.find((step) => step.run?.includes(target));
+      expect(dispatch?.env?.GH_TOKEN).toBe(
+        "${{ steps.publisher-dispatch-token.outputs.token }}",
+      );
+    }
   });
 });

--- a/tests/unit/generated-branch-custody.test.ts
+++ b/tests/unit/generated-branch-custody.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, test } from "vitest";
+
+import { planGeneratedProjectBranchCleanup } from "../../scripts/security/generated-branch-custody.mjs";
+
+const repository = "MentallyQuill/Tavernary";
+const headSha = "a".repeat(40);
+
+function pull(overrides: Record<string, unknown> = {}) {
+  return {
+    number: 72,
+    state: "closed",
+    head: {
+      ref: "automation/project-submission-72",
+      sha: headSha,
+      repo: { full_name: repository },
+    },
+    base: {
+      ref: "main",
+      repo: { full_name: repository },
+    },
+    ...overrides,
+  };
+}
+
+function input(overrides: Record<string, unknown> = {}) {
+  return {
+    repository,
+    defaultBranch: "main",
+    pullNumber: 72,
+    expectedBranch: "automation/project-submission-72",
+    expectedHeadSha: headSha,
+    currentHeadSha: headSha,
+    pull: pull(),
+    ...overrides,
+  };
+}
+
+describe("generated project branch cleanup", () => {
+  test("deletes only the unchanged head of an exact closed submission PR", () => {
+    expect(planGeneratedProjectBranchCleanup(input())).toEqual({
+      action: "delete",
+      branch: "automation/project-submission-72",
+      expectedHeadSha: headSha,
+    });
+  });
+
+  test("accepts the numeric owner-request namespace", () => {
+    const branch = "automation/project-owner-request-290";
+    expect(
+      planGeneratedProjectBranchCleanup(
+        input({
+          expectedBranch: branch,
+          pull: pull({
+            head: {
+              ref: branch,
+              sha: headSha,
+              repo: { full_name: repository },
+            },
+          }),
+        }),
+      ),
+    ).toEqual({ action: "delete", branch, expectedHeadSha: headSha });
+  });
+
+  test("normalizes hexadecimal SHA case", () => {
+    expect(
+      planGeneratedProjectBranchCleanup(
+        input({
+          expectedHeadSha: headSha.toUpperCase(),
+          currentHeadSha: headSha.toUpperCase(),
+        }),
+      ),
+    ).toEqual({
+      action: "delete",
+      branch: "automation/project-submission-72",
+      expectedHeadSha: headSha,
+    });
+  });
+
+  test("treats an already absent branch as an idempotent no-op", () => {
+    expect(
+      planGeneratedProjectBranchCleanup(input({ currentHeadSha: null })),
+    ).toEqual({
+      action: "absent",
+      branch: "automation/project-submission-72",
+      expectedHeadSha: headSha,
+    });
+  });
+
+  test("preserves a branch that moved after pull-request closure", () => {
+    expect(
+      planGeneratedProjectBranchCleanup(
+        input({ currentHeadSha: "b".repeat(40) }),
+      ),
+    ).toEqual({
+      action: "moved",
+      branch: "automation/project-submission-72",
+      expectedHeadSha: headSha,
+      currentHeadSha: "b".repeat(40),
+    });
+  });
+
+  test.each([
+    ["an open pull request", { pull: pull({ state: "open" }) }, "closed"],
+    [
+      "a foreign head repository",
+      {
+        pull: pull({
+          head: {
+            ref: "automation/project-submission-72",
+            sha: headSha,
+            repo: { full_name: "attacker/Tavernary" },
+          },
+        }),
+      },
+      "head repository",
+    ],
+    [
+      "a foreign base repository",
+      {
+        pull: pull({
+          base: { ref: "main", repo: { full_name: "attacker/Tavernary" } },
+        }),
+      },
+      "base repository",
+    ],
+    [
+      "a non-default base branch",
+      {
+        pull: pull({
+          base: { ref: "release", repo: { full_name: repository } },
+        }),
+      },
+      "default branch",
+    ],
+    ["a different pull request", { pull: pull({ number: 73 }) }, "number"],
+    [
+      "a mismatched head branch",
+      {
+        pull: pull({
+          head: {
+            ref: "automation/project-submission-73",
+            sha: headSha,
+            repo: { full_name: repository },
+          },
+        }),
+      },
+      "head branch",
+    ],
+    [
+      "a mismatched head SHA",
+      {
+        pull: pull({
+          head: {
+            ref: "automation/project-submission-72",
+            sha: "c".repeat(40),
+            repo: { full_name: repository },
+          },
+        }),
+      },
+      "head SHA",
+    ],
+  ])("rejects %s", (_label, overrides, message) => {
+    expect(() => planGeneratedProjectBranchCleanup(input(overrides))).toThrow(
+      message,
+    );
+  });
+
+  test.each([
+    "automation/project-submission-0",
+    "automation/project-submission-72/extra",
+    "automation/project-owner-request-canary",
+    "feat/project-submission-72",
+    "automation/project-submission-72%2Fextra",
+  ])("rejects non-production generated branch %s", (expectedBranch) => {
+    expect(() =>
+      planGeneratedProjectBranchCleanup(input({ expectedBranch })),
+    ).toThrow("generated project branch");
+  });
+
+  test.each(["a".repeat(39), "g".repeat(40), `${headSha};echo unsafe`, ""])(
+    "rejects malformed expected SHA %s",
+    (expectedHeadSha) => {
+      expect(() =>
+        planGeneratedProjectBranchCleanup(input({ expectedHeadSha })),
+      ).toThrow("expected head SHA");
+    },
+  );
+
+  test("rejects a malformed current ref SHA", () => {
+    expect(() =>
+      planGeneratedProjectBranchCleanup(
+        input({ currentHeadSha: `${headSha};echo unsafe` }),
+      ),
+    ).toThrow("current head SHA");
+  });
+});

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -1444,7 +1444,7 @@ test("generates submission PRs with scoped permissions and manual recovery", asy
   );
 
   expect(generation.permissions).toEqual({
-    contents: "write",
+    contents: "read",
     issues: "write",
     "pull-requests": "write",
     actions: "write",
@@ -1474,12 +1474,12 @@ test("generates submission PRs with scoped permissions and manual recovery", asy
   expect(source).toContain(
     'node scripts/submissions/reset-project-submission-branch.mjs --branch "$BRANCH"',
   );
-  expect(source).toContain('git config user.name "github-actions[bot]"');
+  expect(source).toContain('git config user.name "Tavernary Publisher"');
   expect(source).toContain(
-    'git config user.email "41898282+github-actions[bot]@users.noreply.github.com"',
+    'git config user.email "tavernary-publisher[bot]@users.noreply.github.com"',
   );
   expect(
-    source.indexOf('git config user.name "github-actions[bot]"'),
+    source.indexOf('git config user.name "Tavernary Publisher"'),
   ).toBeLessThan(
     source.indexOf(
       "node scripts/submissions/reset-project-submission-branch.mjs",
@@ -1608,7 +1608,7 @@ test("handles submission closure from default-branch code only", async () => {
 
   expect(lifecycle.on.pull_request.types).toEqual(["closed"]);
   expect(lifecycle.permissions).toEqual({
-    contents: "write",
+    contents: "read",
     issues: "write",
     "pull-requests": "read",
     actions: "write",
@@ -1727,7 +1727,7 @@ test("generates owner review PRs with operation-scoped guarded writes", async ()
   );
 
   expect(generation.permissions).toEqual({
-    contents: "write",
+    contents: "read",
     issues: "write",
     "pull-requests": "write",
     actions: "write",
@@ -1869,9 +1869,10 @@ test("handles owner closure from default-branch code and exact head state", asyn
 
   expect(lifecycle.on.pull_request.types).toEqual(["closed"]);
   expect(lifecycle.permissions).toEqual({
-    contents: "write",
+    contents: "read",
     issues: "write",
     "pull-requests": "read",
+    actions: "write",
   });
   expect(lifecycle.concurrency).toEqual({
     group:

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -156,6 +156,8 @@ test("uses category-prefixed workflow display names", async () => {
       "Project owner requests: Create review PR",
     "project-owner-request-lifecycle":
       "Project owner requests: Process review result",
+    "generated-project-branch-cleanup":
+      "Security: Clean generated project branch",
     "retry-frontend-dependencies":
       "Project submissions: Retry frontend dependencies",
     "retry-project-submission-enrichment":
@@ -173,6 +175,8 @@ test("uses category-prefixed workflow display names", async () => {
     "targeted-tavernkeeper-scan": "Security: Run targeted TavernKeeper scan",
     "publish-openai-usage": "Support transparency: Publish OpenAI usage",
     "publisher-verification": "Security: Verify Tavernary Publisher",
+    "publisher-automation-branch-verification":
+      "Security: Verify Publisher automation branches",
   } as const;
 
   for (const [file, expectedName] of Object.entries(expectedNames)) {
@@ -189,6 +193,7 @@ test("identifies the object and action in every workflow run name", async () => 
     "triage-project-owner-request": ["Owner request #", "Validate authority"],
     "generate-project-owner-request": ["Owner request #", "Create review PR"],
     "project-owner-request-lifecycle": ["Owner review PR #", "Process result"],
+    "generated-project-branch-cleanup": ["Generated branch cleanup for PR #"],
     "retry-frontend-dependencies": [
       "Project submissions:",
       "Retry merged frontend dependencies",
@@ -209,6 +214,10 @@ test("identifies the object and action in every workflow run name", async () => 
     "targeted-tavernkeeper-scan": ["Security:", "Scan"],
     "publish-openai-usage": ["Support:", "Publish prior-month usage"],
     "publisher-verification": ["Security:", "Verify Publisher write lane"],
+    "publisher-automation-branch-verification": [
+      "Security:",
+      "Verify Publisher branch custody",
+    ],
   } as const;
 
   for (const [file, expectedParts] of Object.entries(expectedRunNameParts)) {
@@ -220,31 +229,10 @@ test("identifies the object and action in every workflow run name", async () => 
 });
 
 test("pins every first-party action to its resolved commit", async () => {
-  for (const name of [
-    "ci",
-    "deploy-pages",
-    "import-tavernkeeper-reports",
-    "refresh-catalog",
-    "enrich-catalog",
-    "backfill-repository-identities",
-    "admit-issue",
-    "triage-submission",
-    "generate-project-submission",
-    "project-submission-lifecycle",
-    "triage-project-owner-request",
-    "generate-project-owner-request",
-    "project-owner-request-lifecycle",
-    "retry-frontend-dependencies",
-    "retry-project-submission-enrichment",
-    "triage-kit-submission",
-    "triage-help-request",
-    "apply-kit-submission",
-    "apply-kit-withdrawal",
-    "targeted-tavernkeeper-scan",
-    "publish-openai-usage",
-    "publisher-verification",
-    "review-catalog-policy",
-  ]) {
+  const names = (await readdir(workflowDirectory))
+    .filter((name) => /\.ya?ml$/u.test(name))
+    .map((name) => name.replace(/\.ya?ml$/u, ""));
+  for (const name of names) {
     for (const step of allSteps(await workflow(name))) {
       if (!step.uses?.startsWith("actions/")) continue;
       const [action, sha] = step.uses.split("@");
@@ -1328,7 +1316,6 @@ test("triage dispatches admitted projects without repository write access", asyn
   expect(triage.permissions).toEqual({
     contents: "read",
     issues: "write",
-    actions: "write",
   });
   expect(triage.concurrency["cancel-in-progress"]).toBe(true);
   expect(triage.concurrency.group).toContain("${{ inputs.issue_number }}");
@@ -1659,7 +1646,6 @@ test("triages owner requests through a read-only repository gate", async () => {
   expect(triage.permissions).toEqual({
     contents: "read",
     issues: "write",
-    actions: "write",
   });
   expect(triage.concurrency).toEqual({
     group: "project-owner-triage-${{ inputs.issue_number }}",
@@ -1872,7 +1858,6 @@ test("handles owner closure from default-branch code and exact head state", asyn
     contents: "read",
     issues: "write",
     "pull-requests": "read",
-    actions: "write",
   });
   expect(lifecycle.concurrency).toEqual({
     group:


### PR DESCRIPTION
## Summary

- reserve generated project branch namespaces for the Tavernary Publisher GitHub App
- gate privileged admission, triage, generation, regeneration, cleanup, and canary paths
- revalidate closed PR and exact head state before atomic App-authenticated cleanup
- add owner-only positive canary and contributor-denial verification support
- document the contributor lane and bot branch custody policy

## Security properties

- only MentallyQuill or the Publisher App can enter privileged generator workflows
- only the Publisher App receives write authority for protected generated branches
- pull_request_target executes trusted main code only and validates before minting credentials
- all privileged generator dispatch edges are dynamically audited by tests
- ordinary contributor branch namespaces remain unrestricted

## Verification

- npm.cmd run check
- 219 test files / 2,495 tests
- 403 static pages built
- static export verified
- independent final review: no Critical, Important, or Minor findings