### PR TITLE
fix(catalog): accept missing load order

### DIFF
--- a/data/snapshots/install/github-1028124712.json
+++ b/data/snapshots/install/github-1028124712.json
@@ -2,7 +2,13 @@
   "schema_version": 1,
   "source_id": "github-1028124712",
   "head_sha": "8f34af01af1bd242d9af8f645e870df13275c8d9",
-  "observed_at": "2026-08-18T17:17:07.406Z",
-  "status": "unavailable",
-  "reason": "invalid-manifest"
+  "observed_at": "2026-08-19T16:48:19.807Z",
+  "status": "verified",
+  "manifest_path": "manifest.json",
+  "folder_name": "dynamic-vars",
+  "manifest": {
+    "display_name": "Dynamic Variable Hooks",
+    "key": null,
+    "minimum_client_version": null
+  }
 }

--- a/data/snapshots/install/github-1034514716.json
+++ b/data/snapshots/install/github-1034514716.json
@@ -2,7 +2,13 @@
   "schema_version": 1,
   "source_id": "github-1034514716",
   "head_sha": "b51fe2220d567c0845cd72d114bd312705a95f59",
-  "observed_at": "2026-08-18T17:17:07.406Z",
-  "status": "unavailable",
-  "reason": "invalid-manifest"
+  "observed_at": "2026-08-19T16:48:19.807Z",
+  "status": "verified",
+  "manifest_path": "manifest.json",
+  "folder_name": "Intiface_Central-Sillytavern-plugin",
+  "manifest": {
+    "display_name": "Intiface Central For Sillytavern",
+    "key": null,
+    "minimum_client_version": null
+  }
 }

--- a/data/snapshots/install/github-1050800660.json
+++ b/data/snapshots/install/github-1050800660.json
@@ -2,7 +2,13 @@
   "schema_version": 1,
   "source_id": "github-1050800660",
   "head_sha": "5554e48575c016175d48fc9a7fb37f0536041e48",
-  "observed_at": "2026-08-18T17:17:07.406Z",
-  "status": "unavailable",
-  "reason": "invalid-manifest"
+  "observed_at": "2026-08-19T16:48:19.807Z",
+  "status": "verified",
+  "manifest_path": "manifest.json",
+  "folder_name": "world-navigatorST",
+  "manifest": {
+    "display_name": "World Navigator",
+    "key": null,
+    "minimum_client_version": null
+  }
 }

--- a/data/snapshots/install/github-1125809015.json
+++ b/data/snapshots/install/github-1125809015.json
@@ -2,7 +2,13 @@
   "schema_version": 1,
   "source_id": "github-1125809015",
   "head_sha": "d51c17548fa85fc667f9862f47b60f179065229e",
-  "observed_at": "2026-08-18T17:17:07.406Z",
-  "status": "unavailable",
-  "reason": "invalid-manifest"
+  "observed_at": "2026-08-19T16:48:19.807Z",
+  "status": "verified",
+  "manifest_path": "manifest.json",
+  "folder_name": "universal-immersion-engine",
+  "manifest": {
+    "display_name": "Universal Immersion Engine",
+    "key": null,
+    "minimum_client_version": null
+  }
 }

--- a/data/snapshots/install/github-1139430137.json
+++ b/data/snapshots/install/github-1139430137.json
@@ -2,7 +2,13 @@
   "schema_version": 1,
   "source_id": "github-1139430137",
   "head_sha": "70ff25474f77516ffc81ebd22fa8a2e37a9b7b4b",
-  "observed_at": "2026-08-18T17:17:07.406Z",
-  "status": "unavailable",
-  "reason": "invalid-manifest"
+  "observed_at": "2026-08-19T16:48:19.807Z",
+  "status": "verified",
+  "manifest_path": "manifest.json",
+  "folder_name": "SillyTavern-CharacterLibrary",
+  "manifest": {
+    "display_name": "Character Library",
+    "key": null,
+    "minimum_client_version": null
+  }
 }

--- a/data/snapshots/install/github-1158773851.json
+++ b/data/snapshots/install/github-1158773851.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "source_id": "github-1158773851",
   "head_sha": "75100e0c0849a2af37092236057aefaaeda9eb0d",
-  "observed_at": "2026-08-18T17:17:07.406Z",
+  "observed_at": "2026-08-19T16:48:19.807Z",
   "status": "unavailable",
   "reason": "invalid-manifest"
 }

--- a/data/snapshots/install/github-1174672121.json
+++ b/data/snapshots/install/github-1174672121.json
@@ -2,7 +2,13 @@
   "schema_version": 1,
   "source_id": "github-1174672121",
   "head_sha": "2205d1d0576acc3dcbcef4d1b0a472c283d4a9ad",
-  "observed_at": "2026-08-18T17:17:07.406Z",
-  "status": "unavailable",
-  "reason": "invalid-manifest"
+  "observed_at": "2026-08-19T16:48:19.807Z",
+  "status": "verified",
+  "manifest_path": "manifest.json",
+  "folder_name": "SillyTavern-UIShortcuts",
+  "manifest": {
+    "display_name": "UI Shortcuts",
+    "key": null,
+    "minimum_client_version": null
+  }
 }

--- a/data/snapshots/install/github-1191978638.json
+++ b/data/snapshots/install/github-1191978638.json
@@ -2,7 +2,13 @@
   "schema_version": 1,
   "source_id": "github-1191978638",
   "head_sha": "8df15490c26cb7cc29ac5f53fe4b57182065758c",
-  "observed_at": "2026-08-18T17:17:07.406Z",
-  "status": "unavailable",
-  "reason": "invalid-manifest"
+  "observed_at": "2026-08-19T16:48:19.807Z",
+  "status": "verified",
+  "manifest_path": "manifest.json",
+  "folder_name": "IkarusAutoImage",
+  "manifest": {
+    "display_name": "Ikarus Auto Image",
+    "key": null,
+    "minimum_client_version": null
+  }
 }

--- a/data/snapshots/install/github-1218665690.json
+++ b/data/snapshots/install/github-1218665690.json
@@ -2,7 +2,13 @@
   "schema_version": 1,
   "source_id": "github-1218665690",
   "head_sha": "0fff51593aafc91298bca7dd81a804b01394568f",
-  "observed_at": "2026-08-18T17:17:07.406Z",
-  "status": "unavailable",
-  "reason": "invalid-manifest"
+  "observed_at": "2026-08-19T16:48:19.807Z",
+  "status": "verified",
+  "manifest_path": "manifest.json",
+  "folder_name": "polyceph",
+  "manifest": {
+    "display_name": "Polyceph",
+    "key": null,
+    "minimum_client_version": null
+  }
 }

--- a/data/snapshots/install/github-1247868572.json
+++ b/data/snapshots/install/github-1247868572.json
@@ -2,7 +2,13 @@
   "schema_version": 1,
   "source_id": "github-1247868572",
   "head_sha": "2c6b36a15ef753a80707ab8c1fb39486b471172a",
-  "observed_at": "2026-08-18T17:17:07.406Z",
-  "status": "unavailable",
-  "reason": "invalid-manifest"
+  "observed_at": "2026-08-19T16:48:19.807Z",
+  "status": "verified",
+  "manifest_path": "manifest.json",
+  "folder_name": "SillyTavern-Token-and-Cost-Statistics",
+  "manifest": {
+    "display_name": "Kuro Token & Cost Analytics",
+    "key": null,
+    "minimum_client_version": "1.12.0"
+  }
 }

--- a/data/snapshots/install/github-1283421850.json
+++ b/data/snapshots/install/github-1283421850.json
@@ -2,7 +2,13 @@
   "schema_version": 1,
   "source_id": "github-1283421850",
   "head_sha": "ef2a249ed582564be221c39875d34cf86290e11c",
-  "observed_at": "2026-08-18T17:17:07.406Z",
-  "status": "unavailable",
-  "reason": "invalid-manifest"
+  "observed_at": "2026-08-19T16:48:19.807Z",
+  "status": "verified",
+  "manifest_path": "manifest.json",
+  "folder_name": "game-engine",
+  "manifest": {
+    "display_name": "Game Engine",
+    "key": null,
+    "minimum_client_version": null
+  }
 }

--- a/data/snapshots/install/github-1319221115.json
+++ b/data/snapshots/install/github-1319221115.json
@@ -2,7 +2,13 @@
   "schema_version": 1,
   "source_id": "github-1319221115",
   "head_sha": "10be7c319c378019da426d2b745f373dd590915d",
-  "observed_at": "2026-08-18T17:17:07.406Z",
-  "status": "unavailable",
-  "reason": "invalid-manifest"
+  "observed_at": "2026-08-19T16:48:19.807Z",
+  "status": "verified",
+  "manifest_path": "manifest.json",
+  "folder_name": "SillyTavern-WorldInfoPlus",
+  "manifest": {
+    "display_name": "SillyTavern-WorldInfoPlus",
+    "key": null,
+    "minimum_client_version": null
+  }
 }

--- a/data/snapshots/install/github-933528919.json
+++ b/data/snapshots/install/github-933528919.json
@@ -2,7 +2,13 @@
   "schema_version": 1,
   "source_id": "github-933528919",
   "head_sha": "77b885b03ba2f55e7a2867dff49a5ded6d129d9b",
-  "observed_at": "2026-08-18T17:17:07.406Z",
-  "status": "unavailable",
-  "reason": "invalid-manifest"
+  "observed_at": "2026-08-19T16:48:19.807Z",
+  "status": "verified",
+  "manifest_path": "manifest.json",
+  "folder_name": "sorcery",
+  "manifest": {
+    "display_name": "Sorcery",
+    "key": null,
+    "minimum_client_version": null
+  }
 }

--- a/public/catalog/tavernary-catalog.json
+++ b/public/catalog/tavernary-catalog.json
@@ -17795,7 +17795,13 @@
       "preset": null,
       "refreshedAt": "2026-08-19T07:56:49.599Z",
       "staleSince": null,
-      "install": null,
+      "install": {
+        "kind": "sillytavern-extension-git",
+        "repositoryUrl": "https://github.com/chew1976/dynamic-vars.git",
+        "branch": null,
+        "manifestPath": "manifest.json",
+        "folderName": "dynamic-vars"
+      },
       "fork": null,
       "search": {
         "title": [
@@ -24922,7 +24928,13 @@
       "preset": null,
       "refreshedAt": "2026-08-19T07:56:49.599Z",
       "staleSince": null,
-      "install": null,
+      "install": {
+        "kind": "sillytavern-extension-git",
+        "repositoryUrl": "https://github.com/Enclave0775/Intiface_Central-Sillytavern-plugin.git",
+        "branch": null,
+        "manifestPath": "manifest.json",
+        "folderName": "Intiface_Central-Sillytavern-plugin"
+      },
       "fork": null,
       "search": {
         "title": [
@@ -29834,7 +29846,13 @@
       "preset": null,
       "refreshedAt": "2026-08-19T07:56:49.599Z",
       "staleSince": null,
-      "install": null,
+      "install": {
+        "kind": "sillytavern-extension-git",
+        "repositoryUrl": "https://github.com/GetfroggyHoe/universal-immersion-engine.git",
+        "branch": null,
+        "manifestPath": "manifest.json",
+        "folderName": "universal-immersion-engine"
+      },
       "fork": null,
       "search": {
         "title": [
@@ -35419,7 +35437,13 @@
       "preset": null,
       "refreshedAt": "2026-08-19T07:56:49.599Z",
       "staleSince": null,
-      "install": null,
+      "install": {
+        "kind": "sillytavern-extension-git",
+        "repositoryUrl": "https://github.com/IkarusV/IkarusAutoImage.git",
+        "branch": null,
+        "manifestPath": "manifest.json",
+        "folderName": "IkarusAutoImage"
+      },
       "fork": null,
       "search": {
         "title": [
@@ -40721,7 +40745,13 @@
       "preset": null,
       "refreshedAt": "2026-08-19T07:56:49.599Z",
       "staleSince": null,
-      "install": null,
+      "install": {
+        "kind": "sillytavern-extension-git",
+        "repositoryUrl": "https://github.com/kurohomeless/SillyTavern-Token-and-Cost-Statistics.git",
+        "branch": null,
+        "manifestPath": "manifest.json",
+        "folderName": "SillyTavern-Token-and-Cost-Statistics"
+      },
       "fork": {
         "parentName": "Extension TokenUsage",
         "parentProjectId": "vibecoder9000-extension-tokenusage",
@@ -58784,7 +58814,13 @@
       "preset": null,
       "refreshedAt": "2026-08-19T07:56:49.599Z",
       "staleSince": null,
-      "install": null,
+      "install": {
+        "kind": "sillytavern-extension-git",
+        "repositoryUrl": "https://github.com/nialyn-mid/polyceph.git",
+        "branch": null,
+        "manifestPath": "manifest.json",
+        "folderName": "polyceph"
+      },
       "fork": null,
       "search": {
         "title": [
@@ -58935,7 +58971,13 @@
       "preset": null,
       "refreshedAt": "2026-08-19T07:56:49.599Z",
       "staleSince": null,
-      "install": null,
+      "install": {
+        "kind": "sillytavern-extension-git",
+        "repositoryUrl": "https://github.com/NickChegg/game-engine.git",
+        "branch": null,
+        "manifestPath": "manifest.json",
+        "folderName": "game-engine"
+      },
       "fork": null,
       "search": {
         "title": [
@@ -60161,7 +60203,13 @@
       "preset": null,
       "refreshedAt": "2026-08-19T07:56:49.599Z",
       "staleSince": null,
-      "install": null,
+      "install": {
+        "kind": "sillytavern-extension-git",
+        "repositoryUrl": "https://github.com/p-e-w/sorcery.git",
+        "branch": null,
+        "manifestPath": "manifest.json",
+        "folderName": "sorcery"
+      },
       "fork": null,
       "search": {
         "title": [
@@ -61448,7 +61496,13 @@
       "preset": null,
       "refreshedAt": "2026-08-19T07:56:49.599Z",
       "staleSince": null,
-      "install": null,
+      "install": {
+        "kind": "sillytavern-extension-git",
+        "repositoryUrl": "https://github.com/Phiarlan/SillyTavern-WorldInfoPlus.git",
+        "branch": null,
+        "manifestPath": "manifest.json",
+        "folderName": "SillyTavern-WorldInfoPlus"
+      },
       "fork": null,
       "search": {
         "title": [
@@ -65144,7 +65198,13 @@
       "preset": null,
       "refreshedAt": "2026-08-19T07:56:49.599Z",
       "staleSince": null,
-      "install": null,
+      "install": {
+        "kind": "sillytavern-extension-git",
+        "repositoryUrl": "https://github.com/PureConcentratedSpite/world-navigatorST.git",
+        "branch": null,
+        "manifestPath": "manifest.json",
+        "folderName": "world-navigatorST"
+      },
       "fork": null,
       "search": {
         "title": [
@@ -73197,7 +73257,13 @@
       "preset": null,
       "refreshedAt": "2026-08-19T07:56:49.599Z",
       "staleSince": null,
-      "install": null,
+      "install": {
+        "kind": "sillytavern-extension-git",
+        "repositoryUrl": "https://github.com/Sillyanonymous/SillyTavern-CharacterLibrary.git",
+        "branch": null,
+        "manifestPath": "manifest.json",
+        "folderName": "SillyTavern-CharacterLibrary"
+      },
       "fork": null,
       "search": {
         "title": [
@@ -73373,7 +73439,13 @@
       "preset": null,
       "refreshedAt": "2026-08-19T07:56:49.599Z",
       "staleSince": null,
-      "install": null,
+      "install": {
+        "kind": "sillytavern-extension-git",
+        "repositoryUrl": "https://github.com/Sillyanonymous/SillyTavern-UIShortcuts.git",
+        "branch": null,
+        "manifestPath": "manifest.json",
+        "folderName": "SillyTavern-UIShortcuts"
+      },
       "fork": null,
       "search": {
         "title": [
@@ -109460,7 +109532,13 @@
             "preset": null,
             "refreshedAt": "2026-08-19T07:56:49.599Z",
             "staleSince": null,
-            "install": null,
+            "install": {
+              "kind": "sillytavern-extension-git",
+              "repositoryUrl": "https://github.com/Sillyanonymous/SillyTavern-CharacterLibrary.git",
+              "branch": null,
+              "manifestPath": "manifest.json",
+              "folderName": "SillyTavern-CharacterLibrary"
+            },
             "fork": null,
             "search": {
               "title": [
@@ -113763,7 +113841,13 @@
             "preset": null,
             "refreshedAt": "2026-08-19T07:56:49.599Z",
             "staleSince": null,
-            "install": null,
+            "install": {
+              "kind": "sillytavern-extension-git",
+              "repositoryUrl": "https://github.com/Sillyanonymous/SillyTavern-CharacterLibrary.git",
+              "branch": null,
+              "manifestPath": "manifest.json",
+              "folderName": "SillyTavern-CharacterLibrary"
+            },
             "fork": null,
             "search": {
               "title": [
@@ -114417,7 +114501,13 @@
             "preset": null,
             "refreshedAt": "2026-08-19T07:56:49.599Z",
             "staleSince": null,
-            "install": null,
+            "install": {
+              "kind": "sillytavern-extension-git",
+              "repositoryUrl": "https://github.com/Sillyanonymous/SillyTavern-UIShortcuts.git",
+              "branch": null,
+              "manifestPath": "manifest.json",
+              "folderName": "SillyTavern-UIShortcuts"
+            },
             "fork": null,
             "search": {
               "title": [
@@ -132416,7 +132506,13 @@
             "preset": null,
             "refreshedAt": "2026-08-19T07:56:49.599Z",
             "staleSince": null,
-            "install": null,
+            "install": {
+              "kind": "sillytavern-extension-git",
+              "repositoryUrl": "https://github.com/GetfroggyHoe/universal-immersion-engine.git",
+              "branch": null,
+              "manifestPath": "manifest.json",
+              "folderName": "universal-immersion-engine"
+            },
             "fork": null,
             "search": {
               "title": [

--- a/scripts/catalog/backfill-extension-install-evidence.mjs
+++ b/scripts/catalog/backfill-extension-install-evidence.mjs
@@ -55,6 +55,7 @@ export async function backfillExtensionInstallEvidence(options = {}) {
     sources: inputs.sources,
     snapshots: inputs.snapshots,
     previousEvidence: inputs.installEvidence,
+    retryReasons: new Set(["invalid-manifest"]),
     providers,
     observedAt: options.observedAt ?? new Date().toISOString(),
   });

--- a/scripts/catalog/extension-install-evidence.d.mts
+++ b/scripts/catalog/extension-install-evidence.d.mts
@@ -52,6 +52,7 @@ export function refreshExtensionInstallEvidence(input: {
   snapshots: Array<Record<string, any>>;
   previousEvidence?: ExtensionInstallEvidenceV1[];
   sourceIds?: string[];
+  retryReasons?: ReadonlySet<UnavailableExtensionInstallEvidence["reason"]>;
   providers: Partial<
     Record<
       "github" | "codeberg",

--- a/scripts/catalog/extension-install-evidence.mjs
+++ b/scripts/catalog/extension-install-evidence.mjs
@@ -20,7 +20,8 @@ export function deriveExtensionInstallEvidence(input) {
     !manifest ||
     typeof manifest.display_name !== "string" ||
     manifest.display_name.trim().length === 0 ||
-    !Number.isFinite(manifest.loading_order) ||
+    (manifest.loading_order !== undefined &&
+      !Number.isFinite(manifest.loading_order)) ||
     !hasEntry
   ) {
     return { ...base, status: "unavailable", reason: "invalid-manifest" };
@@ -86,8 +87,12 @@ export async function refreshExtensionInstallEvidence(input) {
 
     const previous = evidenceBySource.get(sourceId);
     const currentFolderName = repositoryFolderName(snapshot.repository.url);
+    const shouldRetryPrevious =
+      previous?.status === "unavailable" &&
+      input.retryReasons?.has(previous.reason);
     if (
       previous?.head_sha === snapshot.repository.head_sha &&
+      !shouldRetryPrevious &&
       previous.reason !== "fetch-failed" &&
       (previous.status !== "verified" ||
         previous.folder_name === currentFolderName)

--- a/tests/unit/backfill-extension-install-evidence.test.ts
+++ b/tests/unit/backfill-extension-install-evidence.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { backfillExtensionInstallEvidence } from "../../scripts/catalog/backfill-extension-install-evidence.mjs";
 
 describe("backfillExtensionInstallEvidence", () => {
-  it("validates and builds all current-head evidence before publishing", async () => {
+  it("revalidates cached invalid manifests before publishing", async () => {
     const publish = vi.fn();
     const validate = vi.fn().mockResolvedValue({ errors: [] });
     const build = vi.fn().mockResolvedValue({});
@@ -40,7 +40,16 @@ describe("backfillExtensionInstallEvidence", () => {
             },
           },
         ],
-        installEvidence: [],
+        installEvidence: [
+          {
+            schema_version: 1,
+            source_id: "github-1",
+            head_sha: "a".repeat(40),
+            observed_at: "2026-08-17T12:00:00.000Z",
+            status: "unavailable",
+            reason: "invalid-manifest",
+          },
+        ],
       },
       providers: {
         github: {
@@ -48,7 +57,6 @@ describe("backfillExtensionInstallEvidence", () => {
             path: "manifest.json",
             content: JSON.stringify({
               display_name: "Alpha",
-              loading_order: 10,
               js: "index.js",
             }),
             encoding: "utf8",

--- a/tests/unit/extension-install-evidence.test.ts
+++ b/tests/unit/extension-install-evidence.test.ts
@@ -37,6 +37,44 @@ describe("deriveExtensionInstallEvidence", () => {
     });
   });
 
+  it("accepts a manifest without a loading order", () => {
+    expect(
+      deriveExtensionInstallEvidence({
+        sourceId: "github-42",
+        repository,
+        manifestPath: "manifest.json",
+        manifest: {
+          display_name: "Character Library",
+          js: "index.js",
+        },
+        observedAt: "2026-08-18T12:00:00.000Z",
+      }),
+    ).toMatchObject({
+      schema_version: 1,
+      source_id: "github-42",
+      head_sha: "a".repeat(40),
+      manifest_path: "manifest.json",
+      status: "verified",
+      folder_name: "alpha",
+    });
+  });
+
+  it("rejects a non-numeric loading order when present", () => {
+    expect(
+      deriveExtensionInstallEvidence({
+        sourceId: "github-42",
+        repository,
+        manifestPath: "manifest.json",
+        manifest: {
+          display_name: "Alpha",
+          loading_order: "first",
+          js: "index.js",
+        },
+        observedAt: "2026-08-18T12:00:00.000Z",
+      }),
+    ).toMatchObject({ status: "unavailable", reason: "invalid-manifest" });
+  });
+
   it.each([
     ["nested manifest", "extension/manifest.json", "manifest-not-at-root"],
     ["missing js", "manifest.json", "invalid-manifest"],


### PR DESCRIPTION
## Summary

- accept repository-root SillyTavern manifests when `loading_order` is omitted
- continue rejecting present non-numeric `loading_order` values
- revalidate cached `invalid-manifest` evidence during the explicit backfill
- publish 12 newly verified install contracts, including Character Library

## Root cause

Tavernary required a finite `loading_order` even though SillyTavern tolerates an omitted value. The resulting cached `invalid-manifest` evidence caused the public catalog to omit otherwise valid install contracts, and Companion rendered those entries as “Install contract unavailable.”

## Impact

The rebuilt schema-7 catalog adds install contracts to 12 existing projects without changing their other public project fields. Four derived Kit references update consistently.

## Validation

- `npm.cmd test` — 224 files, 2,543 tests passed
- `npm.cmd run lint`
- `npm.cmd run palette:audit`
- `npm.cmd run catalog:validate`
- `npm.cmd run security:validate-reports`
- `npm.cmd run catalog:build`
- `npm.cmd run typecheck`
- `npm.cmd run build` — 403 static pages generated
- `npm.cmd run verify:export`
- independent diff review: ready to merge with no findings

The aggregate `npm.cmd run check` stops at its first formatting phase because the current Windows checkout reports pre-existing CRLF drift in 796 untouched files. Change-scoped whitespace checks and every remaining gate above pass.
