### PR TITLE
fix(ci): reclaim orphan owner branches

### DIFF
--- a/.github/workflows/generate-project-owner-request.yml
+++ b/.github/workflows/generate-project-owner-request.yml
@@ -114,7 +114,7 @@ jobs:
             echo "branch=$branch"
             echo "remote_sha=$remote_sha"
           } >> "$GITHUB_OUTPUT"
-      - name: Refuse unowned or maintainer-diverged branches
+      - name: Protect marked owner branches
         shell: bash
         env:
           PR_NUMBER: ${{ steps.state.outputs.pr_number }}
@@ -122,9 +122,8 @@ jobs:
           REMOTE_SHA: ${{ steps.state.outputs.remote_sha }}
         run: |
           set -euo pipefail
-          if [[ -n "$REMOTE_SHA" && -z "$PR_NUMBER" ]]; then
-            echo "::error::Owner request branch exists without an open marked PR."
-            exit 1
+          if [[ -z "$PR_NUMBER" && -n "$REMOTE_SHA" ]]; then
+            echo "::notice::Reclaiming issue-owned orphan branch at exact remote SHA $REMOTE_SHA."
           fi
           if [[ -n "$PR_NUMBER" &&
                 ( -z "$REMOTE_SHA" || -z "$MARKER_SHA" ||

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -1797,6 +1797,15 @@ test("generates owner review PRs with operation-scoped guarded writes", async ()
   expect(source).not.toContain('gh pr list --state open --head "$branch"');
   expect(source).toContain("git push --force-with-lease=");
   expect(source).not.toMatch(/git push (?:--force|-f)(?!-with-lease)/);
+  expect(source).toContain(
+    "Reclaiming issue-owned orphan branch at exact remote SHA",
+  );
+  expect(source).not.toContain(
+    "Owner request branch exists without an open marked PR.",
+  );
+  expect(source).toMatch(
+    /if \[\[ -n "\$PR_NUMBER" &&[\s\S]*"\$REMOTE_SHA" != "\$MARKER_SHA"/u,
+  );
   expect(source).toContain("feat(catalog): apply owner request #");
   expect(source).toContain("npm run catalog:validate");
   expect(source).toContain("npm run catalog:build");


### PR DESCRIPTION
## Summary

- allow the Publisher workflow to reclaim an issue-owned generated branch left without a PR
- retain exact-SHA force-with-lease replacement
- continue rejecting marked PR branches whose remote head diverges

## Verification

- npm.cmd test -- tests/unit/workflows.test.ts
- npm.cmd run check