### PR TITLE
fix(ci): complete orphan owner recovery

### DIFF
--- a/.github/workflows/generate-project-owner-request.yml
+++ b/.github/workflows/generate-project-owner-request.yml
@@ -460,6 +460,7 @@ jobs:
             repository: process.env.GITHUB_REPOSITORY,
             remoteHeadSha: process.env.REMOTE_SHA || null,
             existingMarker: marker ? { kind: "project-owner", marker } : null,
+            allowOrphanRecovery: !existingPull && Boolean(process.env.REMOTE_SHA),
             generatedContentChanged: process.env.CHANGED === "true",
             pulls,
           });

--- a/scripts/help/project-owner-pr.d.mts
+++ b/scripts/help/project-owner-pr.d.mts
@@ -150,6 +150,7 @@ export function planOwnerPrUpdate(input: {
       }
     | { kind: "project-submission"; marker: Record<string, unknown> }
     | null;
+  allowOrphanRecovery?: boolean;
   generatedContentChanged: boolean;
   pulls?: any[];
 }): OwnerPrUpdatePlan;

--- a/scripts/help/project-owner-pr.mjs
+++ b/scripts/help/project-owner-pr.mjs
@@ -8,6 +8,7 @@ import {
 } from "../publication/project-publication-transaction.mjs";
 
 const markerStart = "<!-- tavernary-project-owner-pr";
+const SHA1_PATTERN = /^[a-f0-9]{40}$/u;
 const PROJECT_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/u;
 const LOGIN_PATTERN = /^(?!-)[A-Za-z0-9-]{1,39}(?<!-)$/u;
 const OPERATIONS = new Set(["edit-card", "move-source", "delist"]);
@@ -566,6 +567,14 @@ function planSourceAwareOwnerPrUpdate(input) {
   }
   if (input.remoteHeadSha === null) {
     return { action: "create", replacePaths: [...expected.generated_paths] };
+  }
+  if (
+    input.allowOrphanRecovery === true &&
+    input.existingMarker === null &&
+    SHA1_PATTERN.test(input.remoteHeadSha)
+  ) {
+    if (!input.generatedContentChanged) return { action: "noop" };
+    return { action: "update", replacePaths: [...expected.generated_paths] };
   }
   const existing = input.existingMarker?.marker;
   if (

--- a/tests/unit/project-owner-pr.test.ts
+++ b/tests/unit/project-owner-pr.test.ts
@@ -590,6 +590,20 @@ test("plans one manual PR transaction for a multi-card source batch", () => {
     planOwnerPrUpdate({
       report,
       repository: "Tavernary/Tavernary",
+      remoteHeadSha: "f".repeat(40),
+      existingMarker: null,
+      generatedContentChanged: true,
+      allowOrphanRecovery: true,
+      pulls: [],
+    }),
+  ).toEqual({
+    action: "update",
+    replacePaths: report.generated_paths,
+  });
+  expect(
+    planOwnerPrUpdate({
+      report,
+      repository: "Tavernary/Tavernary",
       remoteHeadSha: "a".repeat(40),
       existingMarker: { kind: "project-owner", marker: addTransaction },
       generatedContentChanged: true,

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -1800,6 +1800,7 @@ test("generates owner review PRs with operation-scoped guarded writes", async ()
   expect(source).toContain(
     "Reclaiming issue-owned orphan branch at exact remote SHA",
   );
+  expect(source).toContain("allowOrphanRecovery: !existingPull");
   expect(source).not.toContain(
     "Owner request branch exists without an open marked PR.",
   );


### PR DESCRIPTION
## Summary

- let the owner PR planner accept an explicitly authorized orphan recovery
- require no existing marker and a valid exact remote SHA
- keep all normal marker ownership and maintainer-divergence checks fail-closed

## Verification

- npm.cmd test -- tests/unit/project-owner-pr.test.ts tests/unit/workflows.test.ts
- npm.cmd run typecheck
- npm.cmd run check