### PR TITLE
fix: preserve unchanged owner metadata

### DIFF
--- a/scripts/help/generate-project-owner-request.mjs
+++ b/scripts/help/generate-project-owner-request.mjs
@@ -415,6 +415,21 @@ function proposedMetadataByProjectId(decision) {
   );
 }
 
+function ownerMetadataFieldsToGenerate(record, request) {
+  const automaticFields = metadataFieldsToGenerate(record);
+  if (!request || request.isNew) return automaticFields;
+
+  const metadataChanged =
+    request.original.summary !== request.proposed.summary ||
+    request.original.metadata.summary.mode !==
+      request.proposed.metadata.summary.mode ||
+    JSON.stringify(request.original.tags) !==
+      JSON.stringify(request.proposed.tags) ||
+    request.original.metadata.tags.mode !== request.proposed.metadata.tags.mode;
+
+  return metadataChanged ? automaticFields : [];
+}
+
 function ownerProtectedTerms(final, record, submittedSummary = "") {
   const repositoryParts =
     typeof final.source.repository === "string"
@@ -555,7 +570,7 @@ async function resolveOwnerMetadata(input, final, snapshot, catalogedAt) {
     if (!request) {
       throw new Error(`Owner metadata request is missing for ${record.id}.`);
     }
-    const requestedFields = metadataFieldsToGenerate(record);
+    const requestedFields = ownerMetadataFieldsToGenerate(record, request);
     let summary = request.proposed.summary;
     let tags = structuredClone(request.proposed.tags);
 
@@ -934,8 +949,11 @@ export async function generateProjectOwnerRequest(input) {
     final.priorContents.set(snapshotRecord.path, snapshotRecord.contents);
   }
   const metadataCandidates = ownerMetadataCandidates(final, catalogedAt);
+  const proposedMetadata = proposedMetadataByProjectId(final.decision);
   const needsAutomaticMetadata = metadataCandidates.some(
-    (record) => metadataFieldsToGenerate(record).length > 0,
+    (record) =>
+      ownerMetadataFieldsToGenerate(record, proposedMetadata.get(record.id))
+        .length > 0,
   );
   const metadataSnapshotRecord =
     !input.validatedReport &&

--- a/tests/unit/generate-project-owner-request.test.ts
+++ b/tests/unit/generate-project-owner-request.test.ts
@@ -493,7 +493,7 @@ test("replays one validated automatic metadata result without calling the provid
   manifest.proposed = {
     ...editable("Original summary.", {
       summaryMode: "automatic",
-      tagMode: "automatic",
+      tagMode: "manual",
     }),
     name: "Alpha Renamed",
   };
@@ -504,7 +504,6 @@ test("replays one validated automatic metadata result without calling the provid
         "Alpha provides a source-grounded workflow for repository automation and keeps catalog metadata aligned with its documented behavior.",
       evidence: ["readme:4-10"],
     },
-    tags: [{ id: "automation", evidence: ["readme:12-18"] }],
     result: "accepted-unchanged",
     change_reasons: [],
     policy_signal: "none",
@@ -896,6 +895,57 @@ test("preserves a manual summary and generates only automatic tags", async () =>
       requested_fields: ["tags"],
     }),
   ]);
+});
+
+test("preserves unchanged automatic metadata during a name-only edit", async () => {
+  const manifest = editManifest();
+  manifest.original = {
+    kind: "extension",
+    ...editable("Original summary.", {
+      summaryMode: "automatic",
+      tagMode: "automatic",
+    }),
+  };
+  manifest.proposed = editable("Original summary.", {
+    summaryMode: "automatic",
+    tagMode: "automatic",
+  });
+  manifest.proposed.name = "Renamed Alpha";
+  const fixture = harness(manifest);
+  const copySummary = vi.fn();
+  const enrichMetadata = vi.fn();
+  const loadEnrichmentSource = vi.fn();
+
+  const generated = await generate(fixture, {
+    copySummary,
+    enrichMetadata,
+    loadEnrichmentSource,
+  });
+  const written = JSON.parse(fixture.storage.get(projectPath) ?? "");
+
+  expect(copySummary).not.toHaveBeenCalled();
+  expect(enrichMetadata).not.toHaveBeenCalled();
+  expect(loadEnrichmentSource).not.toHaveBeenCalled();
+  expect(written).toMatchObject({
+    name: "Renamed Alpha",
+    summary: "Original summary.",
+    tags: ["automation"],
+    metadata_policy: {
+      summary: { mode: "automatic" },
+      tags: { mode: "automatic" },
+    },
+  });
+  expect(generated.report).toMatchObject({
+    copy_results: [],
+    metadata_results: [],
+    resolved_metadata: {
+      "owner-alpha": {
+        summary: "Original summary.",
+        tags: ["automation"],
+      },
+    },
+  });
+  expect(generated.report).not.toHaveProperty("copy_mode");
 });
 
 test("generates an automatic summary without changing manual tags", async () => {


### PR DESCRIPTION
## Summary
- skip automatic metadata enrichment for edit-card requests that do not change summary, tags, or their policies
- keep enrichment active for new cards and intentional metadata changes
- cover name-only edits and validated metadata replay

## Verification
- npm.cmd test -- tests/unit/generate-project-owner-request.test.ts
- npm.cmd run check (224 files, 2554 tests, 403 static pages, export verified)