### PR TITLE
fix: repair owner publication retry

### DIFF
--- a/.github/workflows/generate-project-owner-request.yml
+++ b/.github/workflows/generate-project-owner-request.yml
@@ -150,8 +150,9 @@ jobs:
           git config user.email "tavernary-publisher[bot]@users.noreply.github.com"
           if [[ -n "$PR_NUMBER" ]]; then
             git fetch origin "refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"
-            git checkout -B "$BRANCH" "origin/$BRANCH"
-            git rebase origin/main
+          fi
+          git checkout -B "$BRANCH" origin/main
+          if [[ -n "$PR_NUMBER" ]]; then
             while IFS= read -r generated_path; do
               [[ -z "$generated_path" ]] && continue
               case "$generated_path" in
@@ -167,8 +168,6 @@ jobs:
                 rm -f -- "$generated_path"
               fi
             done < "${RUNNER_TEMP}/previous-owner-paths.txt"
-          else
-            git checkout -B "$BRANCH" origin/main
           fi
           node scripts/help/generate-project-owner-request.mjs \
             --issue-number "$ISSUE_NUMBER" \

--- a/.github/workflows/publish-project-transaction.yml
+++ b/.github/workflows/publish-project-transaction.yml
@@ -167,6 +167,7 @@ jobs:
           import tags from "./data/vocabularies/tags.json" with { type: "json" };
           import modelFamilies from "./data/vocabularies/model-families.json" with { type: "json" };
           import completionFormats from "./data/vocabularies/completion-formats.json" with { type: "json" };
+          import { tagVocabularyHash } from "./scripts/catalog/tag-vocabulary.mjs";
           import { normalizeProjectOwnerManifest } from "./src/features/help/project-owner-manifest.mjs";
           import {
             fingerprintProjectRecord,
@@ -232,6 +233,7 @@ jobs:
                   frontends: frontends.frontends,
                   primaryFunctions: primaryFunctions.primary_functions,
                   tags: tags.tags,
+                  tagVocabularyHash: tagVocabularyHash(tags),
                   modelFamilies: modelFamilies.model_families,
                   completionFormats: completionFormats.completion_formats,
                   source,

--- a/tests/unit/project-automatic-publication-workflow.test.ts
+++ b/tests/unit/project-automatic-publication-workflow.test.ts
@@ -35,6 +35,10 @@ test("publishes successful generated project transactions by exact SHA", async (
   expect(source).toContain("projectFingerprints");
   expect(source).toContain("sourceFingerprint");
   expect(source).toContain('import tags from "./data/vocabularies/tags.json"');
+  expect(source).toContain(
+    'import { tagVocabularyHash } from "./scripts/catalog/tag-vocabulary.mjs"',
+  );
+  expect(source).toContain("tagVocabularyHash: tagVocabularyHash(tags)");
   expect(source).not.toContain(
     'import capabilities from "./data/vocabularies/capabilities.json"',
   );

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -1726,7 +1726,11 @@ test("generates owner review PRs with operation-scoped guarded writes", async ()
   ) as { with?: { "fetch-depth"?: number; ref?: string } } | undefined;
   const generationJob = generation.jobs.generate as {
     env?: Record<string, string>;
-    steps: Array<{ name?: string; env?: Record<string, string> }>;
+    steps: Array<{
+      name?: string;
+      env?: Record<string, string>;
+      run?: string;
+    }>;
   };
   const modelStep = generationJob.steps.find(
     (step) => step.name === "Generate from latest main and issue state",
@@ -1797,6 +1801,8 @@ test("generates owner review PRs with operation-scoped guarded writes", async ()
   expect(source).not.toContain('gh pr list --state open --head "$branch"');
   expect(source).toContain("git push --force-with-lease=");
   expect(source).not.toMatch(/git push (?:--force|-f)(?!-with-lease)/);
+  expect(modelStep?.run).not.toContain("git rebase origin/main");
+  expect(modelStep?.run).toContain('git checkout -B "$BRANCH" origin/main');
   expect(source).toContain(
     "Reclaiming issue-owned orphan branch at exact remote SHA",
   );


### PR DESCRIPTION
## Summary
- revalidate owner manifests with the same current tag-vocabulary hash used by intake and generation
- rebuild guarded owner PR updates from current main instead of rebasing the prior generated commit
- cover both workflow contracts

## Verification
- npm.cmd test -- tests/unit/project-automatic-publication-workflow.test.ts tests/unit/workflows.test.ts tests/unit/project-owner-pr.test.ts tests/unit/project-publication-planner.test.ts
- npm.cmd run check (224 files, 2554 tests, 403 static pages, export verified)