### PR TITLE
fix(automation): publish rebuilt catalog

### DIFF
--- a/.github/workflows/import-tavernkeeper-reports.yml
+++ b/.github/workflows/import-tavernkeeper-reports.yml
@@ -102,8 +102,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          git add -- data/security/tavernkeeper-report-summaries.json data/security/tavernkeeper-import-state.json
-          if git diff --cached --quiet -- data/security/tavernkeeper-report-summaries.json data/security/tavernkeeper-import-state.json; then
+          git add -- data/security/tavernkeeper-report-summaries.json data/security/tavernkeeper-import-state.json public/catalog/tavernary-catalog.json
+          if git diff --cached --quiet -- data/security/tavernkeeper-report-summaries.json data/security/tavernkeeper-import-state.json public/catalog/tavernary-catalog.json; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
             git fetch --no-tags origin main
             git merge --ff-only origin/main

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -1129,6 +1129,12 @@ test("redispatches Pages without gating the next due import", async () => {
     reportValidate,
   );
 
+  expect(commitSource).toContain(
+    "git add -- data/security/tavernkeeper-report-summaries.json data/security/tavernkeeper-import-state.json public/catalog/tavernary-catalog.json",
+  );
+  expect(commitSource).toContain(
+    "git diff --cached --quiet -- data/security/tavernkeeper-report-summaries.json data/security/tavernkeeper-import-state.json public/catalog/tavernary-catalog.json",
+  );
   expect(noDiffStart).toBeGreaterThanOrEqual(0);
   expect(noDiffSource).toContain("git fetch --no-tags origin main");
   expect(noDiffSource).toContain("git merge --ff-only origin/main");


### PR DESCRIPTION
## Summary
- stage the rebuilt public catalog with imported TavernKeeper summaries
- include the catalog in the no-change decision so reconciliation publishes an atomic clean commit
- add workflow regression coverage for both staged and diff-scoped paths

## Verification
- npm.cmd test -- --run tests/unit/workflows.test.ts (62 passed)
- npm.cmd run check (224 files, 2555 tests, 403-page build, export verified)

## Production evidence
Run 32414229109 imported and validated the repaired report schema, then failed because the generated catalog was left unstaged before rebase. This change fixes that exact handoff.
