### PR TITLE
Fix submission install-evidence transactions

### DIFF
--- a/scripts/publication/project-publication-transaction.mjs
+++ b/scripts/publication/project-publication-transaction.mjs
@@ -262,11 +262,15 @@ function derivedPaths(transaction) {
   );
   const sourcePath = `data/registry/sources/${transaction.source_id}.json`;
   const snapshotPath = repositorySnapshotPath(transaction.source_id);
+  const installSnapshotPath = `data/snapshots/install/${transaction.source_id}.json`;
   if (transaction.operation === "create") {
     return [
       ...cardPaths,
       sourcePath,
       ...(snapshotPath ? [snapshotPath] : []),
+      ...(transaction.generated_paths.includes(installSnapshotPath)
+        ? [installSnapshotPath]
+        : []),
       ...(transaction.generated_paths.includes(
         "data/vocabularies/frontends.json",
       )

--- a/tests/unit/project-publication-transaction.test.ts
+++ b/tests/unit/project-publication-transaction.test.ts
@@ -61,6 +61,21 @@ test("accepts a source/card/snapshot create transaction with exact paths", () =>
   );
 });
 
+test("accepts source-bound install evidence in a create transaction", () => {
+  const generatedPaths = [
+    "data/registry/projects/owner-project.json",
+    "data/registry/sources/github-42.json",
+    "data/snapshots/github/github-42.json",
+    "data/snapshots/install/github-42.json",
+  ];
+
+  const transaction = createProjectPublicationTransaction(
+    createInput({ generated_paths: generatedPaths }),
+  );
+
+  expect(expectedTransactionPaths(transaction)).toEqual(generatedPaths);
+});
+
 test("accepts verified-owner manual create fallback without fabricated copy", () => {
   const transaction = createProjectPublicationTransaction(
     createInput({


### PR DESCRIPTION
## Summary
- accept the exact source-bound install-evidence snapshot in create transactions
- preserve rejection of unrelated generated paths and non-create path sets
- cover the production four-path submission transaction with a regression test

## Root cause
Submission generation began committing install-evidence snapshots, but the signed transaction validator's canonical create-path set was not updated. The workflow therefore pushed generated branches and failed before creating review PRs.

## Verification
- npm.cmd run check
- 2,562 tests passed
- 448 projects and 12 Kits validated
- 579 TavernKeeper report summaries validated; 0 quarantined
- 414 static pages built and export verified