### PR TITLE
Stop project publication backlog loops

### DIFF
--- a/.github/workflows/publish-project-transaction.yml
+++ b/.github/workflows/publish-project-transaction.yml
@@ -77,7 +77,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.repository.default_branch }}
-          fetch-depth: 1
+          fetch-depth: 0
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
@@ -171,8 +171,23 @@ jobs:
           RUN_HEAD_BRANCH: ${{ steps.validation.outputs.head_branch }}
         run: |
           set -euo pipefail
-          main_sha="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${{ github.event.repository.default_branch }}" --jq '.sha')"
-          CURRENT_MAIN_SHA="$main_sha" node --input-type=module <<'NODE'
+          git fetch --no-tags origin "${{ github.event.repository.default_branch }}"
+          git checkout --detach "origin/${{ github.event.repository.default_branch }}"
+          main_sha="$(git rev-parse HEAD)"
+          base_sha="$(node -p "JSON.parse(require('fs').readFileSync('${RUNNER_TEMP}/project-publication-transaction.json','utf8')).base_sha")"
+          base_drift_raw="${RUNNER_TEMP}/project-publication-base-drift-paths.nul"
+          base_drift_json="${RUNNER_TEMP}/project-publication-base-drift-paths.json"
+          base_is_ancestor=false
+          : > "$base_drift_raw"
+          if git merge-base --is-ancestor "$base_sha" "$main_sha"; then
+            base_is_ancestor=true
+            git diff --name-only -z "$base_sha" "$main_sha" > "$base_drift_raw"
+          fi
+          node -e "const fs=require('fs'); const paths=fs.readFileSync(process.argv[1]).toString('utf8').split('\\0').filter(Boolean); fs.writeFileSync(process.argv[2],JSON.stringify(paths))" \
+            "$base_drift_raw" "$base_drift_json"
+          CURRENT_MAIN_SHA="$main_sha" \
+            BASE_IS_ANCESTOR="$base_is_ancestor" \
+            node --input-type=module <<'NODE'
           import fs from "node:fs";
           import trustedEditors from "./data/maintenance/trusted-tavernary-editors.json" with { type: "json" };
           import frontends from "./data/vocabularies/frontends.json" with { type: "json" };
@@ -188,7 +203,10 @@ jobs:
           } from "./src/features/help/project-owner-record.mjs";
           import { verifyTrustedEditor } from "./scripts/maintenance/trusted-editor-authority.mjs";
           import { parseProjectSubmissionIssue } from "./scripts/submissions/parse-project-submission.mjs";
-          import { planProjectPublication } from "./scripts/publication/project-publication-planner.mjs";
+          import {
+            isSafeProjectPublicationBaseDrift,
+            planProjectPublication,
+          } from "./scripts/publication/project-publication-planner.mjs";
           import { fingerprintProjectPublicationInput } from "./scripts/publication/project-publication-transaction.mjs";
 
           const read = (name) => JSON.parse(
@@ -200,6 +218,8 @@ jobs:
           const repository = read("project-publication-source-repository.json");
           const filePages = read("project-publication-files.json");
           const changedPaths = filePages.flat().map(({ filename }) => filename);
+          const baseChangedPaths = read("project-publication-base-drift-paths.json");
+          const baseIsAncestor = process.env.BASE_IS_ANCESTOR === "true";
           const sourcePath =
             `data/registry/sources/${transaction.source_id}.json`;
           const source = fs.existsSync(sourcePath)
@@ -294,6 +314,12 @@ jobs:
             changedPaths,
             current: {
               mainSha: process.env.CURRENT_MAIN_SHA,
+              baseDriftSafe:
+                baseIsAncestor &&
+                isSafeProjectPublicationBaseDrift({
+                  transaction,
+                  changedPaths: baseChangedPaths,
+                }),
               inputDigest,
               projectFingerprints,
               sourceFingerprint,

--- a/scripts/publication/project-publication-planner.d.mts
+++ b/scripts/publication/project-publication-planner.d.mts
@@ -36,3 +36,8 @@ export type ProjectPublicationPlan =
 export function planProjectPublication(
   input: Record<string, any>,
 ): ProjectPublicationPlan;
+
+export function isSafeProjectPublicationBaseDrift(input: {
+  transaction: ProjectPublicationTransaction;
+  changedPaths: string[];
+}): boolean;

--- a/scripts/publication/project-publication-planner.mjs
+++ b/scripts/publication/project-publication-planner.mjs
@@ -5,6 +5,28 @@ const generatedBranches = [
   ["project-owner-request", "automation/project-owner-request-"],
 ];
 
+const safeConcurrentDataPaths = [
+  /^data\/registry\/projects\/[^/]+\.json$/u,
+  /^data\/registry\/sources\/[^/]+\.json$/u,
+  /^data\/snapshots\/(?:codeberg|github|install)\/[^/]+\.json$/u,
+  /^data\/security\/tavernkeeper-report-summaries\.json$/u,
+  /^public\/catalog\/tavernary-catalog(?:-v8)?\.json$/u,
+];
+
+export function isSafeProjectPublicationBaseDrift(input) {
+  const generatedPaths = new Set(input?.transaction?.generated_paths ?? []);
+  const changedPaths = input?.changedPaths;
+  return (
+    Array.isArray(changedPaths) &&
+    changedPaths.every(
+      (path) =>
+        typeof path === "string" &&
+        !generatedPaths.has(path) &&
+        safeConcurrentDataPaths.some((pattern) => pattern.test(path)),
+    )
+  );
+}
+
 function labels(issue) {
   return new Set(
     (issue?.labels ?? [])
@@ -120,7 +142,10 @@ export function planProjectPublication(input) {
   ) {
     return regenerate(transaction, "source-fingerprint-stale");
   }
-  if (input.current.mainSha !== transaction.base_sha) {
+  if (
+    input.current.mainSha !== transaction.base_sha &&
+    input.current.baseDriftSafe !== true
+  ) {
     return regenerate(transaction, "base-behind-main");
   }
   if (transaction.publication_mode === "manual") {

--- a/tests/kits-e2e/kits.spec.ts
+++ b/tests/kits-e2e/kits.spec.ts
@@ -871,6 +871,7 @@ test("compact cards keep title, scan, and Kit actions independently usable", asy
   await expect(page.locator(".catalog-shell")).toHaveAttribute(
     "data-hydrated",
     "true",
+    { timeout: 15_000 },
   );
 
   const shell = page.locator(".project-card-shell").first();

--- a/tests/unit/project-automatic-publication-workflow.test.ts
+++ b/tests/unit/project-automatic-publication-workflow.test.ts
@@ -148,6 +148,34 @@ test("publishes successful generated project transactions by exact SHA", async (
   expect(source).toContain("projects,");
 });
 
+test("accepts only trusted concurrent data drift from main", async () => {
+  const workflow = parse(
+    await readFile(".github/workflows/publish-project-transaction.yml", "utf8"),
+  ) as any;
+  const steps = workflow.jobs.publish.steps as Array<{
+    id?: string;
+    name?: string;
+    run?: string;
+    with?: Record<string, unknown>;
+  }>;
+  const checkout = steps.find(
+    (step) => step.name === "Check out current default-branch publisher",
+  );
+  const plan = steps.find((step) => step.id === "plan");
+
+  expect(checkout?.with?.["fetch-depth"]).toBe(0);
+  expect(plan?.run).toContain(
+    'git merge-base --is-ancestor "$base_sha" "$main_sha"',
+  );
+  expect(plan?.run).toContain(
+    'git diff --name-only -z "$base_sha" "$main_sha"',
+  );
+  expect(plan?.run).toContain("isSafeProjectPublicationBaseDrift");
+  expect(plan?.run).toMatch(
+    /baseDriftSafe:\s*baseIsAncestor &&\s*isSafeProjectPublicationBaseDrift/u,
+  );
+});
+
 test("rejects generated pull requests outside Publisher custody before planning", async () => {
   const workflow = parse(
     await readFile(".github/workflows/publish-project-transaction.yml", "utf8"),

--- a/tests/unit/project-publication-planner.test.ts
+++ b/tests/unit/project-publication-planner.test.ts
@@ -1,6 +1,9 @@
 import { expect, test } from "vitest";
 
-import { planProjectPublication } from "../../scripts/publication/project-publication-planner.mjs";
+import {
+  isSafeProjectPublicationBaseDrift,
+  planProjectPublication,
+} from "../../scripts/publication/project-publication-planner.mjs";
 import { createProjectPublicationTransaction } from "../../scripts/publication/project-publication-transaction.mjs";
 
 const headSha = "c".repeat(40);
@@ -69,6 +72,7 @@ function input(overrides: Record<string, unknown> = {}) {
     changedPaths: transaction.generated_paths,
     current: {
       mainSha: baseSha,
+      baseDriftSafe: true,
       inputDigest: transaction.input_digest,
       projectFingerprints: {},
       sourceFingerprint: null,
@@ -89,6 +93,20 @@ test("merges a successful exact generated transaction", () => {
     projectIds: ["owner-project"],
     sourceId: "github-42",
   });
+});
+
+test("merges when main advances without touching generated transaction paths", () => {
+  expect(
+    planProjectPublication(
+      input({
+        current: {
+          ...input().current,
+          mainSha: "e".repeat(40),
+          baseDriftSafe: true,
+        },
+      }),
+    ),
+  ).toMatchObject({ action: "merge", pullNumber: 73 });
 });
 
 test.each([undefined, false])("pauses when the switch is %s", (enabled) => {
@@ -134,7 +152,7 @@ test("retries unsuccessful or pending mergeability checks", () => {
 
 test.each([
   ["input-digest-stale", { inputDigest: "d".repeat(64) }],
-  ["base-behind-main", { mainSha: "e".repeat(40) }],
+  ["base-behind-main", { mainSha: "e".repeat(40), baseDriftSafe: false }],
   [
     "project-fingerprint-stale",
     { projectFingerprints: { "owner-project": "f".repeat(64) } },
@@ -194,6 +212,41 @@ test.each([
     producer: "project-owner-request",
     issueNumber: 72,
   });
+});
+
+test("allows only disjoint generated data and report artifacts as safe base drift", () => {
+  expect(
+    isSafeProjectPublicationBaseDrift({
+      transaction,
+      changedPaths: [
+        "data/registry/projects/another-project.json",
+        "data/registry/sources/github-99.json",
+        "data/snapshots/github/github-99.json",
+        "data/snapshots/install/github-99.json",
+        "data/security/tavernkeeper-report-summaries.json",
+        "public/catalog/tavernary-catalog-v8.json",
+        "public/catalog/tavernary-catalog.json",
+      ],
+    }),
+  ).toBe(true);
+  expect(
+    isSafeProjectPublicationBaseDrift({
+      transaction,
+      changedPaths: [transaction.generated_paths[0]],
+    }),
+  ).toBe(false);
+  expect(
+    isSafeProjectPublicationBaseDrift({
+      transaction,
+      changedPaths: [".github/workflows/ci.yml"],
+    }),
+  ).toBe(false);
+  expect(
+    isSafeProjectPublicationBaseDrift({
+      transaction,
+      changedPaths: ["data/vocabularies/frontends.json"],
+    }),
+  ).toBe(false);
 });
 
 test("holds a valid manual transaction for deliberate maintainer approval", () => {

--- a/tests/visual/theme.visual.spec.ts
+++ b/tests/visual/theme.visual.spec.ts
@@ -91,6 +91,7 @@ async function waitForCatalogHydration(page: Page) {
   await expect(page.locator(".catalog-shell")).toHaveAttribute(
     "data-hydrated",
     "true",
+    { timeout: 15_000 },
   );
 }
 


### PR DESCRIPTION
## Summary

- give catalog hydration readiness a consistent 15-second window
- allow Publisher merges across unrelated report and disjoint transaction data drift
- continue regenerating for code, workflow, policy, vocabulary, dependency, or exact-path changes

## Verification

- npm.cmd run check
- targeted project publication planner and workflow tests
- targeted catalog visual and Kit browser tests