### PR TITLE
Constrain generated evidence references

### DIFF
--- a/scripts/catalog/enrichment-provider.mjs
+++ b/scripts/catalog/enrichment-provider.mjs
@@ -157,7 +157,7 @@ function responseSchema(input) {
     type: "array",
     minItems: 1,
     maxItems: 8,
-    items: { type: "string" },
+    items: { type: "string", minLength: 1, maxLength: 160 },
   };
   const required = [
     ...requestedFields,

--- a/tests/unit/enrichment-provider.test.ts
+++ b/tests/unit/enrichment-provider.test.ts
@@ -208,6 +208,13 @@ test("sends the exact model, hardened prompt, requested fields, and strict schem
   });
   expect(schema.properties.summary.properties.evidence.items).toEqual({
     type: "string",
+    minLength: 1,
+    maxLength: 160,
+  });
+  expect(schema.properties.tags.items.properties.evidence.items).toEqual({
+    type: "string",
+    minLength: 1,
+    maxLength: 160,
   });
   expect(JSON.stringify(schema)).not.toContain('"uniqueItems"');
   expect(schema.properties.tags.items.properties.id.enum).toEqual([


### PR DESCRIPTION
Summary:
- Add the existing 1 to 160 character evidence-reference contract directly to the strict enrichment response schema.
- Apply the same bound to summary and tag evidence so invalid machine output is repaired at the provider boundary instead of failing project generation.

Verification:
- npm.cmd run check
- 226 test files, 2632 tests
- post-rebase enrichment-provider tests: 55 passed
- 658 TavernKeeper report summaries validated