### PR TITLE
Wake reconciliation after generated validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,3 +129,27 @@ jobs:
         run: npm run test:kits-e2e
       - name: Run Kit fixture layout regression tests
         run: npm run test:kits-visual
+
+  reconcile-generated-validation:
+    needs:
+      - verify
+      - visual
+    if: >-
+      always() &&
+      github.event_name == 'workflow_dispatch' &&
+      (startsWith(github.ref_name, 'automation/project-submission-') ||
+       startsWith(github.ref_name, 'automation/project-owner-request-')) &&
+      needs.verify.result == 'success' &&
+      needs.visual.result == 'success'
+    permissions:
+      actions: write
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wake serialized publication reconciliation
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          gh workflow run reconcile-project-validations.yml
+          --repo "$GITHUB_REPOSITORY" --ref main
+          -f validation_run_id="$GITHUB_RUN_ID"

--- a/.github/workflows/reconcile-project-validations.yml
+++ b/.github/workflows/reconcile-project-validations.yml
@@ -12,6 +12,11 @@ on:
   schedule:
     - cron: "7,22,37,52 * * * *"
   workflow_dispatch:
+    inputs:
+      validation_run_id:
+        description: "Completed generated validation run to reconcile"
+        required: false
+        type: string
 
 permissions:
   actions: write
@@ -30,7 +35,9 @@ jobs:
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' &&
        (github.actor_id == 2625904 ||
-        github.actor_id == vars.TAVERNARY_PUBLISHER_BOT_ID)) ||
+        github.actor_id == vars.TAVERNARY_PUBLISHER_BOT_ID ||
+        (github.actor == 'github-actions[bot]' &&
+         inputs.validation_run_id != ''))) ||
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.head_repository.full_name == github.repository &&
        ((github.event.workflow_run.path == '.github/workflows/ci.yml' &&
@@ -53,6 +60,14 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
+      - name: Await dispatched validation completion
+        if: github.event_name == 'workflow_dispatch' && inputs.validation_run_id != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VALIDATION_RUN_ID: ${{ inputs.validation_run_id }}
+        run: >-
+          gh run watch "$VALIDATION_RUN_ID" --repo "$GITHUB_REPOSITORY"
+          --interval 5 --exit-status
       - name: Reconcile generated project validations
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/tests/unit/project-automatic-publication-workflow.test.ts
+++ b/tests/unit/project-automatic-publication-workflow.test.ts
@@ -35,7 +35,15 @@ test("reconciles generated validation runs from trusted main code", async () => 
       types: ["completed"],
     },
     schedule: [{ cron: "7,22,37,52 * * * *" }],
-    workflow_dispatch: null,
+    workflow_dispatch: {
+      inputs: {
+        validation_run_id: {
+          description: "Completed generated validation run to reconcile",
+          required: false,
+          type: "string",
+        },
+      },
+    },
   });
   expect(workflow.permissions).toEqual({
     actions: "write",
@@ -86,6 +94,19 @@ test("reconciles generated validation runs from trusted main code", async () => 
   expect(reconcile.if).not.toContain("243524590");
   expect(checkout?.with?.ref).toBe("main");
   expect(setupNode?.with?.["node-version"]).toBe(24);
+  expect(steps).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        name: "Await dispatched validation completion",
+        if: expect.stringContaining("inputs.validation_run_id != ''"),
+        env: {
+          GH_TOKEN: "${{ github.token }}",
+          VALIDATION_RUN_ID: "${{ inputs.validation_run_id }}",
+        },
+        run: expect.stringContaining('gh run watch "$VALIDATION_RUN_ID"'),
+      }),
+    ]),
+  );
   expect(steps).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -331,6 +352,34 @@ test("merges validated project transactions with the Publisher App", async () =>
 test("hands successful generated CI to the serialized reconciler", async () => {
   const ci = parse(await readFile(".github/workflows/ci.yml", "utf8")) as any;
   expect(ci.jobs).not.toHaveProperty("dispatch-project-publication");
+
+  const handoff = ci.jobs["reconcile-generated-validation"];
+  expect(handoff.needs).toEqual(["verify", "visual"]);
+  expect(handoff.if).toContain("github.event_name == 'workflow_dispatch'");
+  expect(handoff.if).toContain(
+    "startsWith(github.ref_name, 'automation/project-submission-')",
+  );
+  expect(handoff.if).toContain(
+    "startsWith(github.ref_name, 'automation/project-owner-request-')",
+  );
+  expect(handoff.if).toContain("needs.verify.result == 'success'");
+  expect(handoff.if).toContain("needs.visual.result == 'success'");
+  expect(handoff.permissions).toEqual({
+    actions: "write",
+    contents: "read",
+  });
+  expect(handoff.steps).toEqual([
+    expect.objectContaining({
+      env: { GH_TOKEN: "${{ github.token }}" },
+      run: expect.stringContaining(
+        "gh workflow run reconcile-project-validations.yml",
+      ),
+    }),
+  ]);
+  expect(handoff.steps[0].run).toContain("--ref main");
+  expect(handoff.steps[0].run).toContain(
+    '-f validation_run_id="$GITHUB_RUN_ID"',
+  );
 
   const reconciliationSource = await readFile(
     ".github/workflows/reconcile-project-validations.yml",


### PR DESCRIPTION
## Summary
- dispatch the serialized reconciler from successful generated-branch CI with job-scoped Actions permission
- wait for the source validation run to be formally complete before exact-SHA reconciliation
- retain workflow-run and scheduled reconciliation as independent recovery paths

## Verification
- npm.cmd run check
- 226 test files / 2,632 tests
- production build and static export verification
- workflow/publication security contract suite: 163 tests