### PR TITLE
chore: defer eslint 10 updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
         patterns:
           - react
           - react-dom
+    ignore:
+      - dependency-name: eslint
+        update-types:
+          - version-update:semver-major
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/tests/unit/workflows.test.ts
+++ b/tests/unit/workflows.test.ts
@@ -2102,6 +2102,10 @@ test("groups coupled dependency updates into coherent pull requests", async () =
     updates: Array<{
       "package-ecosystem": string;
       groups?: Record<string, { patterns: string[] }>;
+      ignore?: Array<{
+        "dependency-name": string;
+        "update-types"?: string[];
+      }>;
     }>;
   };
   const npm = dependabot.updates.find(
@@ -2112,6 +2116,10 @@ test("groups coupled dependency updates into coherent pull requests", async () =
   );
 
   expect(npm?.groups?.react.patterns).toEqual(["react", "react-dom"]);
+  expect(npm?.ignore).toContainEqual({
+    "dependency-name": "eslint",
+    "update-types": ["version-update:semver-major"],
+  });
   expect(actions?.groups?.actions.patterns).toEqual(["*"]);
 });
 


### PR DESCRIPTION
## Summary

- keep Dependabot on ESLint 9 until the active React and JSX accessibility plugins support ESLint 10
- ignore only ESLint semver-major updates; minor and patch updates remain enabled
- parse the real Dependabot YAML in a regression test and lock the policy contract

## Evidence

The latest #652 head fails the required lint gate under ESLint 10.9.1 with TypeError: scopeManager.addGlobals is not a function. The installed eslint-plugin-react 7.37.5 and eslint-plugin-jsx-a11y 6.10.2 peer ranges stop at ESLint 9.

## Verification

- focused workflow test failed before the config change and passed after it (64/64)
- npm.cmd run check passed (224 files, 2,623 tests; 428 routes; static export verified)
- independent review: clean

Supersedes #652.