### PR TITLE
Curate UI Bedazzler catalog metadata

### DIFF
--- a/data/registry/projects/mokimoko-sillytavern-uibedazzler.json
+++ b/data/registry/projects/mokimoko-sillytavern-uibedazzler.json
@@ -3,18 +3,27 @@
   "id": "mokimoko-sillytavern-uibedazzler",
   "name": "SillyTavern-UIBedazzler",
   "kind": "extension",
-  "summary": "UI Bedazzler is a SillyTavern extension that redesigns some UI elements and adds new ones to refresh the default interface look. It is probably not compatible with most other UI extensions.",
+  "summary": "UI Bedazzler redesigns SillyTavern with chat and character styling, persona lore injection, variable inspection, and expanded character, World Info, and preset workspaces; it may conflict with other UI extensions.",
   "metadata_status": "curated",
   "source_id": "github-1241909047",
   "frontends": ["sillytavern", "tauritavern"],
   "primary_function": "interface-workflow",
-  "tags": ["customize-the-interface"],
+  "tags": [
+    "customize-the-interface",
+    "manage-characters-and-personas",
+    "manage-lorebooks",
+    "manage-prompts-and-presets",
+    "guide-model-responses"
+  ],
   "cataloged_at": "2026-09-02T22:00:21.637Z",
   "catalog_cohort": "standard",
   "listing_status": "active",
   "listing_status_reason": null,
   "metadata_policy": {
-    "summary": { "mode": "automatic" },
-    "tags": { "mode": "automatic" }
+    "summary": {
+      "mode": "manual",
+      "note": "Trusted Tavernary editor selection."
+    },
+    "tags": { "mode": "manual", "note": "Trusted Tavernary editor selection." }
   }
 }

--- a/public/catalog/tavernary-catalog-v8.json
+++ b/public/catalog/tavernary-catalog-v8.json
@@ -65780,7 +65780,7 @@
       "metadataStatus": "curated",
       "sourceStatus": "healthy",
       "primaryFunction": "interface-workflow",
-      "summary": "UI Bedazzler is a SillyTavern extension that redesigns some UI elements and adds new ones to refresh the default interface look. It is probably not compatible with most other UI extensions.",
+      "summary": "UI Bedazzler redesigns SillyTavern with chat and character styling, persona lore injection, variable inspection, and expanded character, World Info, and preset workspaces; it may conflict with other UI extensions.",
       "canonicalUrl": "https://github.com/mokimoko/SillyTavern-UIBedazzler",
       "catalogedAt": "2026-09-02T22:00:21.637Z",
       "catalogCohort": "standard",
@@ -65801,6 +65801,30 @@
           "id": "customize-the-interface",
           "label": "Customize the interface",
           "description": "Change themes, fonts, layouts, controls, panels, or other interface presentation.",
+          "facet": "goal"
+        },
+        {
+          "id": "manage-characters-and-personas",
+          "label": "Manage characters and personas",
+          "description": "Edit, switch, organize, or evolve characters, personas, and their identity fields.",
+          "facet": "goal"
+        },
+        {
+          "id": "manage-lorebooks",
+          "label": "Manage lorebooks",
+          "description": "Organize, edit, inspect, activate, or synchronize lorebook and World Info entries.",
+          "facet": "goal"
+        },
+        {
+          "id": "manage-prompts-and-presets",
+          "label": "Manage prompts and presets",
+          "description": "Create, organize, lock, search, switch, or reuse prompt and preset configurations.",
+          "facet": "goal"
+        },
+        {
+          "id": "guide-model-responses",
+          "label": "Guide model responses",
+          "description": "Shape what the model says, how it behaves, or which instructions it follows.",
           "facet": "goal"
         }
       ],
@@ -65936,7 +65960,7 @@
           "https://github.com/mokimoko/SillyTavern-UIBedazzler"
         ],
         "summary": [
-          "UI Bedazzler is a SillyTavern extension that redesigns some UI elements and adds new ones to refresh the default interface look. It is probably not compatible with most other UI extensions."
+          "UI Bedazzler redesigns SillyTavern with chat and character styling, persona lore injection, variable inspection, and expanded character, World Info, and preset workspaces; it may conflict with other UI extensions."
         ],
         "kind": [
           "extension"
@@ -65948,7 +65972,24 @@
           "Customize the interface",
           "interface theming",
           "layout customization",
-          "UI personalization"
+          "UI personalization",
+          "Manage characters and personas",
+          "persona management",
+          "character management",
+          "identity management",
+          "Manage lorebooks",
+          "World Info management",
+          "worldbook organization",
+          "loredeck management",
+          "Manage prompts and presets",
+          "prompt management",
+          "prompt engineering",
+          "preset organization",
+          "template management",
+          "Guide model responses",
+          "response steering",
+          "generation control",
+          "instruction control"
         ],
         "frontends": [
           "SillyTavern",

--- a/public/catalog/tavernary-catalog.json
+++ b/public/catalog/tavernary-catalog.json
@@ -64983,7 +64983,7 @@
       "metadataStatus": "curated",
       "sourceStatus": "healthy",
       "primaryFunction": "interface-workflow",
-      "summary": "UI Bedazzler is a SillyTavern extension that redesigns some UI elements and adds new ones to refresh the default interface look. It is probably not compatible with most other UI extensions.",
+      "summary": "UI Bedazzler redesigns SillyTavern with chat and character styling, persona lore injection, variable inspection, and expanded character, World Info, and preset workspaces; it may conflict with other UI extensions.",
       "canonicalUrl": "https://github.com/mokimoko/SillyTavern-UIBedazzler",
       "catalogedAt": "2026-09-02T22:00:21.637Z",
       "catalogCohort": "standard",
@@ -65004,6 +65004,30 @@
           "id": "customize-the-interface",
           "label": "Customize the interface",
           "description": "Change themes, fonts, layouts, controls, panels, or other interface presentation.",
+          "facet": "goal"
+        },
+        {
+          "id": "manage-characters-and-personas",
+          "label": "Manage characters and personas",
+          "description": "Edit, switch, organize, or evolve characters, personas, and their identity fields.",
+          "facet": "goal"
+        },
+        {
+          "id": "manage-lorebooks",
+          "label": "Manage lorebooks",
+          "description": "Organize, edit, inspect, activate, or synchronize lorebook and World Info entries.",
+          "facet": "goal"
+        },
+        {
+          "id": "manage-prompts-and-presets",
+          "label": "Manage prompts and presets",
+          "description": "Create, organize, lock, search, switch, or reuse prompt and preset configurations.",
+          "facet": "goal"
+        },
+        {
+          "id": "guide-model-responses",
+          "label": "Guide model responses",
+          "description": "Shape what the model says, how it behaves, or which instructions it follows.",
           "facet": "goal"
         }
       ],
@@ -65137,7 +65161,7 @@
           "https://github.com/mokimoko/SillyTavern-UIBedazzler"
         ],
         "summary": [
-          "UI Bedazzler is a SillyTavern extension that redesigns some UI elements and adds new ones to refresh the default interface look. It is probably not compatible with most other UI extensions."
+          "UI Bedazzler redesigns SillyTavern with chat and character styling, persona lore injection, variable inspection, and expanded character, World Info, and preset workspaces; it may conflict with other UI extensions."
         ],
         "kind": [
           "extension"
@@ -65149,7 +65173,24 @@
           "Customize the interface",
           "interface theming",
           "layout customization",
-          "UI personalization"
+          "UI personalization",
+          "Manage characters and personas",
+          "persona management",
+          "character management",
+          "identity management",
+          "Manage lorebooks",
+          "World Info management",
+          "worldbook organization",
+          "loredeck management",
+          "Manage prompts and presets",
+          "prompt management",
+          "prompt engineering",
+          "preset organization",
+          "template management",
+          "Guide model responses",
+          "response steering",
+          "generation control",
+          "instruction control"
         ],
         "frontends": [
           "SillyTavern",

--- a/tests/unit/full-catalog-data.test.ts
+++ b/tests/unit/full-catalog-data.test.ts
@@ -103,6 +103,32 @@ function countBy<T>(records: T[], selector: (record: T) => string) {
 }
 
 describe("full catalog data", () => {
+  test("keeps UI Bedazzler's documented workflows discoverable", async () => {
+    const { projectsById } = await loadProductionData();
+
+    expect(projectsById.get("mokimoko-sillytavern-uibedazzler")).toMatchObject({
+      summary:
+        "UI Bedazzler redesigns SillyTavern with chat and character styling, persona lore injection, variable inspection, and expanded character, World Info, and preset workspaces; it may conflict with other UI extensions.",
+      tags: [
+        "customize-the-interface",
+        "manage-characters-and-personas",
+        "manage-lorebooks",
+        "manage-prompts-and-presets",
+        "guide-model-responses",
+      ],
+      metadata_policy: {
+        summary: {
+          mode: "manual",
+          note: "Trusted Tavernary editor selection.",
+        },
+        tags: {
+          mode: "manual",
+          note: "Trusted Tavernary editor selection.",
+        },
+      },
+    });
+  });
+
   test("keeps SLAYImages classified as a SillyTavern extension", async () => {
     const { projectsById } = await loadProductionData();
     const catalog = await buildCatalog({ write: false });


### PR DESCRIPTION
## Summary

- replace the narrow generated copy with a concise README-backed description
- preserve the documented UI-extension compatibility caveat
- classify persona, lorebook, prompt/preset, and response-guidance workflows
- record the established trusted-editor provenance and lock it with a regression test
- regenerate both public catalogs from the current main branch, including the newly published Persona Multi-Avatars entry

## Verification

- `npm.cmd run check` — 224 files and 2,625 tests passed; 428 routes built; static export verified
- catalog validation — 467 registry projects, 462 published projects, and 15 Kits
- security validation — 926 report summaries, no quarantined imports
- independent exact-range review — clean